### PR TITLE
json-rpc: implement missing MockDB methods to fix fuzzer

### DIFF
--- a/json-rpc/src/fuzzing.rs
+++ b/json-rpc/src/fuzzing.rs
@@ -27,32 +27,58 @@ fn test_json_rpc_service_fuzzer() {
 #[test]
 fn test_method_fuzzer() {
     method_fuzzer(&gen_request_params!([]), "get_metadata");
+    method_fuzzer(&gen_request_params!([0]), "get_metadata");
     method_fuzzer(
         &gen_request_params!(["000000000000000000000000000000dd"]),
         "get_account",
     );
+    method_fuzzer(&gen_request_params!([0, 1, true]), "get_transactions");
     method_fuzzer(
         &gen_request_params!(["000000000000000000000000000000dd", 0, true]),
         "get_account_transaction",
     );
-    // todo: fix fuzzing test data to make the following test pass
-    // method_fuzzer(
-    //     &gen_request_params!([ADDRESS, 0, 1, true]),
-    //     "get_account_transactions",
-    // );
-    method_fuzzer(&gen_request_params!([0, 1, true]), "get_transactions");
+    method_fuzzer(
+        &gen_request_params!(["000000000000000000000000000000dd", 0, 1, true]),
+        "get_account_transactions",
+    );
     method_fuzzer(
         &gen_request_params!(["00000000000000000000000000000000000000000a550c18", 0, 10]),
         "get_events",
     );
-    method_fuzzer(&gen_request_params!([0]), "get_metadata");
     method_fuzzer(&gen_request_params!([]), "get_currencies");
+    method_fuzzer(&gen_request_params!([]), "get_network_status");
+    // TODO(philiphayes): fails because generated AccountStateWithProof doesn't
+    // include a DiemAccount resource and the non-fuzzer tests assert that the
+    // response is Ok. Should still work fine inside the fuzzer.
+    // method_fuzzer(
+    //     &gen_request_params!(["000000000000000000000000000000dd"]),
+    //     "get_resources",
+    // );
     method_fuzzer(&gen_request_params!([1]), "get_state_proof");
+    method_fuzzer(
+        &gen_request_params!([]),
+        "get_accumulator_consistency_proof",
+    );
     method_fuzzer(
         &gen_request_params!(["000000000000000000000000000000dd", 0, 1]),
         "get_account_state_with_proof",
     );
-    method_fuzzer(&gen_request_params!([]), "get_network_status");
+    method_fuzzer(
+        &gen_request_params!([0, 1, true]),
+        "get_transactions_with_proofs",
+    );
+    method_fuzzer(
+        &gen_request_params!(["000000000000000000000000000000dd", 0, 1, true]),
+        "get_account_transactions_with_proofs",
+    );
+    method_fuzzer(
+        &gen_request_params!(["00000000000000000000000000000000000000000a550c18", 0, 1]),
+        "get_events_with_proofs",
+    );
+    method_fuzzer(
+        &gen_request_params!(["00000000000000000000000000000000000000000a550c18", 0]),
+        "get_event_by_version_with_proof",
+    );
 }
 
 pub fn method_fuzzer(params_data: &[u8], method: &str) {

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -292,7 +292,7 @@ impl DbReader for MockDiemDB {
         _limit: u64,
         _known_version: Option<u64>,
     ) -> Result<Vec<EventWithProof>> {
-        unimplemented!()
+        Ok(Vec::new())
     }
 
     fn get_event_by_version_with_proof(
@@ -301,7 +301,15 @@ impl DbReader for MockDiemDB {
         _version: u64,
         _proof_version: u64,
     ) -> Result<EventByVersionWithProof> {
-        unimplemented!()
+        Ok(EventByVersionWithProof::new(None, None))
+    }
+
+    fn get_accumulator_consistency_proof(
+        &self,
+        _client_known_version: Option<Version>,
+        _ledger_version: Version,
+    ) -> Result<AccumulatorConsistencyProof> {
+        Ok(AccumulatorConsistencyProof::new(Vec::new()))
     }
 
     fn get_state_proof(&self, known_version: u64) -> Result<StateProof> {


### PR DESCRIPTION
Continuous fuzzing discovered a panic in the json-rpc fuzzer where one of the fuzzers managed to discover `get_accumulator_consistency_proof` and called it. The fuzzer, however, uses a MockDB rather than a real DiemDB. The MockDB didn't have `get_accumulator_consistency_proof` implemented and so the fuzz test panicked with `unimplemented!()`. This means the fuzz panic is a false positive, but something we should fix nonetheless so it can discover more useful stuff.

To fix the problem, this PR back-fills all of the missing DB methods called by the json-rpc service with dummy implementations so the fuzzer won't panic if it discovers other methods. We also add the rest of the json-rpc methods (except `get_resources`) to the `test_method_fuzzer` test so we can surface these `unimplemented!()` panics sooner in CI.

Context: T99758011