### PR TITLE
Cherry-pick PR #9119 into release-1.4: [reconfiguration] another attempt to fix the bug and better test cove…

### DIFF
--- a/consensus/consensus-types/src/executed_block.rs
+++ b/consensus/consensus-types/src/executed_block.rs
@@ -106,7 +106,7 @@ impl ExecutedBlock {
 
     pub fn transactions_to_commit(&self) -> Vec<Transaction> {
         // reconfiguration suffix don't execute
-        if self.quorum_cert().ends_epoch() {
+        if self.block.block_data().is_reconfiguration_suffix() {
             return vec![];
         }
         itertools::zip_eq(
@@ -122,7 +122,7 @@ impl ExecutedBlock {
 
     pub fn reconfig_event(&self) -> Vec<ContractEvent> {
         // reconfiguration suffix don't count, the state compute result is carried over from parents
-        if self.quorum_cert().ends_epoch() {
+        if self.block.block_data().is_reconfiguration_suffix() {
             return vec![];
         }
         self.state_compute_result.reconfig_events().to_vec()

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -142,6 +142,27 @@ impl NetworkSender {
         }
     }
 
+    /// Tries to send msg to given recipients.
+    pub async fn send(&self, msg: ConsensusMsg, recipients: Vec<Author>) {
+        let mut network_sender = self.network_sender.clone();
+        let mut self_sender = self.self_sender.clone();
+        for peer in recipients {
+            if self.author == peer {
+                let self_msg = Event::Message(self.author, msg.clone());
+                if let Err(err) = self_sender.send(self_msg).await {
+                    error!(error = ?err, "Error delivering a self msg");
+                }
+                continue;
+            }
+            if let Err(e) = network_sender.send_to(peer, msg.clone()) {
+                error!(
+                    remote_peer = peer,
+                    error = ?e, "Failed to send a msg to peer",
+                );
+            }
+        }
+    }
+
     /// Sends the vote to the chosen recipients (typically that would be the recipients that
     /// we believe could serve as proposers in the next round). The recipients on the receiving
     /// end are going to be notified about a new vote in the vote queue.
@@ -151,51 +172,21 @@ impl NetworkSender {
     /// out. It does not give indication about when the message is delivered to the recipients,
     /// as well as there is no indication about the network failures.
     pub async fn send_vote(&self, vote_msg: VoteMsg, recipients: Vec<Author>) {
-        let mut network_sender = self.network_sender.clone();
-        let mut self_sender = self.self_sender.clone();
         let msg = ConsensusMsg::VoteMsg(Box::new(vote_msg));
-        for peer in recipients {
-            if self.author == peer {
-                let self_msg = Event::Message(self.author, msg.clone());
-                if let Err(err) = self_sender.send(self_msg).await {
-                    error!(error = ?err, "Error delivering a self vote");
-                }
-                continue;
-            }
-            if let Err(e) = network_sender.send_to(peer, msg.clone()) {
-                error!(
-                    remote_peer = peer,
-                    error = ?e, "Failed to send a vote to peer",
-                );
-            }
-        }
+        self.send(msg, recipients).await
     }
 
     /// Sends the given sync info to the given author.
     /// The future is fulfilled as soon as the message is added to the internal network channel
     /// (does not indicate whether the message is delivered or sent out).
-    pub fn send_sync_info(&self, sync_info: SyncInfo, recipient: Author) {
+    pub async fn send_sync_info(&self, sync_info: SyncInfo, recipient: Author) {
         let msg = ConsensusMsg::SyncInfo(Box::new(sync_info));
-        let mut network_sender = self.network_sender.clone();
-        if let Err(e) = network_sender.send_to(recipient, msg) {
-            warn!(
-                remote_peer = recipient,
-                error = "Failed to send a sync info msg to peer {:?}",
-                "{:?}",
-                e
-            );
-        }
+        self.send(msg, vec![recipient]).await
     }
 
     pub async fn notify_epoch_change(&mut self, proof: EpochChangeProof) {
         let msg = ConsensusMsg::EpochChangeProof(Box::new(proof));
-        let self_msg = Event::Message(self.author, msg);
-        if let Err(e) = self.self_sender.send(self_msg).await {
-            warn!(
-                error = "Failed to notify to self an epoch change",
-                "{:?}", e
-            );
-        }
+        self.send(msg, vec![self.author]).await
     }
 }
 

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -24,6 +24,7 @@ use crate::{
 use anyhow::{bail, ensure, Context, Result};
 use consensus_types::{
     block::Block,
+    block_data::BlockData,
     block_retrieval::{BlockRetrievalResponse, BlockRetrievalStatus},
     common::{Author, Round},
     experimental::{commit_decision::CommitDecision, commit_vote::CommitVote},
@@ -321,11 +322,26 @@ impl RoundManager {
             .proposer_election
             .is_valid_proposer(self.proposal_generator.author(), new_round_event.round)
         {
-            let proposal_msg =
-                ConsensusMsg::ProposalMsg(Box::new(self.generate_proposal(new_round_event).await?));
+            let proposal_msg = Box::new(self.generate_proposal(new_round_event).await?);
             let mut network = self.network.clone();
-            network.broadcast(proposal_msg).await;
-            counters::PROPOSALS_COUNT.inc();
+            if Self::should_inject_reconfiguration_error(proposal_msg.proposal().block_data()) {
+                // We send the proposal to half of the validators to force a timeout.
+                let mut half_peers: Vec<_> = self
+                    .epoch_state
+                    .verifier
+                    .get_ordered_account_addresses_iter()
+                    .collect();
+                half_peers.truncate(half_peers.len() / 2);
+                network
+                    .send(ConsensusMsg::ProposalMsg(proposal_msg), half_peers)
+                    .await;
+                return Err(anyhow::anyhow!("Injected error in reconfiguration suffix"));
+            } else {
+                network
+                    .broadcast(ConsensusMsg::ProposalMsg(proposal_msg))
+                    .await;
+                counters::PROPOSALS_COUNT.inc();
+            }
         }
         Ok(())
     }
@@ -344,7 +360,6 @@ impl RoundManager {
             Block::new_proposal_from_block_data_and_signature(proposal, signature);
         observe_block(signed_proposal.timestamp_usecs(), BlockStage::SIGNED);
         debug!(self.new_log(LogEvent::Propose), "{}", signed_proposal);
-        // return proposal
         Ok(ProposalMsg::new(
             signed_proposal,
             self.block_store.sync_info(),
@@ -398,7 +413,9 @@ impl RoundManager {
                 self.new_log(LogEvent::HelpPeerSync).remote_peer(author),
                 "Remote peer has stale state {}, send it back {}", sync_info, local_sync_info,
             );
-            self.network.send_sync_info(local_sync_info.clone(), author);
+            self.network
+                .send_sync_info(local_sync_info.clone(), author)
+                .await;
         }
         if sync_info.has_newer_certificates(&local_sync_info) {
             debug!(
@@ -866,5 +883,26 @@ impl RoundManager {
         LogSchema::new(event)
             .round(self.round_state.current_round())
             .epoch(self.epoch_state.epoch)
+    }
+
+    /// Given R1 <- B2 if R1 has the reconfiguration txn, we inject error on B2 if R1.round + 1 = B2.round
+    /// Direct suffix is checked by parent.has_reconfiguration && !parent.parent.has_reconfiguration
+    ///
+    /// It's only enabled with fault injection (failpoints feature).
+    #[allow(unused_variables)]
+    fn should_inject_reconfiguration_error(block_data: &BlockData) -> bool {
+        #[cfg(feature = "failpoints")]
+        {
+            let direct_suffix = block_data.is_reconfiguration_suffix()
+                && !block_data
+                    .quorum_cert()
+                    .parent_block()
+                    .has_reconfiguration();
+            let continuous_round =
+                block_data.round() == block_data.quorum_cert().certified_block().round() + 1;
+            direct_suffix && continuous_round
+        }
+        #[cfg(not(feature = "failpoints"))]
+        false
     }
 }

--- a/testsuite/forge/src/backend/local/cargo.rs
+++ b/testsuite/forge/src/backend/local/cargo.rs
@@ -136,7 +136,7 @@ where
     let output = Command::new("cargo")
         .current_dir(directory)
         .env("CARGO_TARGET_DIR", target_directory)
-        .args(&["build", "--bin=diem-node"])
+        .args(&["build", "--bin=diem-node", "--features=failpoints"])
         .output()
         .context("Failed to build diem-node")?;
 


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #9119
Please review the diff to ensure there are not any unexpected changes.

> …rage
> 
> <!--
> Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.
> 
> The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
> -->
> 
> ## Motivation
> 
> https://github.com/diem/diem/pull/8879 didn't fix the problem because I used the wrong function and tests didn't cover it.
> 
> This PR fixes the problem as well as making sure test covers the edge case. 
> 
> The fix is in executed_block.rs.
> 
> 
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
> 
> (Write your answer here.)
> 
> ## Test Plan
> 
> cargo x test -p smoke-test -- genesis --nocapture
> 
> the test failed without the fix, and passed with the fix.
> 
> ## Related PRs
> 
> (If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)
> 
> ## If targeting a release branch, please fill the below out as well
> 
>  * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)

Same as https://github.com/diem/diem/pull/8879 reconfiguration would halt the validators when there's timeout happens before reconfiguration gets committed.

>  * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.

For test, specifically we forces a timeout (by sending proposals to half of the validators) on the direct child block of reconfiguration when failpoints is enabled, so it'll deterministically reproduce the error.

Also we enabled failpoints in forge local build, so all tests involving multi nodes and epoch change would cover the missing case.

Added a unit test for the specific function.

>  * Why we must have it for V1 launch.

The edge case requires hot fix which we're trying to avoid.

>  * What workarounds and alternative we have if we do not push the PR.

Do a hot fix release or hope the edge case never gets triggered.
            
cc @zekun000