### PR TITLE
[forge] disable logtonull

### DIFF
--- a/scripts/fgi/run
+++ b/scripts/fgi/run
@@ -105,7 +105,7 @@ if not args.tag:
         )
         TAG = f"dev_{USER}_pull_{args.pr}"
         print(
-            f"**TIP Use ./scripts/fgi -T {TAG} <...> to restart this run with the same tag without rebuilding it"
+            f"**TIP Use ./scripts/fgi/run -T {TAG} <...> to restart this run with the same tag without rebuilding it"
         )
 if not args.base_image_tag:
     BASE_TAG = "devnet"

--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -241,8 +241,6 @@ pub fn clean_k8s_cluster(
             &format!("chain.era={}", &new_era),
             "--set",
             &format!("imageTag={}", &base_validator_image_tag),
-            "--set",
-            "loggingToNull=true",
         ];
         upgrade_validator(&format!("val{}", i), &helm_repo, &validator_upgrade_options).unwrap();
     });


### PR DESCRIPTION
stop overriding the logging config from forge itself, and instead rely on the config provided by the initial helm install by Terraform

Test:

```
./scripts/fgi/run --pr 9158
```