### PR TITLE
[network] Fix JSON consensus protocol name

### DIFF
--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -54,7 +54,7 @@ impl ProtocolId {
             StateSyncDirectSend => "StateSyncDirectSend",
             DiscoveryDirectSend => "DiscoveryDirectSend",
             HealthCheckerRpc => "HealthCheckerRpc",
-            ConsensusDirectSendJSON => "ConsensusDirectSendCbor",
+            ConsensusDirectSendJSON => "ConsensusDirectSendJson",
         }
     }
 


### PR DESCRIPTION
We aren't using Cbor :).  Should only affect logging