### PR TITLE
[move-model] do not double-instantiate exps in `instrument_call`

### DIFF
--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -1077,12 +1077,9 @@ impl<'env> SpecTranslator<'env> {
                 let quant_ty = self.get_node_type(range.node_id());
                 if let Type::ResourceDomain(mid, sid, inst_opt) = quant_ty.skip_reference() {
                     let addr_var = resource_vars.get(&var.name).unwrap();
-                    let inst = self.inst_slice(inst_opt.as_ref().map(Vec::as_slice).unwrap_or(&[]));
-                    let resource_name = boogie_resource_memory_name(
-                        self.env,
-                        &mid.qualified_inst(*sid, inst),
-                        &None,
-                    );
+                    let memory =
+                        &mid.qualified_inst(*sid, inst_opt.to_owned().unwrap_or_else(Vec::new));
+                    let resource_name = boogie_resource_memory_name(self.env, memory, &None);
                     let resource_value = format!("$ResourceValue({}, {})", resource_name, addr_var);
                     emit!(self.writer, "{{{}}}", resource_value);
                 }

--- a/language/move-prover/tests/sources/functional/exists_in_vector.move
+++ b/language/move-prover/tests/sources/functional/exists_in_vector.move
@@ -68,9 +68,8 @@ module 0x42::VectorExists {
         ensures exists i: u64 : v[i] == 1; // FIXME: not verified, but should be.
         ensures e_in_v_u64(1, v); // FIXME: not verified, but should be.
 
-        // TODO: The followings are things to do next once the FIXMEs above are fixed:
-        // ensures old(e_in_v_vec(0, v)) ==> e_in_v_vec(0, v);
-        // ensures old(e_in_v_range(0, v)) ==> e_in_v_range(0, v);
-        // ensures old(e_in_v_u64(0, v)) ==> e_in_v_u64(0, v);
+        ensures old(e_in_v_vec(0, v)) ==> e_in_v_vec(0, v);
+        ensures old(e_in_v_range(0, v)) ==> e_in_v_range(0, v);
+        ensures old(e_in_v_u64(0, v)) ==> e_in_v_u64(0, v);
     }
 }

--- a/language/move-prover/tests/sources/functional/old_param_err.exp
+++ b/language/move-prover/tests/sources/functional/old_param_err.exp
@@ -1,0 +1,6 @@
+Move prover returns: exiting with bytecode transformation errors
+error: `old(..)` applied to expression which does not depend on state
+   ┌─ tests/sources/functional/old_param_err.move:16:17
+   │
+16 │         ensures old(token.value) == result_1.value + result_2.value;
+   │                 ^^^^^^^^^^^^^^^^

--- a/language/move-prover/tests/sources/functional/old_param_err.move
+++ b/language/move-prover/tests/sources/functional/old_param_err.move
@@ -1,0 +1,18 @@
+module 0x2::Token {
+    struct Token<phantom T> has store { value: u64 }
+
+    fun withdraw<T>(token: &mut Token<T>, value: u64): Token<T> {
+        assert(token.value >= value, 42);
+        token.value = token.value - value;
+        Token { value }
+    }
+
+    public fun split<T>(token: Token<T>, value: u64): (Token<T>, Token<T>) {
+        let other = withdraw(&mut token, value);
+        (token, other)
+    }
+    spec split {
+        aborts_if token.value < value;
+        ensures old(token.value) == result_1.value + result_2.value;
+    }
+}

--- a/language/move-prover/tests/sources/functional/old_param_ok.move
+++ b/language/move-prover/tests/sources/functional/old_param_ok.move
@@ -1,0 +1,18 @@
+module 0x2::Token {
+    struct Token<phantom T> has store { value: u64 }
+
+    fun withdraw<T>(token: &mut Token<T>, value: u64): Token<T> {
+        assert(token.value >= value, 42);
+        token.value = token.value - value;
+        Token { value }
+    }
+
+    public fun split<T>(token: Token<T>, value: u64): (Token<T>, Token<T>) {
+        let other = withdraw(&mut token, value);
+        (token, other)
+    }
+    spec split {
+        aborts_if token.value < value;
+        ensures token.value == result_1.value + result_2.value;
+    }
+}

--- a/language/move-prover/tests/sources/regression/let_rewrite.move
+++ b/language/move-prover/tests/sources/regression/let_rewrite.move
@@ -1,0 +1,22 @@
+module 0x2::Token {
+    struct Token<phantom T> has store { value: u64 }
+
+    public fun burn<T>(_unused: bool, token: Token<T>) {
+        let Token { value } = token;
+        assert(value != 0, 42);
+    }
+    spec burn {
+        let token_value = token.value;
+        aborts_if token_value == 0;
+    }
+}
+
+module 0x2::Liquid {
+    use 0x2::Token;
+
+    struct Liquid<phantom X, phantom Y> has key, store {}
+
+    fun l_burn<X, Y>(token: Token::Token<Liquid<X, Y>>) {
+        Token::burn(false, token);
+    }
+}


### PR DESCRIPTION
As title. The `instrument_call` translates function specs for callee with
awareness of the type arguments, hence, we should not try to re-initialize
them.

A minimal repro is added in `regression/let_rewrite.move`

Partially fixes #9155, but now we have a different error.

*EDIT:* the new error is caused by using `old(..)` in immutable parameter,
which is extracted to be a separate pair of test cases
- old_param_ok.move 
- old_param_err.move

## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI with new test case
