### PR TITLE
[mempool/state-sync] Remove NodeNetworkId & modernize PeerNetworkId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7917,6 +7917,7 @@ dependencies = [
  "proptest",
  "rand 0.8.3",
  "serde",
+ "short-hex-str",
  "storage-interface",
  "storage-service",
  "thiserror",

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::network_id::{NetworkId, NodeNetworkId};
+use crate::network_id::NetworkId;
 use diem_types::PeerId;
 use serde::{Deserialize, Serialize};
 use short_hex_str::AsShortHexStr;
@@ -9,15 +9,11 @@ use std::fmt;
 
 #[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
-pub struct PeerNetworkId(pub NodeNetworkId, pub PeerId);
+pub struct PeerNetworkId(pub NetworkId, pub PeerId);
 
 impl PeerNetworkId {
-    pub fn network_id(&self) -> NodeNetworkId {
+    pub fn network_id(&self) -> NetworkId {
         self.0.clone()
-    }
-
-    pub fn raw_network_id(&self) -> NetworkId {
-        self.0.network_id()
     }
 
     pub fn peer_id(&self) -> PeerId {
@@ -26,18 +22,12 @@ impl PeerNetworkId {
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn random() -> Self {
-        Self(
-            NodeNetworkId::new(NetworkId::default(), 0),
-            PeerId::random(),
-        )
+        Self(NetworkId::Public, PeerId::random())
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn random_validator() -> Self {
-        Self(
-            NodeNetworkId::new(NetworkId::Validator, 0),
-            PeerId::random(),
-        )
+        Self(NetworkId::Validator, PeerId::random())
     }
 }
 
@@ -49,11 +39,6 @@ impl fmt::Debug for PeerNetworkId {
 
 impl fmt::Display for PeerNetworkId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "PeerId:{}, NodeNetworkId:({})",
-            self.peer_id().short_str(),
-            self.raw_network_id()
-        )
+        write!(f, "{}:{}", self.network_id(), self.peer_id().short_str(),)
     }
 }

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -9,25 +9,34 @@ use std::fmt;
 
 #[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
-pub struct PeerNetworkId(pub NetworkId, pub PeerId);
+pub struct PeerNetworkId {
+    network_id: NetworkId,
+    peer_id: PeerId,
+}
 
 impl PeerNetworkId {
+    pub fn new(network_id: NetworkId, peer_id: PeerId) -> Self {
+        Self {
+            network_id,
+            peer_id,
+        }
+    }
     pub fn network_id(&self) -> NetworkId {
-        self.0.clone()
+        self.network_id.clone()
     }
 
     pub fn peer_id(&self) -> PeerId {
-        self.1
+        self.peer_id
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn random() -> Self {
-        Self(NetworkId::Public, PeerId::random())
+        Self::new(NetworkId::Public, PeerId::random())
     }
 
     #[cfg(any(test, feature = "fuzzing"))]
     pub fn random_validator() -> Self {
-        Self(NetworkId::Validator, PeerId::random())
+        Self::new(NetworkId::Validator, PeerId::random())
     }
 }
 

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -124,35 +124,6 @@ impl PartialOrd for NetworkId {
     }
 }
 
-/// An intra-node identifier for a network of a node unique for a network
-/// This extra layer on top of `NetworkId` mainly exists for the application-layer (e.g. mempool,
-/// state sync) to differentiate between multiple public
-/// networks that a node may belong to
-#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
-pub struct NodeNetworkId(NetworkId, usize);
-
-impl NodeNetworkId {
-    pub fn new(network_id: NetworkId, num_id: usize) -> Self {
-        Self(network_id, num_id)
-    }
-
-    pub fn network_id(&self) -> NetworkId {
-        self.0.clone()
-    }
-}
-
-impl fmt::Debug for NodeNetworkId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
-    }
-}
-
-impl fmt::Display for NodeNetworkId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}:{}", self.0, self.1)
-    }
-}
-
 /// Default needed to handle downstream structs that use `Default`
 impl Default for NetworkId {
     fn default() -> NetworkId {

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -247,7 +247,7 @@ static SHARED_MEMPOOL_PENDING_BROADCASTS_COUNT: Lazy<IntGaugeVec> = Lazy::new(||
 
 pub fn shared_mempool_pending_broadcasts(peer: &PeerNetworkId) -> IntGauge {
     SHARED_MEMPOOL_PENDING_BROADCASTS_COUNT.with_label_values(&[
-        peer.raw_network_id().as_str(),
+        peer.network_id().as_str(),
         peer.peer_id().short_str().as_str(),
     ])
 }
@@ -302,7 +302,7 @@ static SHARED_MEMPOOL_ACK_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
 pub fn shared_mempool_ack_inc(peer: &PeerNetworkId, direction: &str, label: &'static str) {
     SHARED_MEMPOOL_ACK_TYPE_COUNT
         .with_label_values(&[
-            peer.raw_network_id().as_str(),
+            peer.network_id().as_str(),
             peer.peer_id().short_str().as_str(),
             direction,
             label,
@@ -393,7 +393,7 @@ static INVALID_ACK_RECEIVED_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
 pub fn invalid_ack_inc(peer: &PeerNetworkId, label: &'static str) {
     INVALID_ACK_RECEIVED_COUNT
         .with_label_values(&[
-            peer.raw_network_id().as_str(),
+            peer.network_id().as_str(),
             peer.peer_id().short_str().as_str(),
             label,
         ])

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -204,7 +204,7 @@ async fn handle_event<V>(
     match event {
         Event::NewPeer(metadata) => {
             counters::shared_mempool_event_inc("new_peer");
-            let peer = PeerNetworkId(network_id, metadata.remote_peer_id);
+            let peer = PeerNetworkId::new(network_id, metadata.remote_peer_id);
             let is_new_peer = smp.peer_manager.add_peer(peer.clone(), metadata.clone());
             let is_upstream_peer = smp.peer_manager.is_upstream_peer(&peer, Some(&metadata));
             debug!(LogSchema::new(LogEntry::NewPeer)
@@ -217,7 +217,7 @@ async fn handle_event<V>(
         }
         Event::LostPeer(metadata) => {
             counters::shared_mempool_event_inc("lost_peer");
-            let peer = PeerNetworkId(network_id, metadata.remote_peer_id);
+            let peer = PeerNetworkId::new(network_id, metadata.remote_peer_id);
             debug!(LogSchema::new(LogEntry::LostPeer)
                 .peer(&peer)
                 .is_upstream_peer(smp.peer_manager.is_upstream_peer(&peer, Some(&metadata))));
@@ -232,7 +232,7 @@ async fn handle_event<V>(
                     transactions,
                 } => {
                     let smp_clone = smp.clone();
-                    let peer = PeerNetworkId(network_id, peer_id);
+                    let peer = PeerNetworkId::new(network_id, peer_id);
                     let timeline_state = match smp.peer_manager.is_upstream_peer(&peer, None) {
                         true => TimelineState::NonQualified,
                         false => TimelineState::NotReady,
@@ -267,7 +267,7 @@ async fn handle_event<V>(
                 } => {
                     let ack_timestamp = SystemTime::now();
                     smp.peer_manager.process_broadcast_ack(
-                        PeerNetworkId(network_id, peer_id),
+                        PeerNetworkId::new(network_id, peer_id),
                         request_id,
                         retry,
                         backoff,
@@ -281,7 +281,7 @@ async fn handle_event<V>(
             sample!(
                 SampleRate::Duration(Duration::from_secs(60)),
                 warn!(LogSchema::new(LogEntry::UnexpectedNetworkMsg)
-                    .peer(&PeerNetworkId(network_id, peer_id)))
+                    .peer(&PeerNetworkId::new(network_id, peer_id)))
             );
         }
     }

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -18,7 +18,7 @@ use crate::{
 use ::network::protocols::network::Event;
 use anyhow::Result;
 use bounded_executor::BoundedExecutor;
-use diem_config::{config::PeerNetworkId, network_id::NodeNetworkId};
+use diem_config::{config::PeerNetworkId, network_id::NetworkId};
 use diem_infallible::Mutex;
 use diem_logger::prelude::*;
 use diem_types::{
@@ -44,7 +44,7 @@ use vm_validator::vm_validator::TransactionValidation;
 pub(crate) async fn coordinator<V>(
     mut smp: SharedMempool<V>,
     executor: Handle,
-    network_events: Vec<(NodeNetworkId, MempoolNetworkEvents)>,
+    network_events: Vec<(NetworkId, MempoolNetworkEvents)>,
     mut client_events: mpsc::Receiver<(
         SignedTransaction,
         oneshot::Sender<Result<SubmissionStatus>>,
@@ -196,7 +196,7 @@ async fn handle_event<V>(
     bounded_executor: &BoundedExecutor,
     scheduled_broadcasts: &mut FuturesUnordered<ScheduledBroadcast>,
     smp: &mut SharedMempool<V>,
-    network_id: NodeNetworkId,
+    network_id: NetworkId,
     event: Event<MempoolSyncMsg>,
 ) where
     V: TransactionValidation,
@@ -277,7 +277,7 @@ async fn handle_event<V>(
             }
         }
         Event::RpcRequest(peer_id, _msg, _res_tx) => {
-            counters::unexpected_msg_count_inc(&network_id.network_id(), &peer_id);
+            counters::unexpected_msg_count_inc(&network_id, &peer_id);
             sample!(
                 SampleRate::Duration(Duration::from_secs(60)),
                 warn!(LogSchema::new(LogEntry::UnexpectedNetworkMsg)

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -506,28 +506,24 @@ mod test {
     use diem_config::network_id::NetworkId;
     use diem_types::PeerId;
 
-    fn peer_network_id(peer_id: PeerId, network: NetworkId) -> PeerNetworkId {
-        PeerNetworkId::new(network, peer_id)
-    }
-
     #[test]
     fn check_peer_prioritization() {
         let peer_id_1 = PeerId::from_hex_literal("0x1").unwrap();
         let peer_id_2 = PeerId::from_hex_literal("0x2").unwrap();
         let val_1 = (
-            peer_network_id(peer_id_1, NetworkId::vfn_network()),
+            PeerNetworkId::new(NetworkId::vfn_network(), peer_id_1),
             PeerRole::Validator,
         );
         let val_2 = (
-            peer_network_id(peer_id_2, NetworkId::vfn_network()),
+            PeerNetworkId::new(NetworkId::vfn_network(), peer_id_2),
             PeerRole::Validator,
         );
         let vfn_1 = (
-            peer_network_id(peer_id_1, NetworkId::Public),
+            PeerNetworkId::new(NetworkId::Public, peer_id_1),
             PeerRole::ValidatorFullNode,
         );
         let preferred_1 = (
-            peer_network_id(peer_id_1, NetworkId::Public),
+            PeerNetworkId::new(NetworkId::Public, peer_id_1),
             PeerRole::PreferredUpstream,
         );
 

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -507,7 +507,7 @@ mod test {
     use diem_types::PeerId;
 
     fn peer_network_id(peer_id: PeerId, network: NetworkId) -> PeerNetworkId {
-        PeerNetworkId(network, peer_id)
+        PeerNetworkId::new(network, peer_id)
     }
 
     #[test]

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -12,7 +12,7 @@ use crate::{
     ConsensusRequest, SubmissionStatus,
 };
 use anyhow::Result;
-use diem_config::{config::NodeConfig, network_id::NodeNetworkId};
+use diem_config::{config::NodeConfig, network_id::NetworkId};
 use diem_infallible::{Mutex, RwLock};
 use diem_types::transaction::SignedTransaction;
 use event_notifications::ReconfigNotificationListener;
@@ -37,7 +37,7 @@ pub(crate) fn start_shared_mempool<V>(
     mempool: Arc<Mutex<CoreMempool>>,
     // First element in tuple is the network ID.
     // See `NodeConfig::is_upstream_peer` for the definition of network ID.
-    mempool_network_handles: Vec<(NodeNetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
+    mempool_network_handles: Vec<(NetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
     client_events: mpsc::Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: mpsc::Receiver<ConsensusRequest>,
     mempool_listener: MempoolNotificationListener,
@@ -93,7 +93,7 @@ pub fn bootstrap(
     db: Arc<dyn DbReader>,
     // The first element in the tuple is the ID of the network that this network is a handle to.
     // See `NodeConfig::is_upstream_peer` for the definition of network ID.
-    mempool_network_handles: Vec<(NodeNetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
+    mempool_network_handles: Vec<(NetworkId, MempoolNetworkSender, MempoolNetworkEvents)>,
     client_events: Receiver<(SignedTransaction, oneshot::Sender<Result<SubmissionStatus>>)>,
     consensus_requests: Receiver<ConsensusRequest>,
     mempool_listener: MempoolNotificationListener,

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -113,7 +113,7 @@ pub(crate) async fn process_transaction_broadcast<V>(
 {
     timer.stop_and_record();
     let _timer = counters::process_txn_submit_latency_timer(
-        peer.raw_network_id().as_str(),
+        peer.network_id().as_str(),
         peer.peer_id().short_str().as_str(),
     );
     let results = process_incoming_transactions(&smp, transactions.clone(), timeline_state).await;
@@ -295,10 +295,7 @@ where
 
 fn log_txn_process_results(results: &[SubmissionStatusBundle], sender: Option<PeerNetworkId>) {
     let (network, sender) = match sender {
-        Some(peer) => (
-            peer.raw_network_id().to_string(),
-            peer.peer_id().to_string(),
-        ),
+        Some(peer) => (peer.network_id().to_string(), peer.peer_id().to_string()),
         None => (
             counters::CLIENT_LABEL.to_string(),
             counters::CLIENT_LABEL.to_string(),

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -295,7 +295,10 @@ where
 
 fn log_txn_process_results(results: &[SubmissionStatusBundle], sender: Option<PeerNetworkId>) {
     let (network, sender) = match sender {
-        Some(peer) => (peer.network_id().to_string(), peer.peer_id().to_string()),
+        Some(peer) => (
+            peer.network_id().to_string(),
+            peer.peer_id().short_str().to_string(),
+        ),
         None => (
             counters::CLIENT_LABEL.to_string(),
             counters::CLIENT_LABEL.to_string(),

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -10,7 +10,7 @@ use crate::{
 use anyhow::Result;
 use diem_config::{
     config::{MempoolConfig, PeerNetworkId},
-    network_id::NodeNetworkId,
+    network_id::NetworkId,
 };
 use diem_infallible::{Mutex, RwLock};
 use diem_types::{
@@ -35,7 +35,7 @@ where
 {
     pub mempool: Arc<Mutex<CoreMempool>>,
     pub config: MempoolConfig,
-    pub network_senders: HashMap<NodeNetworkId, MempoolNetworkSender>,
+    pub network_senders: HashMap<NetworkId, MempoolNetworkSender>,
     pub db: Arc<dyn DbReader>,
     pub validator: Arc<RwLock<V>>,
     pub peer_manager: Arc<PeerManager>,

--- a/mempool/src/tests/mocks.rs
+++ b/mempool/src/tests/mocks.rs
@@ -11,7 +11,7 @@ use anyhow::{format_err, Result};
 use channel::{self, diem_channel, message_queues::QueueStyle};
 use diem_config::{
     config::{NetworkConfig, NodeConfig},
-    network_id::{NetworkId, NodeNetworkId},
+    network_id::NetworkId,
 };
 use diem_infallible::{Mutex, RwLock};
 use diem_types::{
@@ -80,11 +80,7 @@ impl MockSharedMempool {
             Arc::new(RwLock::new(DbReaderWriter::new(MockDbReaderWriter))),
         );
         let reconfig_event_subscriber = event_subscriber.subscribe_to_reconfigurations().unwrap();
-        let network_handles = vec![(
-            NodeNetworkId::new(NetworkId::Validator, 0),
-            network_sender,
-            network_events,
-        )];
+        let network_handles = vec![(NetworkId::Validator, network_sender, network_events)];
 
         start_shared_mempool(
             runtime.handle(),

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -533,7 +533,7 @@ fn setup_node_network_interfaces(
     HashMap<NetworkId, NodeNetworkInterface>,
     Vec<MempoolNetworkHandle>,
 ) {
-    let (network_interface, network_handle) = setup_node_network_interface(PeerNetworkId(
+    let (network_interface, network_handle) = setup_node_network_interface(PeerNetworkId::new(
         node.primary_network(),
         node.primary_peer_id(),
     ));
@@ -550,7 +550,7 @@ fn setup_node_network_interfaces(
                 node.primary_network()
             )
         }
-        let (network_interface, network_handle) = setup_node_network_interface(PeerNetworkId(
+        let (network_interface, network_handle) = setup_node_network_interface(PeerNetworkId::new(
             secondary_network_id.clone(),
             node.secondary_peer_id().unwrap(),
         ));

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -44,6 +44,7 @@ memsocket = { path = "../../network/memsocket", optional = true }
 mempool-notifications = { path = "../inter-component/mempool-notifications" }
 netcore = { path = "../../network/netcore" }
 network = { path = "../../network" }
+short-hex-str = { path = "../../common/short-hex-str" }
 storage-interface = { path = "../../storage/storage-interface" }
 vm-genesis = { path = "../../language/tools/vm-genesis", optional = true }
 

--- a/state-sync/state-sync-v1/src/bootstrapper.rs
+++ b/state-sync/state-sync-v1/src/bootstrapper.rs
@@ -7,7 +7,7 @@ use crate::{
     network::{StateSyncEvents, StateSyncSender},
 };
 use consensus_notifications::ConsensusNotificationListener;
-use diem_config::{config::NodeConfig, network_id::NodeNetworkId};
+use diem_config::{config::NodeConfig, network_id::NetworkId};
 use diem_types::waypoint::Waypoint;
 use event_notifications::EventSubscriptionService;
 use executor_types::ChunkExecutor;
@@ -26,7 +26,7 @@ pub struct StateSyncBootstrapper {
 
 impl StateSyncBootstrapper {
     pub fn bootstrap<M: MempoolNotificationSender + 'static>(
-        network: Vec<(NodeNetworkId, StateSyncSender, StateSyncEvents)>,
+        network: Vec<(NetworkId, StateSyncSender, StateSyncEvents)>,
         mempool_notifier: M,
         consensus_listener: ConsensusNotificationListener,
         storage: Arc<dyn DbReader>,
@@ -63,7 +63,7 @@ impl StateSyncBootstrapper {
         M: MempoolNotificationSender + 'static,
     >(
         runtime: Runtime,
-        network: Vec<(NodeNetworkId, StateSyncSender, StateSyncEvents)>,
+        network: Vec<(NetworkId, StateSyncSender, StateSyncEvents)>,
         mempool_notifier: M,
         consensus_listener: ConsensusNotificationListener,
         node_config: &NodeConfig,

--- a/state-sync/state-sync-v1/src/coordinator.rs
+++ b/state-sync/state-sync-v1/src/coordinator.rs
@@ -248,13 +248,13 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
         network_id: NetworkId,
         metadata: ConnectionMetadata,
     ) -> Result<(), Error> {
-        let peer = PeerNetworkId(network_id, metadata.remote_peer_id);
+        let peer = PeerNetworkId::new(network_id, metadata.remote_peer_id);
         self.request_manager.enable_peer(peer, metadata)?;
         self.check_progress()
     }
 
     fn process_lost_peer(&mut self, network_id: NetworkId, peer_id: PeerId) -> Result<(), Error> {
-        let peer = PeerNetworkId(network_id, peer_id);
+        let peer = PeerNetworkId::new(network_id, peer_id);
         self.request_manager.disable_peer(&peer)
     }
 
@@ -264,7 +264,7 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
         peer_id: PeerId,
         msg: StateSyncMessage,
     ) -> Result<(), Error> {
-        let peer = PeerNetworkId(network_id, peer_id);
+        let peer = PeerNetworkId::new(network_id, peer_id);
         match msg {
             StateSyncMessage::GetChunkRequest(request) => {
                 // Time request handling

--- a/state-sync/state-sync-v1/src/coordinator.rs
+++ b/state-sync/state-sync-v1/src/coordinator.rs
@@ -38,6 +38,7 @@ use futures::{
 };
 use mempool_notifications::MempoolNotificationSender;
 use network::{protocols::network::Event, transport::ConnectionMetadata};
+use short_hex_str::AsShortHexStr;
 use std::{
     cmp,
     collections::HashMap,
@@ -269,8 +270,8 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
                 // Time request handling
                 let _timer = counters::PROCESS_MSG_LATENCY
                     .with_label_values(&[
-                        &peer.network_id().to_string(),
-                        &peer.peer_id().to_string(),
+                        peer.network_id().as_str(),
+                        peer.peer_id().short_str().as_str(),
                         counters::CHUNK_REQUEST_MSG_LABEL,
                     ])
                     .start_timer();
@@ -287,16 +288,16 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
                     );
                     counters::PROCESS_CHUNK_REQUEST_COUNT
                         .with_label_values(&[
-                            &peer.network_id().to_string(),
-                            &peer.peer_id().to_string(),
+                            peer.network_id().as_str(),
+                            peer.peer_id().short_str().as_str(),
                             counters::FAIL_LABEL,
                         ])
                         .inc();
                 } else {
                     counters::PROCESS_CHUNK_REQUEST_COUNT
                         .with_label_values(&[
-                            &peer.network_id().to_string(),
-                            &peer.peer_id().to_string(),
+                            peer.network_id().as_str(),
+                            peer.peer_id().short_str().as_str(),
                             counters::SUCCESS_LABEL,
                         ])
                         .inc();
@@ -307,8 +308,8 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
                 // Time response handling
                 let _timer = counters::PROCESS_MSG_LATENCY
                     .with_label_values(&[
-                        &peer.network_id().to_string(),
-                        &peer.peer_id().to_string(),
+                        peer.network_id().as_str(),
+                        peer.peer_id().short_str().as_str(),
                         counters::CHUNK_RESPONSE_MSG_LABEL,
                     ])
                     .start_timer();
@@ -887,8 +888,8 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
         };
         counters::RESPONSES_SENT
             .with_label_values(&[
-                &peer.network_id().to_string(),
-                &peer.peer_id().to_string(),
+                peer.network_id().as_str(),
+                peer.peer_id().short_str().as_str(),
                 send_result_label,
             ])
             .inc();
@@ -980,7 +981,10 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
 
         // Update counters and logs with processed chunk information
         counters::STATE_SYNC_CHUNK_SIZE
-            .with_label_values(&[&peer.network_id().to_string(), &peer.peer_id().to_string()])
+            .with_label_values(&[
+                peer.network_id().as_str(),
+                peer.peer_id().short_str().as_str(),
+            ])
             .observe(chunk_size as f64);
         let new_version = known_version
             .checked_add(chunk_size)
@@ -1039,8 +1043,8 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
             Ok(()) => {
                 counters::APPLY_CHUNK_COUNT
                     .with_label_values(&[
-                        &peer.network_id().to_string(),
-                        &peer.peer_id().to_string(),
+                        peer.network_id().as_str(),
+                        peer.peer_id().short_str().as_str(),
                         counters::SUCCESS_LABEL,
                     ])
                     .inc();
@@ -1054,8 +1058,8 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
                 .error(&error));
                 counters::APPLY_CHUNK_COUNT
                     .with_label_values(&[
-                        &peer.network_id().to_string(),
-                        &peer.peer_id().to_string(),
+                        peer.network_id().as_str(),
+                        peer.peer_id().short_str().as_str(),
                         counters::FAIL_LABEL,
                     ])
                     .inc();
@@ -1089,7 +1093,10 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
         // Verify response comes from known peer
         if !self.request_manager.is_known_state_sync_peer(peer) {
             counters::RESPONSE_FROM_DOWNSTREAM_COUNT
-                .with_label_values(&[&peer.network_id().to_string(), &peer.peer_id().to_string()])
+                .with_label_values(&[
+                    peer.network_id().as_str(),
+                    peer.peer_id().short_str().as_str(),
+                ])
                 .inc();
             self.request_manager.process_chunk_from_downstream(peer);
             return Err(Error::ReceivedChunkFromDownstream(peer.to_string()));
@@ -1657,8 +1664,8 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
             };
             counters::SUBSCRIPTION_DELIVERY_COUNT
                 .with_label_values(&[
-                    &peer.network_id().to_string(),
-                    &peer.peer_id().to_string(),
+                    peer.network_id().as_str(),
+                    peer.peer_id().short_str().as_str(),
                     result_label,
                 ])
                 .inc();

--- a/state-sync/state-sync-v1/src/fuzzing.rs
+++ b/state-sync/state-sync-v1/src/fuzzing.rs
@@ -9,7 +9,7 @@ use crate::{
     network::StateSyncMessage,
     shared_components::test_utils,
 };
-use diem_config::network_id::{NetworkId, NodeNetworkId};
+use diem_config::network_id::NetworkId;
 use diem_infallible::Mutex;
 use diem_types::{
     ledger_info::LedgerInfoWithSignatures, transaction::TransactionListWithProof, PeerId,
@@ -41,7 +41,7 @@ pub fn test_state_sync_msg_fuzzer_impl(message: StateSyncMessage) {
         let _ = STATE_SYNC_COORDINATOR
             .lock()
             .process_chunk_message(
-                NodeNetworkId::new(NetworkId::Validator, 0),
+                NetworkId::Validator,
                 PeerId::new([0u8; PeerId::LENGTH]),
                 message,
             )

--- a/state-sync/state-sync-v1/src/request_manager.rs
+++ b/state-sync/state-sync-v1/src/request_manager.rs
@@ -20,6 +20,7 @@ use rand::{
     distributions::{Distribution, WeightedIndex},
     thread_rng,
 };
+use short_hex_str::AsShortHexStr;
 use std::{
     cmp::Ordering,
     collections::{
@@ -122,7 +123,7 @@ impl RequestManager {
             .peer(&peer)
             .is_valid_peer(true));
         counters::ACTIVE_UPSTREAM_PEERS
-            .with_label_values(&[&peer.network_id().to_string()])
+            .with_label_values(&[peer.network_id().as_str()])
             .inc();
 
         match self.peer_scores.entry(peer) {
@@ -147,7 +148,7 @@ impl RequestManager {
 
         if self.peer_scores.contains_key(peer) {
             counters::ACTIVE_UPSTREAM_PEERS
-                .with_label_values(&[&peer.network_id().to_string()])
+                .with_label_values(&[peer.network_id().as_str()])
                 .dec();
             self.peer_scores.remove(peer);
         } else {
@@ -290,8 +291,8 @@ impl RequestManager {
             };
             counters::REQUESTS_SENT
                 .with_label_values(&[
-                    &peer.network_id().to_string(),
-                    &peer_id.to_string(),
+                    peer.network_id().as_str(),
+                    peer_id.short_str().as_str(),
                     result_label,
                 ])
                 .inc();

--- a/state-sync/state-sync-v1/src/shared_components.rs
+++ b/state-sync/state-sync-v1/src/shared_components.rs
@@ -87,7 +87,7 @@ pub(crate) mod test_utils {
     use channel::{diem_channel, message_queues::QueueStyle};
     use diem_config::{
         config::{NodeConfig, RoleType},
-        network_id::{NetworkId, NodeNetworkId},
+        network_id::NetworkId,
     };
     use diem_infallible::RwLock;
     use diem_types::{
@@ -166,8 +166,8 @@ pub(crate) mod test_utils {
             PeerManagerRequestSender::new(network_reqs_tx),
             ConnectionRequestSender::new(connection_reqs_tx),
         );
-        let node_network_id = NodeNetworkId::new(NetworkId::Validator, 0);
-        let network_senders = vec![(node_network_id, network_sender)]
+        let network_id = NetworkId::Validator;
+        let network_senders = vec![(network_id, network_sender)]
             .into_iter()
             .collect::<HashMap<_, _>>();
 

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -20,6 +20,7 @@ full_node_networks:
         - "/ip4/{seed_peer_ip}/tcp/6181/ln-noise-ik/f0274c2774519281a8332d0bb9d8101bd58bc7bb154b38039bc9096ce04e1237/ln-handshake/0"
       role: "Validator"
 - network_id: "public"
+  discovery_method: "onchain"
   listen_address: "/ip4/0.0.0.0/tcp/6182"
   identity:
     type: "from_storage"
@@ -31,9 +32,6 @@ full_node_networks:
       namespace: "{vault_ns}"
       token:
         from_config: root
-# This network connects to other validator-fullnodes for failover
-- network_id: "public"
-  discovery_method: "onchain"
 
 mempool:
   default_failovers: 0


### PR DESCRIPTION
## Motivation

NodeNetworkId was built for allowing duplicate networks as a hack around
having two authentication modes on a single public interface.  This has
since been fixed, so this should really clean up the code.

Additionally, made `PeerNetworkId` hopefully something that can be used elsewhere / is more consistent with our other objects (not using tuples and having a constructor / non-public innards)

Also, ensures all nodes do not have a second public network by ensuring uniqueness on NetworkId.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Current tests

## Related PRs

N/A
