### PR TITLE
[move-prover] fix a bug in rewrite_temporary

### DIFF
--- a/language/move-prover/tests/sources/regression/temporary_rewrite.move
+++ b/language/move-prover/tests/sources/regression/temporary_rewrite.move
@@ -1,0 +1,21 @@
+module 0x2::Token {
+    struct Token<phantom T> has store { value: u64 }
+
+    public fun burn<T>(_unused: bool, token: Token<T>) {
+        let Token { value } = token;
+        assert(value != 0, 42);
+    }
+    spec burn {
+        aborts_if token.value == 0;
+    }
+}
+
+module 0x2::Liquid {
+    use 0x2::Token;
+
+    struct Liquid<phantom X, phantom Y> has key, store {}
+
+    fun l_burn<X, Y>(token: Token::Token<Liquid<X, Y>>) {
+        Token::burn(false, token);
+    }
+}


### PR DESCRIPTION
Also simplified the logic there a bit.

This PR fixes #9155, now the `starswap_modules` and `starcoin_modules` verify without a problem.

A minimal repro is produced under `regression/temporary_rewrite.move`.

## Motivation

Bug fix.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI, new test case added
