### PR TITLE
[decoupled-execution] buffer manager main loop logic (w/o message retry)

### DIFF
--- a/consensus/src/experimental/execution_phase.rs
+++ b/consensus/src/experimental/execution_phase.rs
@@ -74,7 +74,7 @@ impl StatelessPipeline for ExecutionPhase {
         };
 
         ResponseWithInstruction {
-            resp: ExecutionResponse { inner: resp_inner },
+            response: ExecutionResponse { inner: resp_inner },
             instruction,
         }
     }

--- a/consensus/src/experimental/persisting_phase.rs
+++ b/consensus/src/experimental/persisting_phase.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crate::{
-    experimental::pipeline_phase::{ResponseWithInstruction, StatelessPipeline},
+    experimental::pipeline_phase::{Instruction, ResponseWithInstruction, StatelessPipeline},
     state_replication::{StateComputer, StateComputerCommitCallBackType},
 };
 use async_trait::async_trait;
@@ -65,10 +65,14 @@ impl StatelessPipeline for PersistingPhase {
             callback,
         } = req;
 
-        ResponseWithInstruction::from(
-            self.persisting_handle
+        // we do not return a response
+        // assuming the commit function panicks if there is any error.
+        ResponseWithInstruction {
+            response: self
+                .persisting_handle
                 .commit(&blocks, commit_ledger_info, callback)
                 .await,
-        )
+            instruction: Instruction::NoResponse,
+        }
     }
 }

--- a/consensus/src/experimental/tests/execution_phase_tests.rs
+++ b/consensus/src/experimental/tests/execution_phase_tests.rs
@@ -63,7 +63,7 @@ fn test_execution_phase_process() {
 
     timed_block_on(&mut runtime, async move {
         let ResponseWithInstruction {
-            resp,
+            response: resp,
             instruction: _,
         } = execution_phase
             .process(ExecutionRequest {


### PR DESCRIPTION
also removed the response from ther persisting phase (assuming state_computer's commit function handles the error by panics)

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
