### PR TITLE
[State Sync] Add a new EventSubscriptionService and tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,6 +3134,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-notifications"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bcs",
+ "channel",
+ "diem-crypto",
+ "diem-infallible",
+ "diem-temppath",
+ "diem-types",
+ "diem-vm",
+ "diem-workspace-hack",
+ "diemdb",
+ "executor-test-helpers",
+ "futures",
+ "itertools 0.10.0",
+ "move-core-types",
+ "serde",
+ "storage-interface",
+ "thiserror",
+ "tokio",
+ "vm-genesis",
+]
+
+[[package]]
 name = "execution-correctness"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ members = [
     "shuffle/sample-app",
     "shuffle/transaction-builder",
     "state-sync/inter-component/consensus-notifications",
+    "state-sync/inter-component/event-notifications",
     "state-sync/inter-component/mempool-notifications",
     "state-sync/state-sync-v1",
     "state-sync/state-sync-v2",

--- a/state-sync/inter-component/event-notifications/Cargo.toml
+++ b/state-sync/inter-component/event-notifications/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "event-notifications"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+repository = "https://github.com/diem/diem"
+description = "The notification service offered by state sync for on-chain events"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+async-trait = "0.1.42"
+futures = "0.3.12"
+itertools = { version = "0.10.0", default-features = false }
+serde = { version = "1.0.124", default-features = false }
+thiserror = "1.0.24"
+tokio = { version = "1.8.1" }
+
+channel = { path = "../../../common/channel" }
+diem-infallible = { path = "../../../common/infallible" }
+diem-types = { path = "../../../types" }
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+storage-interface = { path = "../../../storage/storage-interface" }
+
+
+[dev-dependencies]
+bcs = "0.1.2"
+
+diem-crypto = { path = "../../../crypto/crypto" }
+diem-temppath = { path = "../../../common/temppath" }
+diem-vm = { path = "../../../language/diem-vm" }
+diemdb = { path = "../../../storage/diemdb" }
+executor-test-helpers = { path = "../../../execution/executor-test-helpers" }
+move-core-types = { path = "../../../language/move-core/types" }
+vm-genesis = { path = "../../../language/tools/vm-genesis", features = ["fuzzing"] }

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -1,0 +1,456 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use async_trait::async_trait;
+use channel::{diem_channel, message_queues::QueueStyle};
+use diem_infallible::RwLock;
+use diem_types::{
+    account_state::AccountState,
+    contract_event::ContractEvent,
+    event::EventKey,
+    move_resource::MoveStorage,
+    on_chain_config,
+    on_chain_config::{config_address, OnChainConfigPayload, ON_CHAIN_CONFIG_REGISTRY},
+    transaction::Version,
+};
+use futures::{channel::mpsc::SendError, stream::FusedStream, Stream};
+use itertools::Itertools;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryFrom,
+    iter::FromIterator,
+    ops::Deref,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
+    task::{Context, Poll},
+};
+use storage_interface::DbReaderWriter;
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests;
+
+// Maximum channel sizes for each notification subscriber. If messages are not
+// consumed, they will be dropped (oldest messages first). The remaining messages
+// will be retrieved using FIFO ordering.
+const EVENT_NOTIFICATION_CHANNEL_SIZE: usize = 100;
+const RECONFIG_NOTIFICATION_CHANNEL_SIZE: usize = 1;
+
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Serialize)]
+pub enum Error {
+    #[error("Cannot subscribe to zero event keys!")]
+    CannotSubscribeToZeroEventKeys,
+    #[error("Missing event subscription! Subscription ID: {0}")]
+    MissingEventSubscription(u64),
+    #[error("Unable to send event notification! Error: {0}")]
+    UnableToSendEventNotification(String),
+    #[error("Unexpected error encountered: {0}")]
+    UnexpectedErrorEncountered(String),
+}
+
+impl From<SendError> for Error {
+    fn from(error: SendError) -> Self {
+        Error::UnableToSendEventNotification(error.to_string())
+    }
+}
+
+/// The interface between state sync and the subscription notification service,
+/// allowing state sync to notify the subscription service of new events.
+#[async_trait]
+pub trait EventNotificationSender: Send {
+    /// Notify the subscription service of the events at the specified version.
+    async fn notify_events(
+        &mut self,
+        version: Version,
+        events: Vec<ContractEvent>,
+    ) -> Result<(), Error>;
+
+    /// Forces the subscription service to notify subscribers of the current
+    /// on-chain configurations at the specified version.
+    /// This is useful for forcing reconfiguration notifications even if no
+    /// reconfiguration event was processed (e.g., on startup).
+    async fn notify_initial_configs(&mut self, version: Version) -> Result<(), Error>;
+}
+
+/// The subscription service offered by state sync, responsible for notifying
+/// subscribers of on-chain events.
+pub struct EventSubscriptionService {
+    // Event subscription registry
+    event_key_subscriptions: HashMap<EventKey, HashSet<SubscriptionId>>,
+    subscription_id_to_event_subscription: HashMap<SubscriptionId, EventSubscription>,
+
+    // Reconfig subscription registry
+    reconfig_subscriptions: HashMap<SubscriptionId, ReconfigSubscription>,
+
+    // Database to fetch on-chain configuration data
+    storage: Arc<RwLock<DbReaderWriter>>,
+
+    // Internal subscription ID generator
+    next_subscription_id: AtomicU64,
+}
+
+impl EventSubscriptionService {
+    pub fn new(storage: Arc<RwLock<DbReaderWriter>>) -> Self {
+        Self {
+            event_key_subscriptions: HashMap::new(),
+            subscription_id_to_event_subscription: HashMap::new(),
+            reconfig_subscriptions: HashMap::new(),
+            storage,
+            next_subscription_id: AtomicU64::new(0),
+        }
+    }
+
+    /// Returns an EventNotificationListener that can be monitored for
+    /// subscribed events. If an event key is subscribed to, it means the
+    /// EventNotificationListener will be sent a notification every time an
+    /// event with the matching key occurs on-chain. Note: if the notification
+    /// buffer fills up too quickly, older notifications will be dropped. As
+    /// such, it is the responsibility of the subscriber to ensure notifications
+    /// are processed in a timely manner.
+    pub fn subscribe_to_events(
+        &mut self,
+        event_keys: Vec<EventKey>,
+    ) -> Result<EventNotificationListener, Error> {
+        if event_keys.is_empty() {
+            return Err(Error::CannotSubscribeToZeroEventKeys);
+        }
+
+        let (notification_sender, notification_receiver) =
+            diem_channel::new(QueueStyle::KLAST, EVENT_NOTIFICATION_CHANNEL_SIZE, None);
+
+        // Create a new event subscription
+        let subscription_id = self.get_new_subscription_id();
+        let event_subscription = EventSubscription {
+            subscription_id,
+            notification_sender,
+            event_buffer: vec![],
+        };
+
+        // Store the new subscription
+        if let Some(old_subscription) = self
+            .subscription_id_to_event_subscription
+            .insert(subscription_id, event_subscription)
+        {
+            panic!(
+                "Duplicate event subscription found! This should not occur! ID: {}, subscription: {:?}",
+                subscription_id, old_subscription
+            );
+        }
+
+        // Update the event key subscriptions to include the new subscription
+        for event_key in event_keys {
+            self.event_key_subscriptions
+                .entry(event_key)
+                .and_modify(|subscriptions| {
+                    subscriptions.insert(subscription_id);
+                })
+                .or_insert_with(|| HashSet::from_iter(vec![subscription_id].iter().cloned()));
+        }
+
+        Ok(EventNotificationListener {
+            notification_receiver,
+        })
+    }
+
+    /// Returns a ReconfigNotificationListener that can be monitored for
+    /// reconfiguration events. Subscribers will be sent a notification
+    /// containing all new on-chain configuration values whenever a new epoch
+    /// begins. Note: if the notification buffer fills up too quickly, older
+    /// notifications will be dropped. As such, it is the responsibility of the
+    /// subscriber to ensure notifications are processed in a timely manner.
+    pub fn subscribe_to_reconfigurations(&mut self) -> Result<ReconfigNotificationListener, Error> {
+        let (notification_sender, notification_receiver) =
+            diem_channel::new(QueueStyle::KLAST, RECONFIG_NOTIFICATION_CHANNEL_SIZE, None);
+
+        // Create a new reconfiguration subscription
+        let subscription_id = self.get_new_subscription_id();
+        let reconfig_subscription = ReconfigSubscription {
+            subscription_id,
+            notification_sender,
+        };
+
+        // Store the new subscription
+        if let Some(old_subscription) = self
+            .reconfig_subscriptions
+            .insert(subscription_id, reconfig_subscription)
+        {
+            panic!(
+                "Duplicate reconfiguration subscription found! This should not occur! ID: {}, subscription: {:?}",
+                subscription_id, old_subscription
+            );
+        }
+
+        Ok(ReconfigNotificationListener {
+            notification_receiver,
+        })
+    }
+
+    fn get_new_subscription_id(&mut self) -> u64 {
+        self.next_subscription_id.fetch_add(1, Ordering::Relaxed)
+    }
+
+    /// This notifies all the event subscribers of the new events found at the
+    /// specified version. If a reconfiguration event (i.e., new epoch) is found,
+    /// this method will return true.
+    fn notify_event_subscribers(
+        &mut self,
+        version: Version,
+        events: Vec<ContractEvent>,
+    ) -> Result<bool, Error> {
+        let mut reconfig_event_found = false;
+        let mut event_subscription_ids_to_notify = HashSet::new();
+
+        for event in events.iter() {
+            let event_key = event.key();
+
+            // Process all subscriptions for the current event
+            if let Some(subscription_ids) = self.event_key_subscriptions.get(event_key) {
+                // Add the event to the subscription's pending event buffer
+                // and store the subscriptions that will need to notified once all
+                // events have been processed.
+                for subscription_id in subscription_ids.iter() {
+                    if let Some(event_subscription) = self
+                        .subscription_id_to_event_subscription
+                        .get_mut(subscription_id)
+                    {
+                        event_subscription.buffer_event(event.clone());
+                        event_subscription_ids_to_notify.insert(*subscription_id);
+                    } else {
+                        return Err(Error::MissingEventSubscription(*subscription_id));
+                    }
+                }
+            }
+
+            // Take note if a reconfiguration (new epoch) has occurred
+            if *event_key == on_chain_config::new_epoch_event_key() {
+                reconfig_event_found = true;
+            }
+        }
+
+        // Notify event subscribers of the new events
+        for event_subscription_id in event_subscription_ids_to_notify {
+            if let Some(event_subscription) = self
+                .subscription_id_to_event_subscription
+                .get_mut(&event_subscription_id)
+            {
+                event_subscription.notify_subscriber_of_events(version)?;
+            } else {
+                return Err(Error::MissingEventSubscription(event_subscription_id));
+            }
+        }
+
+        Ok(reconfig_event_found)
+    }
+
+    /// This notifies all the reconfiguration subscribers of the on-chain
+    /// configurations at the specified version.
+    fn notify_reconfiguration_subscribers(&mut self, version: Version) -> Result<(), Error> {
+        if self.reconfig_subscriptions.is_empty() {
+            return Ok(()); // No reconfiguration subscribers!
+        }
+
+        let new_configs = self.read_on_chain_configs(version)?;
+        for (_, reconfig_subscription) in self.reconfig_subscriptions.iter_mut() {
+            reconfig_subscription.notify_subscriber_of_configs(version, new_configs.clone())?;
+        }
+
+        Ok(())
+    }
+
+    /// Reads the values of all on-chain configs at the specified version.
+    fn read_on_chain_configs(&self, version: Version) -> Result<OnChainConfigPayload, Error> {
+        // Get the access paths for all the configs in the registry
+        let config_access_paths = ON_CHAIN_CONFIG_REGISTRY
+            .iter()
+            .map(|config_id| config_id.access_path())
+            .collect();
+
+        // Read the config values
+        let on_chain_configs = self
+            .storage
+            .read()
+            .reader
+            .deref()
+            .batch_fetch_resources_by_version(config_access_paths, version)
+            .map_err(|error| {
+                Error::UnexpectedErrorEncountered(format!(
+                    "Failed to batch fetch resources at version: {:?}. Error: {:?}",
+                    version, error
+                ))
+            })?;
+
+        // Fetch the account state blob
+        let (account_state_blob, _) = self
+            .storage
+            .read()
+            .reader
+            .get_account_state_with_proof_by_version(config_address(), version)
+            .map_err(|error| {
+                Error::UnexpectedErrorEncountered(format!(
+                    "Failed to fetch account state with proof {:?}",
+                    error
+                ))
+            })?;
+        let account_state_blob = account_state_blob.ok_or_else(|| {
+            Error::UnexpectedErrorEncountered("Missing account state blob!".into())
+        })?;
+
+        // Fetch the new epoch from storage
+        let epoch = AccountState::try_from(&account_state_blob)
+            .and_then(|state| {
+                Ok(state
+                    .get_configuration_resource()?
+                    .ok_or_else(|| {
+                        Error::UnexpectedErrorEncountered(
+                            "Configuration resource does not exist!".into(),
+                        )
+                    })?
+                    .epoch())
+            })
+            .map_err(|error| {
+                Error::UnexpectedErrorEncountered(format!(
+                    "Failed to fetch configuration resource! Error: {:?}",
+                    error
+                ))
+            })?;
+
+        // Return the config payload
+        Ok(OnChainConfigPayload::new(
+            epoch,
+            Arc::new(
+                ON_CHAIN_CONFIG_REGISTRY
+                    .iter()
+                    .cloned()
+                    .zip_eq(on_chain_configs)
+                    .collect(),
+            ),
+        ))
+    }
+}
+
+#[async_trait]
+impl EventNotificationSender for EventSubscriptionService {
+    async fn notify_events(
+        &mut self,
+        version: Version,
+        events: Vec<ContractEvent>,
+    ) -> Result<(), Error> {
+        if events.is_empty() {
+            return Ok(()); // No events!
+        }
+
+        // Notify event subscribers and check if a reconfiguration event was processed
+        let reconfig_event_processed = self.notify_event_subscribers(version, events)?;
+
+        // If a reconfiguration event was found, also notify the reconfig subscribers
+        // of the new configuration values.
+        if reconfig_event_processed {
+            self.notify_reconfiguration_subscribers(version)
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn notify_initial_configs(&mut self, version: Version) -> Result<(), Error> {
+        self.notify_reconfiguration_subscribers(version)
+    }
+}
+
+/// A unique ID used to identify each subscription.
+type SubscriptionId = u64;
+
+/// A single event subscription, holding the subscription identifier, channel to
+/// send the corresponding notifications and a buffer to hold pending events.
+#[derive(Debug)]
+struct EventSubscription {
+    pub subscription_id: SubscriptionId,
+    pub event_buffer: Vec<ContractEvent>,
+    pub notification_sender: channel::diem_channel::Sender<(), EventNotification>,
+}
+
+impl EventSubscription {
+    fn buffer_event(&mut self, event: ContractEvent) {
+        self.event_buffer.push(event)
+    }
+
+    fn notify_subscriber_of_events(&mut self, version: Version) -> Result<(), Error> {
+        let event_notification = EventNotification {
+            subscribed_events: self.event_buffer.drain(..).collect(),
+            version,
+        };
+
+        self.notification_sender
+            .push((), event_notification)
+            .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
+    }
+}
+
+/// A single reconfig subscription, holding the channel to send the
+/// corresponding notifications.
+#[derive(Debug)]
+struct ReconfigSubscription {
+    pub subscription_id: SubscriptionId,
+    pub notification_sender: channel::diem_channel::Sender<(), ReconfigNotification>,
+}
+
+impl ReconfigSubscription {
+    fn notify_subscriber_of_configs(
+        &mut self,
+        version: Version,
+        on_chain_configs: OnChainConfigPayload,
+    ) -> Result<(), Error> {
+        let reconfig_notification = ReconfigNotification {
+            version,
+            on_chain_configs,
+        };
+
+        self.notification_sender
+            .push((), reconfig_notification)
+            .map_err(|error| Error::UnexpectedErrorEncountered(format!("{:?}", error)))
+    }
+}
+
+/// A notification for events.
+#[derive(Debug)]
+pub struct EventNotification {
+    pub version: Version,
+    pub subscribed_events: Vec<ContractEvent>,
+}
+
+/// A notification for reconfigurations.
+#[derive(Debug)]
+pub struct ReconfigNotification {
+    pub version: Version,
+    pub on_chain_configs: OnChainConfigPayload,
+}
+
+/// A subscription listener for on-chain events.
+pub type EventNotificationListener = NotificationListener<EventNotification>;
+
+/// A subscription listener for reconfigurations.
+pub type ReconfigNotificationListener = NotificationListener<ReconfigNotification>;
+
+/// The component responsible for listening to subscription notifications.
+pub struct NotificationListener<T> {
+    pub notification_receiver: channel::diem_channel::Receiver<(), T>,
+}
+
+impl<T> Stream for NotificationListener<T> {
+    type Item = T;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.get_mut().notification_receiver).poll_next(cx)
+    }
+}
+
+impl<T> FusedStream for NotificationListener<T> {
+    fn is_terminated(&self) -> bool {
+        self.notification_receiver.is_terminated()
+    }
+}

