### PR TITLE
[State Sync] Avoid using is_ok() in tests.

### DIFF
--- a/state-sync/inter-component/consensus-notifications/src/lib.rs
+++ b/state-sync/inter-component/consensus-notifications/src/lib.rs
@@ -321,7 +321,7 @@ mod tests {
 
         // Send a notification
         let notify_result = block_on(consensus_notifier.notify_new_commit(vec![], vec![]));
-        assert!(notify_result.is_ok());
+        notify_result.unwrap();
     }
 
     #[test]
@@ -408,7 +408,7 @@ mod tests {
         // Send a commit notification and verify a successful response
         let notify_result =
             block_on(consensus_notifier.notify_new_commit(vec![create_user_transaction()], vec![]));
-        assert!(notify_result.is_ok());
+        notify_result.unwrap();
 
         // Send a sync notification and very an error response
         let notify_result = block_on(consensus_notifier.sync_to_target(create_ledger_info()));

--- a/state-sync/inter-component/mempool-notifications/src/lib.rs
+++ b/state-sync/inter-component/mempool-notifications/src/lib.rs
@@ -279,7 +279,7 @@ mod tests {
 
         // Send a notification and verify no timeout because no notification was sent!
         let notify_result = block_on(mempool_notifier.notify_new_commit(vec![], 0, 1000));
-        assert!(notify_result.is_ok());
+        notify_result.unwrap();
     }
 
     #[test]
@@ -301,7 +301,7 @@ mod tests {
         // Send a notification and verify no timeout because no notification was sent!
         let notify_result =
             block_on(mempool_notifier.notify_new_commit(transactions.clone(), 0, 1000));
-        assert!(notify_result.is_ok());
+        notify_result.unwrap();
 
         // Send another notification with a single user transaction now included.
         transactions.push(create_user_transaction());
@@ -371,7 +371,7 @@ mod tests {
             101,
             1000,
         ));
-        assert!(notify_result.is_ok());
+        notify_result.unwrap();
     }
 
     fn create_user_transaction() -> Transaction {

--- a/state-sync/state-sync-v1/src/coordinator.rs
+++ b/state-sync/state-sync-v1/src/coordinator.rs
@@ -1779,9 +1779,7 @@ mod tests {
         let (sync_request, mut callback_receiver) = create_sync_notification_at_version(0);
         block_on(validator_coordinator.process_sync_request(sync_request)).unwrap();
         match callback_receiver.try_recv() {
-            Ok(Some(notification_result)) => {
-                assert!(notification_result.result.is_ok())
-            }
+            Ok(Some(notification_result)) => notification_result.result.unwrap(),
             result => panic!("Expected okay but got: {:?}", result),
         };
 
@@ -1846,9 +1844,7 @@ mod tests {
             .wait_for_initialization(callback_sender)
             .unwrap();
         match callback_receiver.try_recv() {
-            Ok(Some(result)) => {
-                assert!(result.is_ok())
-            }
+            Ok(Some(result)) => result.unwrap(),
             result => panic!("Expected okay but got: {:?}", result),
         };
 
@@ -1901,7 +1897,7 @@ mod tests {
         .unwrap();
         match callback_receiver.try_recv() {
             Ok(Some(notification_result)) => {
-                assert!(notification_result.result.is_ok());
+                notification_result.result.unwrap();
             }
             callback_result => panic!("Expected an okay result but got: {:?}", callback_result),
         };

--- a/state-sync/state-sync-v1/src/executor_proxy.rs
+++ b/state-sync/state-sync-v1/src/executor_proxy.rs
@@ -554,9 +554,9 @@ mod tests {
         // Grab the first two executed transactions and verify responses
         let txns = executor_proxy.get_chunk(0, 2, 2).unwrap();
         assert_eq!(txns.transactions, vec![dummy_txn_1, reconfig_txn]);
-        assert!(executor_proxy
+        executor_proxy
             .execute_chunk(txns, ledger_info_epoch_1.clone(), None)
-            .is_ok());
+            .unwrap();
         assert_eq!(
             ledger_info_epoch_1,
             executor_proxy.get_epoch_change_ledger_info(1).unwrap()
@@ -574,9 +574,9 @@ mod tests {
         // Grab the last transaction and verify responses
         let txns = executor_proxy.get_chunk(4, 1, 5).unwrap();
         assert_eq!(txns.transactions, vec![rotation_txn]);
-        assert!(executor_proxy
+        executor_proxy
             .execute_chunk(txns, ledger_info_epoch_2.clone(), None)
-            .is_ok());
+            .unwrap();
         assert_eq!(
             ledger_info_epoch_2,
             executor_proxy.get_epoch_change_ledger_info(2).unwrap()

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -109,17 +109,17 @@ impl StateSyncPeer {
             .write()
             .commit_new_txns(num_txns);
         let mempool = self.mempool.as_ref().unwrap();
-        assert!(mempool.add_txns(signed_txns.clone()).is_ok());
+        mempool.add_txns(signed_txns.clone()).unwrap();
 
-        assert!(Runtime::new()
+        Runtime::new()
             .unwrap()
             .block_on(
                 self.consensus_notifier
                     .as_ref()
                     .unwrap()
-                    .notify_new_commit(committed_txns, vec![])
+                    .notify_new_commit(committed_txns, vec![]),
             )
-            .is_ok());
+            .unwrap();
         let mempool_txns = mempool.read_timeline(0, signed_txns.len());
         for txn in signed_txns.iter() {
             assert!(!mempool_txns.contains(txn));


### PR DESCRIPTION
## Motivation

This (small) PR updates state sync to avoid using `assert!(....is_ok())` in the tests and instead use `unwrap()` directly. The reason for this is that on assertion failures the error message displayed doesn't show the actual result returned, rather just that the assertion failed. For example, one of the state sync tests recently flaked (here: https://github.com/diem/diem/issues/9062), and the use of `is_ok()` hides the exact error. This PR should hopefully help us get better signals for test failures in the future.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The existing unit tests cover these changes.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906