### PR TITLE
[move-unit-tests] Fix native function aborts

### DIFF
--- a/language/tools/move-unit-test/src/test_reporter.rs
+++ b/language/tools/move-unit-test/src/test_reporter.rs
@@ -231,7 +231,7 @@ impl TestFailure {
                             .source_map
                             .get_function_source_map(*fdef_idx)
                             .ok()?;
-                        let loc = function_source_map.get_code_location(*offset)?;
+                        let loc = function_source_map.get_code_location(*offset).unwrap();
                         let msg = format!("In this function in {}", format_module_id(module_id));
                         // TODO(tzakian) maybe migrate off of move-langs diagnostics?
                         Some(Diagnostic::new(

--- a/language/tools/move-unit-test/tests/test_sources/cross_module_aborts.exp
+++ b/language/tools/move-unit-test/tests/test_sources/cross_module_aborts.exp
@@ -8,7 +8,7 @@ Failures in 0x1::B:
 
 ┌── failing_test ──────
 │ error[E11001]: test failure
-│   ┌─ tests/test_sources/cross_module_aborts.move:5:9
+│   ┌─ cross_module_aborts.move:5:9
 │   │
 │ 4 │     public fun this_aborts() {
 │   │                ----------- In this function in 0x1::M

--- a/language/tools/move-unit-test/tests/test_sources/missing_data.exp
+++ b/language/tools/move-unit-test/tests/test_sources/missing_data.exp
@@ -7,7 +7,7 @@ Failures in 0x1::MissingData:
 
 ┌── missing_data ──────
 │ ITE: An unknown error was reported. Location: error[E11001]: test failure
-│   ┌─ tests/test_sources/missing_data.move:6:9
+│   ┌─ missing_data.move:6:9
 │   │
 │ 5 │     fun missing_data() acquires Missing {
 │   │         ------------ In this function in 0x1::MissingData

--- a/language/tools/move-unit-test/tests/test_sources/native_abort.exp
+++ b/language/tools/move-unit-test/tests/test_sources/native_abort.exp
@@ -1,0 +1,37 @@
+Running Move unit tests
+[ PASS    ] 0x1::A::native_abort_good_right_code
+[ FAIL    ] 0x1::A::native_abort_good_wrong_code
+[ FAIL    ] 0x1::A::native_abort_unexpected_abort
+
+Test failures:
+
+Failures in 0x1::A:
+
+┌── native_abort_good_wrong_code ──────
+│ error[E11001]: test failure
+│    ┌─ Vector.move:24:23
+│    │
+│ 24 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+│    │                       ^^^^^^
+│    │                       │
+│    │                       Test did not abort with expected code. Expected test to abort with 0 but instead it aborted with 1 here
+│    │                       In this function in 0x1::Vector
+│ 
+│ 
+└──────────────────
+
+
+┌── native_abort_unexpected_abort ──────
+│ error[E11001]: test failure
+│    ┌─ Vector.move:24:23
+│    │
+│ 24 │     native public fun borrow<Element>(v: &vector<Element>, i: u64): &Element;
+│    │                       ^^^^^^
+│    │                       │
+│    │                       Test was not expected to abort but it aborted with 1 here
+│    │                       In this function in 0x1::Vector
+│ 
+│ 
+└──────────────────
+
+Test result: FAILED. Total tests: 3; passed: 1; failed: 2

--- a/language/tools/move-unit-test/tests/test_sources/native_abort.move
+++ b/language/tools/move-unit-test/tests/test_sources/native_abort.move
@@ -1,0 +1,20 @@
+module 0x1::A {
+    use Std::Vector;
+
+    #[test]
+    fun native_abort_unexpected_abort() {
+        Vector::borrow(&Vector::empty<u64>(), 1);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 0)]
+    fun native_abort_good_wrong_code() {
+        Vector::borrow(&Vector::empty<u64>(), 1);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 1)]
+    fun native_abort_good_right_code() {
+        Vector::borrow(&Vector::empty<u64>(), 1);
+    }
+}

--- a/language/tools/move-unit-test/tests/test_sources/native_signer_creation.exp
+++ b/language/tools/move-unit-test/tests/test_sources/native_signer_creation.exp
@@ -9,7 +9,7 @@ Failures in 0x1::M:
 
 ┌── test_doesnt_exist ──────
 │ error[E11001]: test failure
-│    ┌─ tests/test_sources/native_signer_creation.move:47:9
+│    ┌─ native_signer_creation.move:47:9
 │    │
 │ 36 │     fun test_doesnt_exist() {
 │    │         ----------------- In this function in 0x1::M

--- a/language/tools/move-unit-test/tests/test_sources/native_signer_creation.storage.exp
+++ b/language/tools/move-unit-test/tests/test_sources/native_signer_creation.storage.exp
@@ -9,7 +9,7 @@ Failures in 0x1::M:
 
 ┌── test_doesnt_exist ──────
 │ error[E11001]: test failure
-│    ┌─ tests/test_sources/native_signer_creation.move:47:9
+│    ┌─ native_signer_creation.move:47:9
 │    │
 │ 36 │     fun test_doesnt_exist() {
 │    │         ----------------- In this function in 0x1::M

--- a/language/tools/move-unit-test/tests/test_sources/proposal_test.exp
+++ b/language/tools/move-unit-test/tests/test_sources/proposal_test.exp
@@ -12,7 +12,7 @@ Failures in 0x1::Module:
 
 ┌── tests_d ──────
 │ error[E11001]: test failure
-│     ┌─ tests/test_sources/proposal_test.move:102:9
+│     ┌─ proposal_test.move:102:9
 │     │
 │  95 │     fun tests_d(a1: signer, a2: signer)
 │     │         ------- In this function in 0x1::Module

--- a/language/tools/move-unit-test/tests/test_sources/proposal_test.storage.exp
+++ b/language/tools/move-unit-test/tests/test_sources/proposal_test.storage.exp
@@ -12,7 +12,7 @@ Failures in 0x1::Module:
 
 ┌── tests_d ──────
 │ error[E11001]: test failure
-│     ┌─ tests/test_sources/proposal_test.move:102:9
+│     ┌─ proposal_test.move:102:9
 │     │
 │  95 │     fun tests_d(a1: signer, a2: signer)
 │     │         ------- In this function in 0x1::Module

--- a/language/tools/move-unit-test/tests/test_sources/signer_args.exp
+++ b/language/tools/move-unit-test/tests/test_sources/signer_args.exp
@@ -17,7 +17,7 @@ Failures in 0x1::M:
 
 ┌── single_signer_fail ──────
 │ error[E11001]: test failure
-│   ┌─ tests/test_sources/signer_args.move:9:9
+│   ┌─ signer_args.move:9:9
 │   │
 │ 8 │     fun single_signer_fail(_a: signer) {
 │   │         ------------------ In this function in 0x1::M

--- a/language/tools/move-unit-test/tests/test_sources/storage_on_error_empty_and_non_empty.exp
+++ b/language/tools/move-unit-test/tests/test_sources/storage_on_error_empty_and_non_empty.exp
@@ -11,7 +11,7 @@ Failures in 0x1::A:
 
 ┌── x ──────
 │ error[E11001]: test failure
-│   ┌─ tests/test_sources/storage_on_error_empty_and_non_empty.move:6:9
+│   ┌─ storage_on_error_empty_and_non_empty.move:6:9
 │   │
 │ 5 │     fun x() {
 │   │         - In this function in 0x1::A
@@ -24,7 +24,7 @@ Failures in 0x1::A:
 
 ┌── y ──────
 │ error[E11001]: test failure
-│    ┌─ tests/test_sources/storage_on_error_empty_and_non_empty.move:12:9
+│    ┌─ storage_on_error_empty_and_non_empty.move:12:9
 │    │
 │ 10 │     fun y(a: signer) {
 │    │         - In this function in 0x1::A

--- a/language/tools/move-unit-test/tests/test_sources/storage_on_error_empty_and_non_empty.storage.exp
+++ b/language/tools/move-unit-test/tests/test_sources/storage_on_error_empty_and_non_empty.storage.exp
@@ -11,7 +11,7 @@ Failures in 0x1::A:
 
 ┌── x ──────
 │ error[E11001]: test failure
-│   ┌─ tests/test_sources/storage_on_error_empty_and_non_empty.move:6:9
+│   ┌─ storage_on_error_empty_and_non_empty.move:6:9
 │   │
 │ 5 │     fun x() {
 │   │         - In this function in 0x1::A
@@ -26,7 +26,7 @@ Failures in 0x1::A:
 
 ┌── y ──────
 │ error[E11001]: test failure
-│    ┌─ tests/test_sources/storage_on_error_empty_and_non_empty.move:12:9
+│    ┌─ storage_on_error_empty_and_non_empty.move:12:9
 │    │
 │ 10 │     fun y(a: signer) {
 │    │         - In this function in 0x1::A

--- a/language/tools/move-unit-test/tests/test_sources/timeout.exp
+++ b/language/tools/move-unit-test/tests/test_sources/timeout.exp
@@ -11,7 +11,7 @@ Failures in 0x1::M:
 
 ┌── no_timeout_fail ──────
 │ error[E11001]: test failure
-│    ┌─ tests/test_sources/timeout.move:18:29
+│    ┌─ timeout.move:18:29
 │    │
 │ 18 │     fun no_timeout_fail() { abort 0 }
 │    │         ---------------     ^^^^^^^ Test was not expected to abort but it aborted with 0 here

--- a/language/tools/move-unit-test/tests/test_sources/unexpected_abort.exp
+++ b/language/tools/move-unit-test/tests/test_sources/unexpected_abort.exp
@@ -11,7 +11,7 @@ Failures in 0x1::M:
 
 ┌── unexpected_abort ──────
 │ error[E11001]: test failure
-│   ┌─ tests/test_sources/unexpected_abort.move:5:9
+│   ┌─ unexpected_abort.move:5:9
 │   │
 │ 4 │     public fun unexpected_abort() {
 │   │                ---------------- In this function in 0x1::M
@@ -24,7 +24,7 @@ Failures in 0x1::M:
 
 ┌── unexpected_abort_in_other_function ──────
 │ error[E11001]: test failure
-│    ┌─ tests/test_sources/unexpected_abort.move:28:9
+│    ┌─ unexpected_abort.move:28:9
 │    │
 │ 27 │     fun abort_in_other_function() {
 │    │         ----------------------- In this function in 0x1::M
@@ -37,7 +37,7 @@ Failures in 0x1::M:
 
 ┌── wrong_abort_code ──────
 │ error[E11001]: test failure
-│    ┌─ tests/test_sources/unexpected_abort.move:11:9
+│    ┌─ unexpected_abort.move:11:9
 │    │
 │ 10 │     public fun wrong_abort_code() {
 │    │                ---------------- In this function in 0x1::M


### PR DESCRIPTION
Fixes an issue in unit tests where if an abort code was raised from a native function we wouldn't signal an error. Now if we can't find the code offset given back by the VM we fall back to the function declaration location.

## Testing
Added a test to make sure we signal the appropriate errors when aborts are raised from native functions 
