### PR TITLE
[decoupled-execution] add signing / aggregating logic

### DIFF
--- a/consensus/src/experimental/execution_phase.rs
+++ b/consensus/src/experimental/execution_phase.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    experimental::pipeline_phase::{ResponseWithInstruction, StatelessPipeline},
+    experimental::pipeline_phase::{Instruction, ResponseWithInstruction, StatelessPipeline},
     state_replication::StateComputer,
 };
 use anyhow::Result;
@@ -67,8 +67,15 @@ impl StatelessPipeline for ExecutionPhase {
             })
             .collect::<Result<Vec<ExecutedBlock>, ExecutionError>>();
 
-        // TODO: empty the request channel non-blockingly as they will also fail
+        let instruction = if resp_inner.is_ok() {
+            Instruction::Ok
+        } else {
+            Instruction::Clear
+        };
 
-        ResponseWithInstruction::from(ExecutionResponse { inner: resp_inner })
+        ResponseWithInstruction {
+            resp: ExecutionResponse { inner: resp_inner },
+            instruction,
+        }
     }
 }

--- a/consensus/src/experimental/signing_phase.rs
+++ b/consensus/src/experimental/signing_phase.rs
@@ -43,7 +43,10 @@ impl Display for SigningRequest {
     }
 }
 
-pub type SigningResponse = Result<Ed25519Signature, Error>;
+pub struct SigningResponse {
+    pub signature_result: Result<Ed25519Signature, Error>,
+    pub commit_ledger_info: LedgerInfo,
+}
 
 pub struct SigningPhase {
     safety_rule_handle: Arc<Mutex<MetricsSafetyRules>>,
@@ -65,10 +68,12 @@ impl StatelessPipeline for SigningPhase {
             commit_ledger_info,
         } = req;
 
-        ResponseWithInstruction::from(
-            self.safety_rule_handle
+        ResponseWithInstruction::from(SigningResponse {
+            signature_result: self
+                .safety_rule_handle
                 .lock()
-                .sign_commit_vote(ordered_ledger_info, commit_ledger_info),
-        )
+                .sign_commit_vote(ordered_ledger_info, commit_ledger_info.clone()),
+            commit_ledger_info,
+        })
     }
 }


### PR DESCRIPTION
1. change the semantic meaning of the roots
	a) previously they mean the last processed item, where we will need a sentinel node at the beginning
	b) now they point to the first unprocessed item.
2. add signing phase logic to buffer manager
3. add aggregating phase logic to buffer manager
4. remove aggregation root --- now when a prefix of items are ready to persist, we dequeue them and push them to the persisting phase. There will not be any retry for persisting phase (since we panick at the block store level in the previous implementations).

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
