### PR TITLE
[State Sync] Use the claim crate for better test assertions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "claim"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81099d6bb72e1df6d50bb2347224b666a670912bb7f06dbe867a4a070ab3ce8"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1162,7 @@ name = "consensus-notifications"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "claim",
  "diem-crypto",
  "diem-types",
  "diem-workspace-hack",
@@ -4666,6 +4676,7 @@ name = "mempool-notifications"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "claim",
  "diem-crypto",
  "diem-types",
  "diem-workspace-hack",
@@ -7751,6 +7762,7 @@ dependencies = [
  "bcs",
  "bytes",
  "channel",
+ "claim",
  "consensus-notifications",
  "diem-config",
  "diem-crypto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "channel",
+ "claim",
  "diem-crypto",
  "diem-infallible",
  "diem-temppath",

--- a/common/channel/src/diem_channel.rs
+++ b/common/channel/src/diem_channel.rs
@@ -140,6 +140,7 @@ impl<K: Eq + Hash + Clone, M> Drop for Sender<K, M> {
 }
 
 /// The receiving end of the diem_channel.
+#[derive(Debug)]
 pub struct Receiver<K: Eq + Hash + Clone, M> {
     shared_state: Arc<Mutex<SharedState<K, M>>>,
 }

--- a/state-sync/inter-component/consensus-notifications/Cargo.toml
+++ b/state-sync/inter-component/consensus-notifications/Cargo.toml
@@ -21,4 +21,6 @@ diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [dev-dependencies]
+claim = "0.5.0"
+
 move-core-types = { path = "../../../language/move-core/types" }

--- a/state-sync/inter-component/event-notifications/Cargo.toml
+++ b/state-sync/inter-component/event-notifications/Cargo.toml
@@ -26,6 +26,7 @@ storage-interface = { path = "../../../storage/storage-interface" }
 
 [dev-dependencies]
 bcs = "0.1.2"
+claim = "0.5.0"
 
 diem-crypto = { path = "../../../crypto/crypto" }
 diem-temppath = { path = "../../../common/temppath" }

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -452,6 +452,7 @@ pub type EventNotificationListener = NotificationListener<EventNotification>;
 pub type ReconfigNotificationListener = NotificationListener<ReconfigNotification>;
 
 /// The component responsible for listening to subscription notifications.
+#[derive(Debug)]
 pub struct NotificationListener<T> {
     pub notification_receiver: channel::diem_channel::Receiver<(), T>,
 }

--- a/state-sync/inter-component/mempool-notifications/Cargo.toml
+++ b/state-sync/inter-component/mempool-notifications/Cargo.toml
@@ -20,4 +20,6 @@ diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [dev-dependencies]
+claim = "0.5.0"
+
 diem-crypto = { path = "../../../crypto/crypto" }

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -49,6 +49,7 @@ vm-genesis = { path = "../../language/tools/vm-genesis", optional = true }
 
 [dev-dependencies]
 bytes = "1.0.1"
+claim = "0.5.0"
 proptest = "1.0.0"
 
 channel = { path = "../../common/channel" }


### PR DESCRIPTION
## Motivation

This PR updates all state sync code to utilize the [claim](https://crates.io/crates/claim) crate for better assertion support. While I'm generally reluctant of adding new crate dependencies to code, the claim crate provides much nicer error messages on assertion failures and avoids situations where assertion failures produce unhelpful outputs (e.g., see here: https://github.com/diem/diem/issues/9062). Instead, using claim, we now get error messages like:

Failure on `assert_matches!`:
```
thread 'coordinator::tests::test_new_and_lost_peers' panicked at 'assertion failed, expression does not match any of the given variants.
    expression: Ok(())
    variants: Err(Error::InvalidStateSyncPeer(..))', state-sync/state-sync-v1/src/coordinator.rs:1978:9
```

Failure on `assert_ok!`:

```
thread 'tests::test_missing_configs' panicked at 'assertion failed, expected Ok(..), got Err(CannotSubscribeToZeroEventKeys)', state-sync/inter-component/event-notifications/src/tests.rs:398:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

Moreover, using the crate has: (i) made the tests more readable (i.e., it allows the reader to better distinguish between general unwraps/expects and the assertions the test cares about); and (ii) reduced the lines of code (e.g., due to having native support for things like `assert_matches`). Finally, we note that this dependency is test-only.

The PR offers the following commits:
1. Adopt claim for consensus notifications
2. Adopt claim for mempool notifications
3. Adopt claim for state sync
4. Adopt claim for event notifications

Note: this is a follow-up to: https://github.com/diem/diem/pull/9124 (after a recommendation by @zekun000 😄).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The existing unit tests cover these changes.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906