### PR TITLE
[move-prover] warn on unused global invariants

### DIFF
--- a/language/move-prover/tests/sources/functional/unused_global_invariant.exp
+++ b/language/move-prover/tests/sources/functional/unused_global_invariant.exp
@@ -1,0 +1,29 @@
+warning: Global invariant is not checked anywhere in the code
+   ┌─ tests/sources/functional/unused_global_invariant.move:41:9
+   │
+41 │         invariant exists<R0>(@0x2) ==> exists<R0>(@0x3);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Global invariant is not checked anywhere in the code
+   ┌─ tests/sources/functional/unused_global_invariant.move:46:9
+   │
+46 │         invariant exists<R1<u64>>(@0x2) ==> exists<R1<u64>>(@0x3);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Global invariant is not checked anywhere in the code
+   ┌─ tests/sources/functional/unused_global_invariant.move:51:9
+   │
+51 │         invariant [suspendable] exists<R2>(@0x2) ==> exists<R2>(@0x3);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Global invariant is not checked anywhere in the code
+   ┌─ tests/sources/functional/unused_global_invariant.move:57:9
+   │
+57 │         invariant [suspendable] exists<R3<u64>>(@0x2) ==> exists<R3<u64>>(@0x3);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: Global invariant is not checked anywhere in the code
+   ┌─ tests/sources/functional/unused_global_invariant.move:63:9
+   │
+63 │         invariant exists<R4>(@0x2) ==> exists<R4>(@0x3);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/language/move-prover/tests/sources/functional/unused_global_invariant.move
+++ b/language/move-prover/tests/sources/functional/unused_global_invariant.move
@@ -1,0 +1,65 @@
+module 0x42::UnusedGlobalInvariant {
+    struct R0 has key {}
+    struct R1<T: store> has key { t: T }
+    struct R2 has key {}
+    struct R3<T: store> has key { t: T }
+    struct R4 has key {}
+
+    fun publish_r1_bool(s: signer) {
+        let r = R1 { t: true };
+        move_to(&s, r);
+    }
+
+    fun publish_r2(s: signer) {
+        let r = R2 {};
+        move_to(&s, r);
+    }
+    spec publish_r2 {
+        pragma delegate_invariants_to_caller;
+    }
+
+    fun publish_r3<T: store>(s: signer, t: T) {
+        let r = R3 { t };
+        move_to(&s, r);
+    }
+    spec publish_r3 {
+        pragma delegate_invariants_to_caller;
+    }
+    fun call_publish_r3(s: signer) {
+        publish_r3(s, true);
+    }
+
+    fun check_r4() {
+        if (exists<R4>(@0x2)) {
+            abort 42
+        }
+    }
+
+    spec module {
+        // This invariant is not checked anywhere in the code.
+        // Because no function talks about R0
+        invariant exists<R0>(@0x2) ==> exists<R0>(@0x3);
+
+        // This invariant is not checked anywhere in the code.
+        // Although publish_r1_bool modifies R1, it modifies R1<bool> and this
+        // invariant is about R1<u64>
+        invariant exists<R1<u64>>(@0x2) ==> exists<R1<u64>>(@0x3);
+
+        // This invariant is not checked anywhere in the code.
+        // Although publish_r2 modifies R2, it delegates the invariant to caller
+        // and there is no caller to accept this invariant.
+        invariant [suspendable] exists<R2>(@0x2) ==> exists<R2>(@0x3);
+
+        // This invariant is not checked anywhere in the code.
+        // Although publish_r3 modifies R3<T> it delegates the invariant to
+        // caller, which is call_publish_r3, but call_publish_r3 modifies
+        // R3<bool> and this invariant is about R3<u64>.
+        invariant [suspendable] exists<R3<u64>>(@0x2) ==> exists<R3<u64>>(@0x3);
+
+        // This invariant is not checked anywhere in the code.
+        // Although check_r4 mentioned R4, there is no write operation that is
+        // associated with R4. This invariant can be assumed in the beginning
+        // of the function, but is never checked.
+        invariant exists<R4>(@0x2) ==> exists<R4>(@0x3);
+    }
+}


### PR DESCRIPTION
If the prover finds that a global invariant is not **checked**
in any function, throw a warning for that invariant.

The the new `unused_global_invariant.move` test case for the effect of
this checking.

This fixes #9167.

## Motivation

This warning is good to have and helps filter out unused specs.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI, new test cases added
