### PR TITLE
Refactor TransportManager to better indicate direction & have more comments / code reuse

### DIFF
--- a/network/src/peer_manager/mod.rs
+++ b/network/src/peer_manager/mod.rs
@@ -249,11 +249,11 @@ where
                 connection_event = self.transport_notifs_rx.select_next_some() => {
                     self.handle_connection_event(connection_event);
                 }
-                request = self.requests_rx.select_next_some() => {
-                    self.handle_request(request).await;
-                }
                 connection_request = self.connection_reqs_rx.select_next_some() => {
-                    self.handle_connection_request(connection_request).await;
+                    self.handle_outbound_connection_request(connection_request).await;
+                }
+                request = self.requests_rx.select_next_some() => {
+                    self.handle_outbound_request(request).await;
                 }
                 complete => {
                     break;
@@ -417,7 +417,7 @@ where
         }
     }
 
-    async fn handle_connection_request(&mut self, request: ConnectionRequest) {
+    async fn handle_outbound_connection_request(&mut self, request: ConnectionRequest) {
         trace!(
             NetworkSchema::new(&self.network_context),
             peer_manager_request = request,
@@ -486,7 +486,7 @@ where
         }
     }
 
-    async fn handle_request(&mut self, request: PeerManagerRequest) {
+    async fn handle_outbound_request(&mut self, request: PeerManagerRequest) {
         trace!(
             NetworkSchema::new(&self.network_context),
             peer_manager_request = request,

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -604,7 +604,7 @@ fn test_dial_disconnect() {
         // Send DisconnectPeer request to PeerManager.
         let (disconnect_resp_tx, disconnect_resp_rx) = oneshot::channel();
         peer_manager
-            .handle_connection_request(ConnectionRequest::DisconnectPeer(
+            .handle_outbound_connection_request(ConnectionRequest::DisconnectPeer(
                 ids[0],
                 disconnect_resp_tx,
             ))


### PR DESCRIPTION
## Motivation

While I was looking through code to integrate NetworkInterface into PeerManager, I was getting a little confused on direction (Notification vs Request), so I've added direction to names of functions, and did a little cleanup in the `TransportManager` to hopefully make it mostly straightforward.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

No functional change, unit tests should cover it.