### PR TITLE
[move-prover] Implement spec (ghost) vars by mapping them to regular memory.

### DIFF
--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -235,6 +235,11 @@ pub enum SpecBlockMember_ {
         name: Name,
         type_parameters: Vec<(Name, AbilitySet)>,
         type_: Type,
+        init: Option<Exp>,
+    },
+    Update {
+        lhs: Exp,
+        rhs: Exp,
     },
     Let {
         name: Name,
@@ -1002,6 +1007,7 @@ impl AstDebug for SpecBlockMember_ {
                 name,
                 type_parameters,
                 type_,
+                init: _,
             } => {
                 if *is_global {
                     w.write("global ");
@@ -1012,6 +1018,12 @@ impl AstDebug for SpecBlockMember_ {
                 type_parameters.ast_debug(w);
                 w.write(": ");
                 type_.ast_debug(w);
+            }
+            SpecBlockMember_::Update { lhs, rhs } => {
+                w.write("update ");
+                lhs.ast_debug(w);
+                w.write(" = ");
+                rhs.ast_debug(w);
             }
             SpecBlockMember_::Let {
                 name,

--- a/language/move-lang/src/expansion/dependency_ordering.rs
+++ b/language/move-lang/src/expansion/dependency_ordering.rs
@@ -538,6 +538,10 @@ fn spec_block_member(context: &mut Context, sp!(_, sbm_): &E::SpecBlockMember) {
         M::Let { def: e, .. } | M::Include { exp: e, .. } | M::Apply { exp: e, .. } => {
             exp(context, e)
         }
+        M::Update { lhs, rhs } => {
+            exp(context, lhs);
+            exp(context, rhs);
+        }
         // A special treatment to the `pragma friend` declarations.
         //
         // The `pragma friend = <address::module_name::function_name>` notion exists before the

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -1209,20 +1209,29 @@ fn spec_member(context: &mut Context, sp!(loc, pm): P::SpecBlockMember) -> E::Sp
             name,
             type_parameters: pty_params,
             type_: t,
+            init,
         } => {
             let type_parameters = type_parameters(context, pty_params);
             let old_aliases = context
                 .aliases
                 .shadow_for_type_parameters(type_parameters.iter().map(|(name, _)| name));
             let t = type_(context, t);
+            let i = init.map(|e| exp_(context, e));
             context.set_to_outer_scope(old_aliases);
             EM::Variable {
                 is_global,
                 name,
                 type_parameters,
                 type_: t,
+                init: i,
             }
         }
+        PM::Update { lhs, rhs } => {
+            let lhs = exp_(context, lhs);
+            let rhs = exp_(context, rhs);
+            EM::Update { lhs, rhs }
+        }
+
         PM::Let {
             name,
             post_state: old,
@@ -2079,6 +2088,7 @@ fn unbound_names_spec_block_member(unbound: &mut BTreeSet<Name>, sp!(_, m_): &E:
         // And will error in the Move prover
         M::Function { .. }
         | M::Variable { .. }
+        | M::Update { .. }
         | M::Let { .. }
         | M::Include { .. }
         | M::Apply { .. }

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -346,11 +346,16 @@ pub enum SpecBlockMember_ {
         name: Name,
         type_parameters: Vec<(Name, Vec<Ability>)>,
         type_: Type,
+        init: Option<Exp>,
     },
     Let {
         name: Name,
         post_state: bool,
         def: Exp,
+    },
+    Update {
+        lhs: Exp,
+        rhs: Exp,
     },
     Include {
         properties: Vec<PragmaProperty>,
@@ -1291,6 +1296,7 @@ impl AstDebug for SpecBlockMember_ {
                 name,
                 type_parameters,
                 type_,
+                init: _,
             } => {
                 if *is_global {
                     w.write("global ");
@@ -1301,6 +1307,12 @@ impl AstDebug for SpecBlockMember_ {
                 type_parameters.ast_debug(w);
                 w.write(": ");
                 type_.ast_debug(w);
+            }
+            SpecBlockMember_::Update { lhs, rhs } => {
+                w.write("update ");
+                lhs.ast_debug(w);
+                w.write(" = ");
+                rhs.ast_debug(w);
             }
             SpecBlockMember_::Let {
                 name,

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -77,7 +77,7 @@ pub(crate) struct SpecVarEntry {
     pub loc: Loc,
     pub module_id: ModuleId,
     pub var_id: SpecVarId,
-    pub type_params: Vec<Type>,
+    pub type_params: Vec<(Symbol, Type)>,
     pub type_: Type,
 }
 
@@ -183,7 +183,7 @@ impl<'env> ModelBuilder<'env> {
         name: QualifiedSymbol,
         module_id: ModuleId,
         var_id: SpecVarId,
-        type_params: Vec<Type>,
+        type_params: Vec<(Symbol, Type)>,
         type_: Type,
     ) {
         let entry = SpecVarEntry {

--- a/language/move-model/src/exp_generator.rs
+++ b/language/move-model/src/exp_generator.rs
@@ -9,8 +9,9 @@ use crate::{
         FieldEnv, FunctionEnv, GlobalEnv, Loc, NodeId, QualifiedId, QualifiedInstId, StructId,
     },
     symbol::Symbol,
-    ty::{Type, BOOL_TYPE, NUM_TYPE},
+    ty::{PrimitiveType, Type, BOOL_TYPE, NUM_TYPE},
 };
+use num::BigUint;
 
 /// A trait that defines a generator for `Exp`.
 pub trait ExpGenerator<'env> {
@@ -59,6 +60,12 @@ pub trait ExpGenerator<'env> {
     fn mk_bool_const(&self, value: bool) -> Exp {
         let node_id = self.new_node(BOOL_TYPE.clone(), None);
         ExpData::Value(node_id, Value::Bool(value)).into_exp()
+    }
+
+    /// Make an address constant.
+    fn mk_address_const(&self, value: BigUint) -> Exp {
+        let node_id = self.new_node(Type::Primitive(PrimitiveType::Address), None);
+        ExpData::Value(node_id, Value::Address(value)).into_exp()
     }
 
     /// Makes a Call expression.

--- a/language/move-model/src/exp_rewriter.rs
+++ b/language/move-model/src/exp_rewriter.rs
@@ -190,16 +190,6 @@ pub trait ExpRewriterFunctions {
                     exp
                 }
             }
-            SpecVar(id, mid, vid, label) => {
-                let (id_changed, new_id) = self.internal_rewrite_id(id);
-                if let Some(new_exp) = self.rewrite_spec_var(new_id, *mid, *vid, label) {
-                    new_exp
-                } else if id_changed {
-                    SpecVar(new_id, *mid, *vid, label.to_owned()).into_exp()
-                } else {
-                    exp
-                }
-            }
             Call(id, oper, args) => {
                 let (id_changed, new_id) = self.internal_rewrite_id(id);
                 let new_args_opt = self.internal_rewrite_vec(args);

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -310,7 +310,8 @@ pub fn run_bytecode_model_builder<'a>(
             let name = m.identifier_at(m.struct_handle_at(def.struct_handle).name);
             let symbol = env.symbol_pool().make(name.as_str());
             let struct_id = StructId::new(symbol);
-            let data = env.create_struct_data(m, def_idx, symbol, Loc::default(), Spec::default());
+            let data =
+                env.create_move_struct_data(m, def_idx, symbol, Loc::default(), Spec::default());
             module_data.struct_data.insert(struct_id, data);
             module_data.struct_idx_to_id.insert(def_idx, struct_id);
         }

--- a/language/move-model/src/ty.rs
+++ b/language/move-model/src/ty.rs
@@ -369,29 +369,27 @@ impl Type {
     /// Attempt to convert this type into a normalized::Type
     pub fn into_struct_type(self, env: &GlobalEnv) -> Option<MType> {
         use Type::*;
-        Some(match self {
+        match self {
             Struct(mid, sid, ts) => env.get_struct_type(mid, sid, &ts),
-            _ => return None,
-        })
+            _ => None,
+        }
     }
 
     /// Attempt to convert this type into a normalized::Type
     pub fn into_normalized_type(self, env: &GlobalEnv) -> Option<MType> {
         use Type::*;
-        Some (
-                match self {
-                    Primitive(p) => p.into_normalized_type().expect("Invariant violation: unexpected spec primitive"),
-                    Struct(mid, sid, ts) =>
-                        env.get_struct_type(mid, sid, &ts),
-                    Vector(et) => MType::Vector(
-                        Box::new(et.into_normalized_type(env)
-                                 .expect("Invariant violation: vector type argument contains incomplete, tuple, reference, or spec type"))
-                    ),
-                    TypeParameter(idx) => MType::TypeParameter(idx as u16),
-                    Tuple(..) | Error | Fun(..) | TypeDomain(..) | ResourceDomain(..) | Var(..) | Reference(..) =>
-                        return None
-                }
-            )
+        match self {
+            Primitive(p) => Some(p.into_normalized_type().expect("Invariant violation: unexpected spec primitive")),
+            Struct(mid, sid, ts) =>
+                env.get_struct_type(mid, sid, &ts),
+            Vector(et) => Some(MType::Vector(
+                Box::new(et.into_normalized_type(env)
+                    .expect("Invariant violation: vector type argument contains incomplete, tuple, reference, or spec type"))
+            )),
+            TypeParameter(idx) => Some(MType::TypeParameter(idx as u16)),
+            Tuple(..) | Error | Fun(..) | TypeDomain(..) | ResourceDomain(..) | Var(..) | Reference(..) =>
+                None
+        }
     }
 
     /// Attempt to convert this type into a language_storage::StructTag

--- a/language/move-model/tests/sources/invariants_err.exp
+++ b/language/move-model/tests/sources/invariants_err.exp
@@ -36,9 +36,3 @@ error: data invariants cannot depend on global state (directly or indirectly use
    │
 15 │     invariant spec_var > 0;
    │     ^^^^^^^^^^^^^^^^^^^^^^^
-
-error: data invariants cannot depend on global state (directly or indirectly uses a global spec var or resource storage).
-   ┌─ tests/sources/invariants_err.move:17:5
-   │
-17 │     invariant rec_fun(true);
-   │     ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/language/move-model/tests/testsuite.rs
+++ b/language/move-model/tests/testsuite.rs
@@ -29,7 +29,9 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
                 .find_module_by_language_storage_id(&raw_module.self_id())
                 .expect("Module not found");
             assert_eq!(m.get_function_count(), other_m.get_function_count());
-            assert_eq!(m.get_struct_count(), other_m.get_struct_count());
+            // other_m can have ghost structs, so only check that we have at least as many
+            // structs as in bytecode.
+            assert!(m.get_struct_count() <= other_m.get_struct_count());
             for (i, _) in raw_module.struct_defs().iter().enumerate() {
                 let idx = StructDefinitionIndex(i as u16);
                 let s = m.get_struct_by_def_idx(idx);

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -285,25 +285,6 @@ pub fn boogie_declare_global(env: &GlobalEnv, name: &str, ty: &Type) -> String {
     )
 }
 
-pub fn boogie_global_declarator(
-    env: &GlobalEnv,
-    name: &str,
-    param_count: usize,
-    ty: &Type,
-) -> String {
-    assert!(!ty.is_reference());
-    if param_count > 0 {
-        format!(
-            "{} : [{}]{}",
-            name,
-            (0..param_count).map(|_| "$TypeValue").join(", "),
-            boogie_type(env, ty)
-        )
-    } else {
-        format!("{} : {}", name, boogie_type(env, ty))
-    }
-}
-
 pub fn boogie_byte_blob(_options: &BoogieOptions, val: &[u8]) -> String {
     let args = val.iter().map(|v| format!("{}", *v)).collect_vec();
     if args.is_empty() {

--- a/language/move-prover/bytecode/src/access_path.rs
+++ b/language/move-prover/bytecode/src/access_path.rs
@@ -882,6 +882,7 @@ impl<'a> fmt::Display for OffsetDisplay<'a> {
                         .get_struct(*sid)
                         .get_field_by_offset(*fld)
                         .get_identifier()
+                        .expect("identifier defined")
                         .as_str(),
                 ),
                 Type::Error => {

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -388,83 +388,83 @@ fun Test::resource_with_old($t0|val: u64) {
 
 ==== spec-instrumenter input specs ====
 
-fun Test::branching_result[baseline[
+fun Test::branching_result[baseline]
 spec {
   aborts_if And($t0, Eq<u64>($t2, 0));
   ensures Implies($t0, Eq<u64>(result0(), Div($t1, $t2)));
   ensures Implies(Not($t0), Eq<u64>(result0(), Mul($t1, $t2)));
 }
 
-fun Test::branching_result[verification[
+fun Test::branching_result[verification]
 spec {
   aborts_if And($t0, Eq<u64>($t2, 0));
   ensures Implies($t0, Eq<u64>(result0(), Div($t1, $t2)));
   ensures Implies(Not($t0), Eq<u64>(result0(), Mul($t1, $t2)));
 }
 
-fun Test::implicit_and_explicit_abort[baseline[
+fun Test::implicit_and_explicit_abort[baseline]
 spec {
   aborts_if Eq<u64>($t1, 0);
   aborts_if Eq<u64>($t0, 0);
   ensures Eq<u64>(result0(), Div($t0, $t1));
 }
 
-fun Test::implicit_and_explicit_abort[verification[
+fun Test::implicit_and_explicit_abort[verification]
 spec {
   aborts_if Eq<u64>($t1, 0);
   aborts_if Eq<u64>($t0, 0);
   ensures Eq<u64>(result0(), Div($t0, $t1));
 }
 
-fun Test::multiple_results[baseline[
+fun Test::multiple_results[baseline]
 spec {
   aborts_if Eq<u64>($t1, 0);
   ensures Eq<u64>(result0(), Div($t0, $t1));
   ensures Eq<u64>(result1(), Mod($t0, $t1));
 }
 
-fun Test::multiple_results[verification[
+fun Test::multiple_results[verification]
 spec {
   aborts_if Eq<u64>($t1, 0);
   ensures Eq<u64>(result0(), Div($t0, $t1));
   ensures Eq<u64>(result1(), Mod($t0, $t1));
 }
 
-fun Test::mut_ref_param[baseline[
+fun Test::mut_ref_param[baseline]
 spec {
   aborts_if Eq<u64>(select Test::R.v($t0), 0);
   ensures Eq<u64>(result0(), Old<u64>(select Test::R.v($t0)));
   ensures Eq<u64>(select Test::R.v($t0), Add(Old<u64>(select Test::R.v($t0)), 1));
 }
 
-fun Test::mut_ref_param[verification[
+fun Test::mut_ref_param[verification]
 spec {
   aborts_if Eq<u64>(select Test::R.v($t0), 0);
   ensures Eq<u64>(result0(), Old<u64>(select Test::R.v($t0)));
   ensures Eq<u64>(select Test::R.v($t0), Add(Old<u64>(select Test::R.v($t0)), 1));
 }
 
-fun Test::ref_param[baseline[
+fun Test::ref_param[baseline]
 spec {
   ensures Eq<u64>(result0(), select Test::R.v($t0));
 }
 
-fun Test::ref_param[verification[
+fun Test::ref_param[verification]
 spec {
   ensures Eq<u64>(result0(), select Test::R.v($t0));
 }
 
-fun Test::ref_param_return_ref[baseline[
+fun Test::ref_param_return_ref[baseline]
 spec {
   ensures Eq<u64>(result0(), select Test::R.v($t0));
 }
 
-fun Test::ref_param_return_ref[verification[
+fun Test::ref_param_return_ref[verification]
 spec {
   ensures Eq<u64>(result0(), select Test::R.v($t0));
 }
 
-fun Test::resource_with_old[baseline[
+fun Test::resource_with_old[baseline]
 spec {
   requires Gt($t0, 0);
   aborts_if Not(exists<Test::R>(0));
@@ -473,7 +473,7 @@ spec {
   modifies global<Test::R>(0);
 }
 
-fun Test::resource_with_old[verification[
+fun Test::resource_with_old[verification]
 spec {
   requires Gt($t0, 0);
   aborts_if Not(exists<Test::R>(0));

--- a/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
@@ -73,25 +73,25 @@ fun Generics::remove_u64($t0|a: address): Generics::R<u64> {
 
 ==== spec-instrumenter input specs ====
 
-fun Generics::remove[baseline[
+fun Generics::remove[baseline]
 spec {
   modifies global<Generics::R<#0>>($t0);
   ensures Not(exists<Generics::R<#0>>($t0));
 }
 
-fun Generics::remove[verification[
+fun Generics::remove[verification]
 spec {
   modifies global<Generics::R<#0>>($t0);
   ensures Not(exists<Generics::R<#0>>($t0));
 }
 
-fun Generics::remove_u64[baseline[
+fun Generics::remove_u64[baseline]
 spec {
   modifies global<Generics::R<u64>>($t0);
   ensures Not(exists<Generics::R<u64>>($t0));
 }
 
-fun Generics::remove_u64[verification[
+fun Generics::remove_u64[verification]
 spec {
   modifies global<Generics::R<u64>>($t0);
   ensures Not(exists<Generics::R<u64>>($t0));

--- a/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
@@ -484,80 +484,80 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
 
 ==== spec-instrumenter input specs ====
 
-fun A::mutate_at[baseline[
+fun A::mutate_at[baseline]
 spec {
   ensures Eq<u64>(select A::S.x(global<A::S>($t0)), 2);
   aborts_if Not(exists<A::S>($t0));
   modifies global<A::S>($t0);
 }
 
-fun A::mutate_at[verification[
+fun A::mutate_at[verification]
 spec {
   ensures Eq<u64>(select A::S.x(global<A::S>($t0)), 2);
   aborts_if Not(exists<A::S>($t0));
   modifies global<A::S>($t0);
 }
 
-fun A::read_at[baseline[
+fun A::read_at[baseline]
 spec {
   aborts_if Not(exists<A::S>($t0));
   ensures Eq<u64>(result0(), select A::S.x(global<A::S>($t0)));
 }
 
-fun A::read_at[verification[
+fun A::read_at[verification]
 spec {
   aborts_if Not(exists<A::S>($t0));
   ensures Eq<u64>(result0(), select A::S.x(global<A::S>($t0)));
 }
 
-fun B::move_from_test_incorrect[baseline[
+fun B::move_from_test_incorrect[baseline]
 spec {
   modifies global<B::T>($t1);
 }
 
-fun B::move_from_test_incorrect[verification[
+fun B::move_from_test_incorrect[verification]
 spec {
   modifies global<B::T>($t1);
 }
 
-fun B::move_to_test_incorrect[baseline[
+fun B::move_to_test_incorrect[baseline]
 spec {
   modifies global<B::T>($t1);
 }
 
-fun B::move_to_test_incorrect[verification[
+fun B::move_to_test_incorrect[verification]
 spec {
   modifies global<B::T>($t1);
 }
 
-fun B::mutate_S_test1_incorrect[baseline[
+fun B::mutate_S_test1_incorrect[baseline]
 spec {
   requires Neq<address>($t0, $t1);
   modifies global<A::S>($t1);
 }
 
-fun B::mutate_S_test1_incorrect[verification[
+fun B::mutate_S_test1_incorrect[verification]
 spec {
   requires Neq<address>($t0, $t1);
   modifies global<A::S>($t1);
 }
 
-fun B::mutate_S_test2_incorrect[baseline[
+fun B::mutate_S_test2_incorrect[baseline]
 spec {
   modifies global<A::S>($t0);
 }
 
-fun B::mutate_S_test2_incorrect[verification[
+fun B::mutate_S_test2_incorrect[verification]
 spec {
   modifies global<A::S>($t0);
 }
 
-fun B::mutate_at_test_incorrect[baseline[
+fun B::mutate_at_test_incorrect[baseline]
 spec {
   modifies global<B::T>($t1);
 }
 
-fun B::mutate_at_test_incorrect[verification[
+fun B::mutate_at_test_incorrect[verification]
 spec {
   modifies global<B::T>($t1);
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
@@ -192,7 +192,7 @@ fun Test::incr_twice() {
 
 ==== spec-instrumenter input specs ====
 
-fun Test::get_and_incr[baseline[
+fun Test::get_and_incr[baseline]
 spec {
   requires Neq<address>($t0, 0);
   aborts_if Not(exists<Test::R>($t0));
@@ -202,7 +202,7 @@ spec {
   ensures Eq<u64>(result0(), select Test::R.v(global<Test::R>($t0)));
 }
 
-fun Test::get_and_incr[verification[
+fun Test::get_and_incr[verification]
 spec {
   requires Neq<address>($t0, 0);
   aborts_if Not(exists<Test::R>($t0));
@@ -212,13 +212,13 @@ spec {
   ensures Eq<u64>(result0(), select Test::R.v(global<Test::R>($t0)));
 }
 
-fun Test::incr_twice[baseline[
+fun Test::incr_twice[baseline]
 spec {
   aborts_if Not(exists<Test::R>(1));
   ensures Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(Old<Test::R>(global<Test::R>(1))), 2));
 }
 
-fun Test::incr_twice[verification[
+fun Test::incr_twice[verification]
 spec {
   aborts_if Not(exists<Test::R>(1));
   ensures Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(Old<Test::R>(global<Test::R>(1))), 2));

--- a/language/move-prover/bytecode/tests/usage_analysis/test.exp
+++ b/language/move-prover/bytecode/tests/usage_analysis/test.exp
@@ -166,8 +166,8 @@ function Test::update [baseline] {
   directly asserted = {}
 }
 function Test::assert_assume_memory [baseline] {
-  accessed = {}
-  directly accessed = {}
+  accessed = {Test::A<bool, u64>, Test::A<u64, bool>}
+  directly accessed = {Test::A<bool, u64>, Test::A<u64, bool>}
   modified = {}
   directly modified = {}
   assumed = {Test::A<bool, u64>}
@@ -176,7 +176,7 @@ function Test::assert_assume_memory [baseline] {
   directly asserted = {Test::A<u64, bool>}
 }
 function Test::call_assert_assume_memory [baseline] {
-  accessed = {}
+  accessed = {Test::A<bool, u64>, Test::A<u64, bool>}
   directly accessed = {}
   modified = {}
   directly modified = {}

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -202,10 +202,6 @@ impl<'env> Evaluator<'env> {
                 self.exp_state
                     .get_var(env.symbol_pool().string(*name).as_str())
             }
-            ExpData::SpecVar(..) => {
-                // TODO (mengxu) handle spec var if they are still here
-                unreachable!()
-            }
             ExpData::Call(node_id, op, args) => self.evaluate_operation(*node_id, op, args)?,
             ExpData::IfElse(_, cond, t_exp, f_exp) => {
                 self.evaluate_if_then_else(cond, t_exp, f_exp)?

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -1,0 +1,70 @@
+Move prover returns: exiting with boogie verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/global_vars.move:41:9
+   │
+41 │         ensures sum_of_T == 2;
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/global_vars.move:37: call_add_sub_invalid
+   =     at tests/sources/functional/global_vars.move:38: call_add_sub_invalid
+   =     at tests/sources/functional/global_vars.move:17: add
+   =     at tests/sources/functional/global_vars.move:18: add
+   =     at tests/sources/functional/global_vars.move:20
+   =     at tests/sources/functional/global_vars.move:24: sub
+   =     at tests/sources/functional/global_vars.move:25: sub
+   =     at tests/sources/functional/global_vars.move:27
+   =     at tests/sources/functional/global_vars.move:17: add
+   =     at tests/sources/functional/global_vars.move:18: add
+   =     at tests/sources/functional/global_vars.move:20
+   =     at tests/sources/functional/global_vars.move:39: call_add_sub_invalid
+   =     at tests/sources/functional/global_vars.move:41
+
+error: precondition does not hold at this call
+   ┌─ tests/sources/functional/global_vars.move:66:9
+   │
+66 │         requires access_verified;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/global_vars.move:74: do_privileged_invalid
+   =         _s = <redacted>
+   =     at tests/sources/functional/global_vars.move:66
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/global_vars.move:102:9
+    │
+102 │         ensures type_has_property<u64>;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/global_vars.move:98: expect_property_of_u64_invalid
+    =     at tests/sources/functional/global_vars.move:99: expect_property_of_u64_invalid
+    =     at tests/sources/functional/global_vars.move:86: give_property_to
+    =     at tests/sources/functional/global_vars.move:88
+    =     at tests/sources/functional/global_vars.move:100: expect_property_of_u64_invalid
+    =     at tests/sources/functional/global_vars.move:102
+
+error: global memory invariant does not hold
+    ┌─ tests/sources/functional/global_vars.move:114:5
+    │
+114 │     invariant global<R>(@0).v <= limit;
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/global_vars.move:136: limit_change_invalid
+    =         s = <redacted>
+    =     at tests/sources/functional/global_vars.move:137: limit_change_invalid
+    =     at tests/sources/functional/global_vars.move:116: publish
+    =         s = <redacted>
+    =     at tests/sources/functional/global_vars.move:117: publish
+    =     at tests/sources/functional/global_vars.move:118: publish
+    =     at tests/sources/functional/global_vars.move:138: limit_change_invalid
+    =     at tests/sources/functional/global_vars.move:140
+    =     at tests/sources/functional/global_vars.move:114
+
+error: global memory invariant does not hold
+    ┌─ tests/sources/functional/global_vars.move:114:5
+    │
+114 │     invariant global<R>(@0).v <= limit;
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/global_vars.move:128: update_invalid
+    =     at tests/sources/functional/global_vars.move:129: update_invalid
+    =     at tests/sources/functional/global_vars.move:114


### PR DESCRIPTION
This re-activates and refines the specification variable implementation of the Move prover.

Spec variables are declared as previously, but with the option to add an initializer:

```
spec module {
   global spec_var: num = 1; // optional initializer
}
```

An update of a spec var can appear in a function spec block:

```
fun f() ...
spec f {
  ...
  update spec_var = spec_var + 1; // assignment; no old
}
```

In contrast to the older defunct implementation, this one maps spec vars to regular global "ghost" memory. That is for each `global x: T`, there is a generated `struct Ghost$x has key { v: T }`. Access to spec vars is right-away mapped to accessing this memory (at address `@0`) in move-model. This way, memory usage and global invariant analysis can be applied to spec vars uniformly.

For a number of examples, see the test [global_vars.move](https://github.com/wrwg/diem/blob/spec_var/language/move-prover/tests/sources/functional/global_vars.move).

This implementation isn't complete yet; there is some more work to do with opaque functions.


## Motivation

More expressive spec lang

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New tests

## Related PRs

NA