--- a/state-sync/inter-component/event-notifications/src/tests.rs
+++ b/state-sync/inter-component/event-notifications/src/tests.rs
@@ -1,0 +1,455 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{
+    Error, EventNotificationListener, EventNotificationSender, EventSubscriptionService,
+    ReconfigNotificationListener,
+};
+use diem_infallible::RwLock;
+use diem_types::{
+    account_address::AccountAddress,
+    contract_event::ContractEvent,
+    event::EventKey,
+    on_chain_config,
+    on_chain_config::ON_CHAIN_CONFIG_REGISTRY,
+    transaction::{Transaction, Version, WriteSetPayload},
+};
+use diem_vm::DiemVM;
+use diemdb::DiemDB;
+use executor_test_helpers::bootstrap_genesis;
+use futures::{executor::block_on, FutureExt, StreamExt};
+use move_core_types::language_storage::TypeTag;
+use std::{convert::TryInto, sync::Arc};
+use storage_interface::DbReaderWriter;
+
+#[test]
+fn test_all_configs_returned() {
+    // Create subscription service and mock database
+    let mut event_service = EventSubscriptionService::new(create_database());
+
+    // Create reconfig subscribers
+    let mut listener_1 = event_service.subscribe_to_reconfigurations().unwrap();
+    let mut listener_2 = event_service.subscribe_to_reconfigurations().unwrap();
+    let mut listener_3 = event_service.subscribe_to_reconfigurations().unwrap();
+
+    // Notify the subscription service of 10 force reconfigurations and verify the
+    // notifications contain all configs.
+    let version = 0;
+    let epoch = 1;
+    let num_reconfigs = 10;
+    for _ in 0..num_reconfigs {
+        notify_initial_configs(&mut event_service, version);
+        verify_reconfig_notifications_received(
+            vec![&mut listener_1, &mut listener_2, &mut listener_3],
+            version,
+            epoch,
+        );
+    }
+
+    // Notify the subscription service of 10 reconfiguration events and verify the
+    // notifications contain all configs.
+    let reconfig_event = create_test_event(on_chain_config::new_epoch_event_key());
+    for _ in 0..num_reconfigs {
+        notify_events(&mut event_service, version, vec![reconfig_event.clone()]);
+        verify_reconfig_notifications_received(
+            vec![&mut listener_1, &mut listener_2, &mut listener_3],
+            version,
+            epoch,
+        );
+    }
+}
+
+#[test]
+fn test_reconfig_notification_no_queuing() {
+    // Create subscription service and mock database
+    let mut event_service = EventSubscriptionService::new(create_database());
+
+    // Create reconfig subscribers
+    let mut listener_1 = event_service.subscribe_to_reconfigurations().unwrap();
+    let mut listener_2 = event_service.subscribe_to_reconfigurations().unwrap();
+
+    // Notify the subscription service of 10 reconfiguration events
+    let reconfig_event = create_test_event(on_chain_config::new_epoch_event_key());
+    let num_reconfigs = 10;
+    for _ in 0..num_reconfigs {
+        notify_events(&mut event_service, 0, vec![reconfig_event.clone()]);
+    }
+
+    // Verify that only 1 notification was received by listener_1 (i.e., messages were dropped)
+    let notification_count = count_reconfig_notifications(&mut listener_1);
+    assert_eq!(notification_count, 1);
+
+    // Notify the subscription service of 5 new force reconfigurations
+    let num_reconfigs = 5;
+    for _ in 0..num_reconfigs {
+        notify_initial_configs(&mut event_service, 0);
+    }
+
+    // Verify that only 1 notification was received by listener_1 (i.e., messages were dropping)
+    let notification_count = count_reconfig_notifications(&mut listener_1);
+    assert_eq!(notification_count, 1);
+
+    // Verify that only 1 notification was received by listener_2 (i.e., messages were dropped)
+    let notification_count = count_reconfig_notifications(&mut listener_2);
+    assert_eq!(notification_count, 1);
+}
+
+#[test]
+fn test_event_and_reconfig_subscribers() {
+    // Create subscription service and mock database
+    let mut event_service = EventSubscriptionService::new(create_database());
+
+    // Create several event keys
+    let event_key_1 = create_random_event_key();
+    let event_key_2 = create_random_event_key();
+    let reconfig_event_key = on_chain_config::new_epoch_event_key();
+
+    // Create subscribers for the various event keys
+    let mut event_listener_1 = event_service
+        .subscribe_to_events(vec![event_key_1])
+        .unwrap();
+    let mut event_listener_2 = event_service
+        .subscribe_to_events(vec![event_key_1, event_key_2])
+        .unwrap();
+    let mut event_listener_3 = event_service
+        .subscribe_to_events(vec![reconfig_event_key])
+        .unwrap();
+
+    // Create reconfiguration subscribers
+    let mut reconfig_listener_1 = event_service.subscribe_to_reconfigurations().unwrap();
+    let mut reconfig_listener_2 = event_service.subscribe_to_reconfigurations().unwrap();
+
+    // Force an initial reconfiguration and verify the listeners received the notifications
+    notify_initial_configs(&mut event_service, 0);
+    verify_reconfig_notifications_received(
+        vec![&mut reconfig_listener_1, &mut reconfig_listener_2],
+        0,
+        1,
+    );
+    verify_no_event_notifications(vec![
+        &mut event_listener_1,
+        &mut event_listener_2,
+        &mut event_listener_3,
+    ]);
+
+    // Notify the service of a reconfiguration event and verify correct notifications
+    let reconfig_event = create_test_event(reconfig_event_key);
+    notify_events(&mut event_service, 0, vec![reconfig_event.clone()]);
+    verify_reconfig_notifications_received(
+        vec![&mut reconfig_listener_1, &mut reconfig_listener_2],
+        0,
+        1,
+    );
+    verify_event_notification_received(
+        vec![&mut event_listener_3],
+        0,
+        vec![reconfig_event.clone()],
+    );
+    verify_no_event_notifications(vec![&mut event_listener_1, &mut event_listener_2]);
+
+    // Notify the service of a reconfiguration and two other events, and verify notifications
+    let event_1 = create_test_event(event_key_1);
+    let event_2 = create_test_event(event_key_2);
+    notify_events(
+        &mut event_service,
+        0,
+        vec![event_1.clone(), event_2.clone(), reconfig_event.clone()],
+    );
+    verify_reconfig_notifications_received(
+        vec![&mut reconfig_listener_1, &mut reconfig_listener_2],
+        0,
+        1,
+    );
+    verify_event_notification_received(vec![&mut event_listener_1], 0, vec![event_1.clone()]);
+    verify_event_notification_received(
+        vec![&mut event_listener_2],
+        0,
+        vec![event_1.clone(), event_2],
+    );
+    verify_event_notification_received(vec![&mut event_listener_3], 0, vec![reconfig_event]);
+
+    // Notify the subscription service of one event only (no reconfigurations)
+    notify_events(&mut event_service, 0, vec![event_1.clone()]);
+    verify_event_notification_received(
+        vec![&mut event_listener_1, &mut event_listener_2],
+        0,
+        vec![event_1],
+    );
+    verify_no_reconfig_notifications(vec![&mut reconfig_listener_1, &mut reconfig_listener_2]);
+    verify_no_event_notifications(vec![&mut event_listener_3]);
+}
+
+#[test]
+fn test_event_notification_queuing() {
+    // Create subscription service and mock database
+    let mut event_service = EventSubscriptionService::new(create_database());
+
+    // Create several event keys
+    let event_key_1 = create_random_event_key();
+    let event_key_2 = on_chain_config::new_epoch_event_key();
+    let event_key_3 = create_random_event_key();
+
+    // Subscribe to the various events (except event_key_3)
+    let mut listener_1 = event_service
+        .subscribe_to_events(vec![event_key_1])
+        .unwrap();
+    let mut listener_2 = event_service
+        .subscribe_to_events(vec![event_key_2])
+        .unwrap();
+
+    // Notify the subscription service of 1000 new events (with event_key_1)
+    let num_events = 1000;
+    let event_1 = create_test_event(event_key_1);
+    for version in 0..num_events {
+        notify_events(&mut event_service, version, vec![event_1.clone()]);
+    }
+
+    // Verify that less than 1000 notifications were received by listener_1
+    // (i.e., messages were dropped).
+    let notification_count = count_event_notifications_and_ensure_ordering(&mut listener_1);
+    assert!(notification_count < num_events);
+
+    // Notify the subscription service of 50 new events (with event_key_1 and event_key_2)
+    let num_events = 50;
+    let event_2 = create_test_event(event_key_1);
+    for version in 0..num_events {
+        notify_events(
+            &mut event_service,
+            version,
+            vec![event_2.clone(), event_1.clone()],
+        );
+    }
+
+    // Verify that 50 events were received (i.e., no message dropping occurred).
+    let notification_count = count_event_notifications_and_ensure_ordering(&mut listener_1);
+    assert_eq!(notification_count, num_events);
+
+    // Notify the subscription service of 1000 new events (with event_key_3)
+    let num_events = 1000;
+    let event_3 = create_test_event(event_key_3);
+    for version in 0..num_events {
+        notify_events(&mut event_service, version, vec![event_3.clone()]);
+    }
+
+    // Verify neither listener received the event notifications
+    verify_no_event_notifications(vec![&mut listener_1, &mut listener_2]);
+}
+
+#[test]
+fn test_event_subscribers() {
+    // Create subscription service and mock database
+    let mut event_service = EventSubscriptionService::new(create_database());
+
+    // Create several event keys
+    let event_key_1 = create_random_event_key();
+    let event_key_2 = create_random_event_key();
+    let event_key_3 = on_chain_config::new_epoch_event_key();
+    let event_key_4 = create_random_event_key();
+    let event_key_5 = create_random_event_key();
+
+    // Subscribe to the various events (except event_key_5)
+    let mut listener_1 = event_service
+        .subscribe_to_events(vec![event_key_1])
+        .unwrap();
+    let mut listener_2 = event_service
+        .subscribe_to_events(vec![event_key_1, event_key_2])
+        .unwrap();
+    let mut listener_3 = event_service
+        .subscribe_to_events(vec![event_key_2, event_key_3, event_key_4])
+        .unwrap();
+
+    // Notify the subscription service of a new event (with event_key_1)
+    let version = 99;
+    let event_1 = create_test_event(event_key_1);
+    notify_events(&mut event_service, version, vec![event_1.clone()]);
+
+    // Verify listener 1 and 2 receive the event notification
+    verify_event_notification_received(
+        vec![&mut listener_1, &mut listener_2],
+        version,
+        vec![event_1],
+    );
+
+    // Verify listener 3 doesn't get the event. Also verify that listener 1 and 2 don't get more events.
+    verify_no_event_notifications(vec![&mut listener_1, &mut listener_2, &mut listener_3]);
+
+    // Notify the subscription service of new events (with event_key_2 and event_key_3)
+    let version = 200;
+    let event_2 = create_test_event(event_key_2);
+    let event_3 = create_test_event(event_key_3);
+    notify_events(
+        &mut event_service,
+        version,
+        vec![event_2.clone(), event_3.clone()],
+    );
+
+    // Verify listener 1 doesn't get any notifications
+    verify_no_event_notifications(vec![&mut listener_1]);
+
+    // Verify listener 2 and 3 get the event notifications
+    verify_event_notification_received(vec![&mut listener_2], version, vec![event_2.clone()]);
+    verify_event_notification_received(vec![&mut listener_3], version, vec![event_2, event_3]);
+
+    // Notify the subscription service of a new event (with event_key_5)
+    let event_5 = create_test_event(event_key_5);
+    notify_events(&mut event_service, version, vec![event_5]);
+    verify_no_event_notifications(vec![&mut listener_1]);
+}
+
+#[test]
+fn test_no_events_no_subscribers() {
+    // Create subscription service and mock database
+    let mut event_service = EventSubscriptionService::new(create_database());
+
+    // Verify a notification with zero events returns successfully
+    notify_events(&mut event_service, 1, vec![]);
+
+    // Verify no subscribers doesn't cause notification errors
+    notify_events(
+        &mut event_service,
+        1,
+        vec![create_test_event(create_random_event_key())],
+    );
+
+    // Attempt to subscribe to zero event keys
+    assert!(matches!(
+        event_service.subscribe_to_events(vec![]),
+        Err(Error::CannotSubscribeToZeroEventKeys)
+    ));
+
+    // Add subscribers to the service
+    let _event_listener = event_service.subscribe_to_events(vec![create_random_event_key()]);
+    let _reconfig_listener = event_service.subscribe_to_reconfigurations();
+
+    // Verify a notification with zero events returns successfully
+    notify_events(&mut event_service, 1, vec![]);
+}
+
+// Counts the number of event notifications received by the listener. Also ensures that
+// the notifications have increasing versions.
+fn count_event_notifications_and_ensure_ordering(listener: &mut EventNotificationListener) -> u64 {
+    let mut notification_received = true;
+    let mut notification_count = 0;
+    let mut last_version_received: i64 = -1;
+
+    while notification_received {
+        if let Some(event_notification) = listener.select_next_some().now_or_never() {
+            notification_count += 1;
+            assert!(last_version_received < event_notification.version.try_into().unwrap());
+            last_version_received = event_notification.version.try_into().unwrap();
+        } else {
+            notification_received = false;
+        }
+    }
+
+    notification_count
+}
+
+// Counts the number of reconfig notifications received by the listener.
+fn count_reconfig_notifications(listener: &mut ReconfigNotificationListener) -> u64 {
+    let mut notification_received = true;
+    let mut notification_count = 0;
+
+    while notification_received {
+        if listener.select_next_some().now_or_never().is_some() {
+            notification_count += 1;
+        } else {
+            notification_received = false;
+        }
+    }
+
+    notification_count
+}
+
+// Ensures that no event notifications have been received by the listeners
+fn verify_no_event_notifications(listeners: Vec<&mut EventNotificationListener>) {
+    for listener in listeners {
+        assert!(listener.select_next_some().now_or_never().is_none());
+    }
+}
+
+// Ensures that no reconfig notifications have been received by the listeners
+fn verify_no_reconfig_notifications(listeners: Vec<&mut ReconfigNotificationListener>) {
+    for listener in listeners {
+        assert!(listener.select_next_some().now_or_never().is_none());
+    }
+}
+
+// Ensures that the specified listeners have received the expected notifications.
+fn verify_event_notification_received(
+    listeners: Vec<&mut EventNotificationListener>,
+    expected_version: Version,
+    expected_events: Vec<ContractEvent>,
+) {
+    for listener in listeners {
+        if let Some(event_notification) = listener.select_next_some().now_or_never() {
+            assert_eq!(event_notification.version, expected_version);
+            assert_eq!(event_notification.subscribed_events, expected_events);
+        } else {
+            panic!("Expected an event notification but got None!");
+        }
+    }
+}
+
+// Ensures that the specified listeners have received the expected notifications.
+// Also verifies that the reconfiguration notifications contain all on-chain configs.
+fn verify_reconfig_notifications_received(
+    listeners: Vec<&mut ReconfigNotificationListener>,
+    expected_version: Version,
+    expected_epoch: u64,
+) {
+    for listener in listeners {
+        if let Some(reconfig_notification) = listener.select_next_some().now_or_never() {
+            assert_eq!(reconfig_notification.version, expected_version);
+            assert_eq!(
+                reconfig_notification.on_chain_configs.epoch(),
+                expected_epoch
+            );
+
+            let returned_configs = reconfig_notification.on_chain_configs.configs();
+            for config in ON_CHAIN_CONFIG_REGISTRY {
+                assert!(returned_configs.contains_key(config));
+            }
+        } else {
+            panic!("Expected a reconfiguration notification but got None!");
+        }
+    }
+}
+
+fn notify_initial_configs(event_service: &mut EventSubscriptionService, version: Version) {
+    block_on(event_service.notify_initial_configs(version)).unwrap();
+}
+
+fn notify_events(
+    event_service: &mut EventSubscriptionService,
+    version: Version,
+    events: Vec<ContractEvent>,
+) {
+    block_on(event_service.notify_events(version, events)).unwrap();
+}
+
+fn create_test_event(event_key: EventKey) -> ContractEvent {
+    ContractEvent::new(event_key, 0, TypeTag::Bool, bcs::to_bytes(&0).unwrap())
+}
+
+fn create_random_event_key() -> EventKey {
+    EventKey::new_from_address(&AccountAddress::random(), 0)
+}
+
+fn create_database() -> Arc<RwLock<DbReaderWriter>> {
+    // Generate a genesis change set
+    let (genesis, _) = vm_genesis::test_genesis_change_set_and_validators(Some(1));
+
+    // Create test diem database
+    let db_path = diem_temppath::TempPath::new();
+    db_path.create_as_dir().unwrap();
+    let (_, db_rw) = DbReaderWriter::wrap(DiemDB::new_for_test(db_path.path()));
+
+    // Bootstrap the genesis transaction
+    let genesis_txn = Transaction::GenesisTransaction(WriteSetPayload::Direct(genesis));
+    bootstrap_genesis::<DiemVM>(&db_rw, &genesis_txn).unwrap();
+
+    Arc::new(RwLock::new(db_rw))
+}

--- a/x.toml
+++ b/x.toml
@@ -198,6 +198,7 @@ members = [
     "diem-transaction-benchmarks",
     "diem-wallet",
     "diemdb-benchmark",
+    "event-notifications", # Will be removed once the subscription service is plugged in.
     "executor-benchmark",
     "executor-test-helpers",
     "forge",


### PR DESCRIPTION
## Motivation

This PR adds a new on-chain event subscription service to state sync (EventSubscriptionService). Using this service, other components can subscribe to on-chain events and be notified about on-chain reconfigurations. This service differs from the existing on-chain publishing (already provided by state sync) in the following ways:

1. The service will support arbitrary event subscriptions (not just reconfiguration events!). This is required by future work streams (e.g., the on-chain networking identity work).
2. The service will not require reconfiguration subscribers to subscribe to individual on-chain configurations, but instead receive all configs when a reconfiguration event occurs. This is because: (i) subscribing to individual configs only adds code complexity, but doesn't provide any tangible benefits (e.g., performance or resource usage). Reconfigurations are fairly infrequent and subscribers tend to just pull out the data they want anyway; (ii) there are actually bugs in our code today where subscribers subscribe to individual configs, but on reconfiguration notifications, access configs they didn't subscribe to (!!). This is because the code already returns all configurations to subscribers anyway; and (iii) there doesn't currently appear to be any requirements for this functionality. If we wish to have this functionality, we can always extend this service to provide it in the future.
3. The service will better encapsulate the relationships between subscribers and notifications, and not leak implementation details and abstractions. Moreover, the service will be better tested! Right now, there's minimal testing for the on-chain publishing support.

Notes:
- Half of this PR is just unit tests (so it hopefully shouldn't be that scary! 😄)
- This PR is comprised of two commits: (i) the new service itself; (ii) unit tests.
- Once this PR lands, I'll send the next PR that plugs this service into Diem node (and finally be able to remove the old subscription service 😸).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New unit tests have been added for the service.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906