### PR TITLE
[move-book] Perform maintenance, draft named addresses

### DIFF
--- a/language/changes/5-named-addresses.md
+++ b/language/changes/5-named-addresses.md
@@ -7,8 +7,8 @@
 Named addresses are a new source language only feature. (That is, the named address feature is
 compiled away and not present in the Move bytecode format). The feature allows names to be used in
 place of numerical values in any spot where addresses are used. Named addresses are declared as top
-level elements (outside of modules and scripts) with `address MyAddr;` and can be assigned like so
-`address MyAddr = 0x42;`
+level elements (outside of modules and scripts) in Move Packages, or passed as
+arguments to the Move compiler.
 
 With the landing of this feature, Move standard library modules now reside under the address `Std`,
 e.g. `Std::Vector`. Similarly, Diem Framework modules now reside under the address `DiemFramework`,

--- a/language/documentation/book/src/abort-and-assert.md
+++ b/language/documentation/book/src/abort-and-assert.md
@@ -21,7 +21,7 @@ Similar to [`return`](./functions.md), `abort` is useful for exiting control flo
 In this example, the function will pop two items off of the vector, but will abort early if the vector does not have two items
 
 ```move=
-use 0x1::Vector;
+use Std::Vector;
 fun pop_twice<T>(v: &mut vector<T>): (T, T) {
     if (Vector::length(v) < 2) abort 42;
 
@@ -32,7 +32,7 @@ fun pop_twice<T>(v: &mut vector<T>): (T, T) {
 This is even more useful deep inside a control-flow construct. For example, this function checks that all numbers in the vector are less than the specified `bound`. And aborts otherwise
 
 ```move=
-use 0x1::Vector;
+use Std::Vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
     let i = 0;
     let n = Vector::length(v);
@@ -61,7 +61,7 @@ if (condition) () else abort code
 The `abort` examples above can be rewritten using `assert`
 
 ```move=
-use 0x1::Vector;
+use Std::Vector;
 fun pop_twice<T>(v: &mut vector<T>): (T, T) {
     assert(Vector::length(v) >= 2, 42); // Now uses 'assert'
 
@@ -72,7 +72,7 @@ fun pop_twice<T>(v: &mut vector<T>): (T, T) {
 and
 
 ```move=
-use 0x1::Vector;
+use Std::Vector;
 fun check_vec(v: &vector<u64>, bound: u64) {
     let i = 0;
     let n = Vector::length(v);
@@ -123,7 +123,7 @@ In this example, the module has two separate error codes used in multiple functi
 address 0x42 {
 module Example {
 
-    use 0x1::Vector;
+    use Std::Vector;
 
     const EMPTY_VECTOR: u64 = 0;
     const INDEX_OUT_OF_BOUNDS: u64 = 1;

--- a/language/documentation/book/src/address.md
+++ b/language/documentation/book/src/address.md
@@ -6,17 +6,58 @@ Although an `address` is a 128 bit integer under the hood, Move addresses are in
 
 You can use runtime address values (values of type `address`) to access resources at that address. You *cannot* access modules at runtime via address values.
 
-## Literals
+## Addresses and Their Syntax
 
-`address` literals are 16-byte hex literals, i.e. `@0x<hex encoded value>`. For convenience, leading `0`s are added for literals that are too short.
+Addresses come in two flavors, named or numerical. The syntax for a named address follows the
+same rules for any named identifier in Move. The syntax of a numerical address is not restricted
+to hex-encoded values, and any valid [`u128` numerical value](./integers.md) can be used as an
+address value, e.g., `42`, `0xCAFE`, and `2021` are all valid numerical address
+literals.
+
+To distinguish when an address is being used in an expression context or not, the
+syntax when using an address differs depending on the context where it's used:
+* When an address is used as an expression the address must be prefixed by the `@` character, i.e., `@`[`<numerical_value>`](./integers.md)` or `@<named_address_identifier>`.
+* Outside of expression contexts, the address may be written without the leading `@` character, i.e., [`<numerical_value>`](./integers.md) or `<named_address_identifier>`.
+
+In general, you can think of `@` as an operator that takes an address from being a namespace item to being an expression item.
+
+## Named Addresses
+
+Named addresses are a feature that allow identifiers to be used in place of
+numerical values in any spot where addresses are used, and not just at the
+value level.  Named addresses are declared and bound as top level elements
+(outside of modules and scripts) in Move Packages, or passed as arguments
+to the Move compiler.
+
+Named addresses only exist at the source language level and will be fully
+substituted for their value at the bytecode level. Because of this, modules
+and module members _must_ be accessed through the module's named address
+and not through the numerical value assigned to the named address during
+compilation, e.g., `use MyAddr::Foo` is _not_ equivalent to `use 0x2::Foo`
+even if the Move program is compiled with `MyAddr` set to `0x2`. This
+distinction is discussed in more detail in the section on [Modules and
+Scripts](./modules-and-scripts.md).
 
 ### Examples
 
 ```move
 let a1: address = @0x1; // shorthand for 0x00000000000000000000000000000001
 let a2: address = @0x42; // shorthand for 0x00000000000000000000000000000042
-let a3: address = @0xDEADBEEF; // // shorthand for 0x000000000000000000000000DEADBEEF
+let a3: address = @0xDEADBEEF; // shorthand for 0x000000000000000000000000DEADBEEF
 let a4: address = @0x0000000000000000000000000000000A;
+let a5: address = @Std; // Assigns `a5` the value of the named address `Std`
+let a6: address = @66;
+let a7: address = @0x42;
+
+module 66::SomeModule {   // Not in expression context, so no @ needed
+    use 0x1::OtherModule; // Not in expression context so no @ needed
+    use Std::Vector;      // Can use a named address as a namespace item when using other modules
+    ...
+}
+
+module Std::OtherModule {  // Can use a named address as a namespace item to declare a module
+    ...
+}
 ```
 
 ## Global Storage Operations

--- a/language/documentation/book/src/address.md
+++ b/language/documentation/book/src/address.md
@@ -8,15 +8,15 @@ You can use runtime address values (values of type `address`) to access resource
 
 ## Literals
 
-`address` literals are 16-byte hex literals, i.e. `0x<hex encoded value>`. For convenience, leading `0`s are added for literals that are too short.
+`address` literals are 16-byte hex literals, i.e. `@0x<hex encoded value>`. For convenience, leading `0`s are added for literals that are too short.
 
 ### Examples
 
 ```move
-let a1: address = 0x1; // shorthand for 0x00000000000000000000000000000001
-let a2: address = 0x42; // shorthand for 0x00000000000000000000000000000042
-let a3: address = 0xDEADBEEF; // // shorthand for 0x000000000000000000000000DEADBEEF
-let a4: address = 0x0000000000000000000000000000000A;
+let a1: address = @0x1; // shorthand for 0x00000000000000000000000000000001
+let a2: address = @0x42; // shorthand for 0x00000000000000000000000000000042
+let a3: address = @0xDEADBEEF; // // shorthand for 0x000000000000000000000000DEADBEEF
+let a4: address = @0x0000000000000000000000000000000A;
 ```
 
 ## Global Storage Operations

--- a/language/documentation/book/src/coding-conventions.md
+++ b/language/documentation/book/src/coding-conventions.md
@@ -22,7 +22,7 @@ This section lays out some basic coding conventions for Move that the Move team 
 For example, if there is a module
 
 ```move=
-module Foo {
+module 0x1::Foo {
     resource struct Foo { }
     const CONST_FOO: u64 = 0;
     public fun do_foo(): Foo { Foo{} }
@@ -33,7 +33,7 @@ module Foo {
 this would be imported and used as:
 
 ```move=
-module Bar {
+module 0x1::Bar {
     use 0x1::Foo::{Self, Foo};
 
     public fun do_bar(x: u64): Foo {
@@ -55,7 +55,7 @@ module OtherFoo {
     ...
 }
 
-module Importer {
+module 0x1::Importer {
     use 0x1::OtherFoo::Foo as OtherFoo;
     use 0x1::Foo::Foo;
 ....

--- a/language/documentation/book/src/coding-conventions.md
+++ b/language/documentation/book/src/coding-conventions.md
@@ -23,7 +23,7 @@ For example, if there is a module
 
 ```move=
 module 0x1::Foo {
-    resource struct Foo { }
+    struct Foo { }
     const CONST_FOO: u64 = 0;
     public fun do_foo(): Foo { Foo{} }
     ...
@@ -51,7 +51,7 @@ And, if there is a local name-clash when importing two modules:
 
 ```move=
 module OtherFoo {
-    resource struct Foo {}
+    struct Foo {}
     ...
 }
 
@@ -64,7 +64,7 @@ module 0x1::Importer {
 
 ## Comments
 
-- Each module, struct, resource, and public function declaration should be commented
+- Each module, struct, and public function declaration should be commented
 - Move has both doc comments `///`, regular single-line comments `//`, and block comments `/* */`
 
 ## Formatting
@@ -73,4 +73,4 @@ The Move team plans to write an autoformatter to enforce formatting conventions.
 
 - Four space indentation should be used except for `script` and `address` blocks whose contents should not be indented
 - Lines should be broken if they are longer than 100 characters
-- Resources, structs, and constants should be declared before all functions in a module
+- Structs and constants should be declared before all functions in a module

--- a/language/documentation/book/src/constants.md
+++ b/language/documentation/book/src/constants.md
@@ -31,7 +31,7 @@ module Example {
     const MY_ADDRESS: address = 0x42;
 
     public fun permissioned(s: &signer) {
-        assert(0x1::Signer::address_of(s) == MY_ADDRESS, 0);
+        assert(Std::Signer::address_of(s) == MY_ADDRESS, 0);
     }
 
 }

--- a/language/documentation/book/src/constants.md
+++ b/language/documentation/book/src/constants.md
@@ -28,7 +28,7 @@ script {
 address 0x42 {
 module Example {
 
-    const MY_ADDRESS: address = 0x42;
+    const MY_ADDRESS: address = @0x42;
 
     public fun permissioned(s: &signer) {
         assert(Std::Signer::address_of(s) == MY_ADDRESS, 0);
@@ -45,7 +45,7 @@ Constants must start with a capital letter `A` to `Z`. After the first letter, c
 ```move
 const FLAG: bool = false;
 const MY_ERROR_CODE: u64 = 0;
-const ADDRESS_42: address = 0x42;
+const ADDRESS_42: address = @0x42;
 ```
 
 Even though you can use letters `a` to `z` in a constant. The  [general style guidelines](./coding-conventions.md) are to use just uppercase letters `A` to `Z`, with underscores `_` between each word.
@@ -67,7 +67,7 @@ For example
 
 ```move
 const MY_BOOL: bool = false;
-const MY_ADDRESS: address = 0x70DD;
+const MY_ADDRESS: address = @0x70DD;
 const BYTES: vector<u8> = b"hello world";
 const HEX_BYTES: vector<u8> = x"DEADBEEF";
 ```

--- a/language/documentation/book/src/creating-coins.md
+++ b/language/documentation/book/src/creating-coins.md
@@ -55,7 +55,7 @@ We've created a directory called `toycoin` which has a subdirectory `src` for th
 
 ## Creating Our Coin
 
-We'll call our module `Coin`, and we'll publish it at address `0x2`. By convention, the Move standard library is published at address `0x1`, and for simplicity we'll use `0x2` for our tutorial code. Any address will work, as long as the address the modules are published to and the address the modules are accessed from is the same.
+We'll call our module `Coin`, and we'll publish it at address `0x2`. The Move standard library is published at the named address `Std`, and for simplicity we'll use `0x2` for our tutorial code. Any address will work, as long as the address the modules are published to and the address the modules are accessed from is the same.
 
 In our module we'll define a new type `Coin`, which will be a structure with a single field `value`, containing the number of coins. The type of the `value` field is `u64`, which is, as you might have guessed, an unsigned 64-bit integer.
 
@@ -243,7 +243,7 @@ Now we can write a slightly more complicated script that tests our `Coin` module
 
 ```move=
 script {
-    use 0x1::Debug;
+    use Std::Debug;
     use 0x2::Coin;
 
     fun main() {

--- a/language/documentation/book/src/functions.md
+++ b/language/documentation/book/src/functions.md
@@ -260,7 +260,7 @@ A function can `acquire` as many resources as it needs to
 ```move=
 address 0x42 {
 module Example {
-    use 0x1::Vector;
+    use Std::Vector;
 
     struct Balance has key { value: u64 }
     struct Box<T> has key { items: vector<T> }
@@ -341,11 +341,9 @@ Without modifying the VM source code, a programmer cannot add new native functio
 Most `native` functions you will likely see are in standard library code such as `Vector`
 
 ```move=
-address 0x1 {
-module Vector {
+module Std::Vector {
     native public fun empty<Element>(): vector<Element>;
     ...
-}
 }
 ```
 
@@ -460,8 +458,8 @@ Note that the body of this function could also have been written as `if (y > x) 
 However `return` really shines is in exiting deep within other control flow constructs. In this example, the function iterates through a vector to find the index of a given value:
 
 ```move=
-use 0x1::Vector;
-use 0x1::Option::{Self, Option};
+use Std::Vector;
+use Std::Option::{Self, Option};
 fun index_of<T>(v: &vector<T>, target: &T): Option<u64> {
     let i = 0;
     let n = Vector::length(v);

--- a/language/documentation/book/src/generics.md
+++ b/language/documentation/book/src/generics.md
@@ -104,7 +104,7 @@ Note: when the compiler is unable to infer the types, you'll need annotate them 
 ```move=
 address 0x2 {
 module M {
-    using 0x1::Vector;
+    using Std::Vector;
 
     fun foo() {
         // let v = Vector::new();
@@ -122,7 +122,7 @@ However, the compiler will be able to infer the type if that return value is use
 ```move=
 address 0x2 {
 module M {
-    using 0x1::Vector;
+    using Std::Vector;
 
     fun foo() {
         let v = Vector::new();

--- a/language/documentation/book/src/global-storage-operators.md
+++ b/language/documentation/book/src/global-storage-operators.md
@@ -65,7 +65,7 @@ The simple `Counter` module below exercises each of the five global storage oper
 ```move
 address 0x42 {
 module Counter {
-    use 0x1::Signer;
+    use Std::Signer;
 
     /// Resource that wraps an integer counter
     struct Counter has key { i: u64 }

--- a/language/documentation/book/src/integers.md
+++ b/language/documentation/book/src/integers.md
@@ -10,7 +10,7 @@ Move supports three unsigned integer types: `u8`, `u64`, and `u128`. Values of t
 
 ## Literals
 
-Literal values for these types are specified as a sequence of digits, e.g.,`112`. The type of the literal can optionally be added as a suffix, e.g., `112u8`. If the type is not specified, the compiler will try to infer the type from the context where the literal is used. If the type cannot be inferred, it is assumed to be `u64`.
+Literal values for these types are specified either as a sequence of digits (e.g.,`112`) or as hex literals, e.g., `0xFF`. The type of the literal can optionally be added as a suffix, e.g., `112u8`. If the type is not specified, the compiler will try to infer the type from the context where the literal is used. If the type cannot be inferred, it is assumed to be `u64`.
 
 If a literal is too large for its specified (or inferred) size range, an error is reported.
 
@@ -40,6 +40,11 @@ let _unused = x + complex_u8;
 let complex_u128 = 3; // inferred: u128
 // inferred from function argument type
 function_that_takes_u128(complex_u128);
+
+// literals can be written in hex
+let hex_u8: u8 = 0x1;
+let hex_u64: u64 = 0xCAFE;
+let hex_u128: u128 = 0xDEADBEEF;
 ```
 
 ## Operations

--- a/language/documentation/book/src/modules-and-scripts.md
+++ b/language/documentation/book/src/modules-and-scripts.md
@@ -25,10 +25,8 @@ arguments, and must not return a value. Here is an example with each of these co
 
 ```move
 script {
-    // Import the Debug module published at account address 0x1.
-    // 0x1 is shorthand for the fully qualified address
-    // 0x00000000000000000000000000000001.
-    use 0x1::Debug;
+    // Import the Debug module published at the named account address Std.
+    use Std::Debug;
 
     const ONE: u64 = 1;
 
@@ -60,7 +58,7 @@ address 0x42 {
 module Test {
     struct Example has copy, drop { i: u64 }
 
-    use 0x1::Debug;
+    use Std::Debug;
     friend 0x42::AnotherTest;
 
     const ONE: u64 = 1;

--- a/language/documentation/book/src/signer.md
+++ b/language/documentation/book/src/signer.md
@@ -13,8 +13,8 @@ A `signer` is somewhat similar to a Unix [UID](https://en.wikipedia.org/wiki/Use
 A Move program can create any `address` value without special permission using address literals:
 
 ```move
-let a1 = 0x1;
-let a2 = 0x2;
+let a1 = @0x1;
+let a2 = @0x2;
 // ... and so on for every other possible address
 ```
 
@@ -24,7 +24,7 @@ However, `signer` values are special because they cannot be created via literals
 script {
     use Std::Signer;
     fun main(s: signer) {
-        assert(Signer::address_of(&s) == 0x42, 0);
+        assert(Signer::address_of(&s) == @0x42, 0);
     }
 }
 ```

--- a/language/documentation/book/src/signer.md
+++ b/language/documentation/book/src/signer.md
@@ -22,7 +22,7 @@ However, `signer` values are special because they cannot be created via literals
 
 ```move=
 script {
-    use 0x1::Signer;
+    use Std::Signer;
     fun main(s: signer) {
         assert(Signer::address_of(&s) == 0x42, 0);
     }
@@ -35,7 +35,7 @@ A transaction script can have an arbitrary number of `signer`s as long as the si
 
 ```move=
 script {
-    use 0x1::Signer;
+    use Std::Signer;
     fun main(s1: signer, s2: signer, x: u64, y: u8) {
         // ...
     }
@@ -46,7 +46,7 @@ This is useful for implementing *multi-signer scripts* that atomically act with 
 
 ## `signer` Operators
 
-The `0x1::Signer` standard library module provides two utility functions over `signer` values:
+The `Std::Signer` standard library module provides two utility functions over `signer` values:
 
 | Function | Description
 | ---------- | ----------

--- a/language/documentation/book/src/standard-library.md
+++ b/language/documentation/book/src/standard-library.md
@@ -10,7 +10,7 @@ The Move standard library exposes interfaces that implement the following functi
 
 The `Vector` module defines a number of operations over the primitive
 [`vector`](./vector.md) type. The module is published under the
-core code address at `0x1` and consists of a number of native functions, as
+named address `Std` and consists of a number of native functions, as
 well as functions defined in Move. The API for this module is as follows.
 
 ### Functions
@@ -168,7 +168,7 @@ Return whether the vector `v` is empty.
 ## Option
 
 The `Option` module defines a generic option type `Option<T>` that represents a
-value of type `T` that may, or may not, be present. It is published under the core code address at `0x1`.
+value of type `T` that may, or may not, be present. It is published under the named address `Std`.
 
 The Move option type is internally represented as a singleton vector, and may
 contain a value of `resource` or `copyable` kind.  If you are familiar with option

--- a/language/documentation/book/src/tuples.md
+++ b/language/documentation/book/src/tuples.md
@@ -37,7 +37,7 @@ module Example {
 
 
     fun returns_3_values(): (u64, bool, address) {
-        (0, false, 0x42)
+        (0, false, @0x42)
     }
     fun returns_4_values(x: &u64): (&u64, u8, u128, vector<u8>) {
         (x, 0, 1, b"foobar")
@@ -67,11 +67,11 @@ module Example {
     fun examples(cond: bool) {
         let () = ();
         let (x, y): (u8, u64) = (0, 1);
-        let (a, b, c, d) = (0x0, 0, false, b"");
+        let (a, b, c, d) = (@0x0, 0, false, b"");
 
         () = ();
         (x, y) = if (cond) (1, 2) else (3, 4);
-        (a, b, c, d) = (0x1, 1, true, b"1");
+        (a, b, c, d) = (@0x1, 1, true, b"1");
     }
 
     fun examples_with_function_calls() {

--- a/language/documentation/book/src/uses.md
+++ b/language/documentation/book/src/uses.md
@@ -7,27 +7,27 @@ The `use` syntax can be used to create aliases to members in other modules. `use
 There are several different syntax cases for `use`. Starting with the most simple, we have the following for creating aliases to other modules
 
 ```move
-use <address>::<module name>;
-use <address>::<module name> as <module alias name>;
+use <named_address|address>::<module name>;
+use <named_address|address>::<module name> as <module alias name>;
 ```
 
 For example
 
 ```move
-use 0x1::Vector;
-use 0x1::Vector as V;
+use Std::Vector;
+use Std::Vector as V;
 ```
 
-`use 0x1::Vector;` introduces an alias `Vector` for `0x1::Vector`. This means that anywhere you would want to use the module name `0x1::Vector` (assuming this `use` is in scope), you could use `Vector` instead. `use 0x1::Vector;`  is equivalent to `use 0x1::Vector as Vector;`
+`use Std::Vector;` introduces an alias `Vector` for `Std::Vector`. This means that anywhere you would want to use the module name `Std::Vector` (assuming this `use` is in scope), you could use `Vector` instead. `use Std::Vector;`  is equivalent to `use Std::Vector as Vector;`
 
-Similarly `use 0x1::Vector as V;` would let you use `V` instead of `0x1::Vector`
+Similarly `use Std::Vector as V;` would let you use `V` instead of `Std::Vector`
 
 ```move=
-use 0x1::Vector;
-use 0x1::Vector as V;
+use Std::Vector;
+use Std::Vector as V;
 
 fun new_vecs(): (vector<u8>, vector<u8>, vector<u8>) {
-    let v1 = 0x1::Vector::empty();
+    let v1 = Std::Vector::empty();
     let v2 = Vector::empty();
     let v3 = V::empty();
     (v1, v2, v3)
@@ -44,18 +44,18 @@ use <address>::<module name>::<module member> as <member alias>;
 For example
 
 ```move
-use 0x1::Vector::empty;
-use 0x1::Vector::empty as empty_vec;
+use Std::Vector::empty;
+use Std::Vector::empty as empty_vec;
 ```
 
-This would let you use the function `0x1::Vector::empty` without full qualification. Instead you could use `empty` and `empty_vec` respectively. Again, `use 0x1::Vector::empty;` is equivalent to `use 0x1::Vector::empty as empty;`
+This would let you use the function `Std::Vector::empty` without full qualification. Instead you could use `empty` and `empty_vec` respectively. Again, `use Std::Vector::empty;` is equivalent to `use Std::Vector::empty as empty;`
 
 ```move=
-use 0x1::Vector::empty;
-use 0x1::Vector::empty as empty_vec;
+use Std::Vector::empty;
+use Std::Vector::empty as empty_vec;
 
 fun new_vecs(): (vector<u8>, vector<u8>, vector<u8>) {
-    let v1 = 0x1::Vector::empty();
+    let v1 = Std::Vector::empty();
     let v2 = empty();
     let v3 = empty_vec();
     (v1, v2, v3)
@@ -71,7 +71,7 @@ use <address>::<module name>::{<module member>, <module member> as <member alias
 For example
 
 ```move=
-use 0x1::Vector::{push_back, length as len, pop_back};
+use Std::Vector::{push_back, length as len, pop_back};
 
 fun swap_last_two<T>(v: &mut vector<T>) {
     assert(len(v) >= 2, 42);
@@ -85,24 +85,24 @@ fun swap_last_two<T>(v: &mut vector<T>) {
 If you need to add an alias to the Module itself in addition to module members, you can do that in a single `use` using `Self`. `Self` is a member of sorts that refers to the module.
 
 ```move
-use 0x1::Vector::{Self, empty};
+use Std::Vector::{Self, empty};
 ```
 
 For clarity, all of the following are equivalent:
 
 ```move
-use 0x1::Vector;
-use 0x1::Vector as Vector;
-use 0x1::Vector::Self;
-use 0x1::Vector::Self as Vector;
-use 0x1::Vector::{Self};
-use 0x1::Vector::{Self as Vector};
+use Std::Vector;
+use Std::Vector as Vector;
+use Std::Vector::Self;
+use Std::Vector::Self as Vector;
+use Std::Vector::{Self};
+use Std::Vector::{Self as Vector};
 ```
 
 If needed, you can have as many aliases for any item as you like
 
 ```move=
-use 0x1::Vector::{
+use Std::Vector::{
     Self,
     Self as V,
     length,
@@ -127,7 +127,7 @@ Inside of a `module` all `use` declarations are usable regardless of the order o
 ```move=
 address 0x42 {
 module Example {
-    use 0x1::Vector;
+    use Std::Vector;
 
     fun example(): vector<u8> {
         let v = empty();
@@ -136,7 +136,7 @@ module Example {
         v
     }
 
-    use 0x1::Vector::empty;
+    use Std::Vector::empty;
 }
 }
 ```
@@ -154,7 +154,7 @@ address 0x42 {
 module Example {
 
     fun example(): vector<u8> {
-        use 0x1::Vector::{empty, push_back};
+        use Std::Vector::{empty, push_back};
 
         let v = empty();
         push_back(&mut v, 0);
@@ -173,7 +173,7 @@ module Example {
 
     fun example(): vector<u8> {
         let result = {
-            use 0x1::Vector::{empty, push_back};
+            use Std::Vector::{empty, push_back};
             let v = empty();
             push_back(&mut v, 0);
             push_back(&mut v, 10);
@@ -191,7 +191,7 @@ Attempting to use the alias after the block ends will result in an error
 ```move=
 fun example(): vector<u8> {
     let result = {
-        use 0x1::Vector::{empty, push_back};
+        use Std::Vector::{empty, push_back};
         let v = empty();
         push_back(&mut v, 0);
         push_back(&mut v, 10);
@@ -208,7 +208,7 @@ Any `use` must be the first item in the block. If the `use` comes after any expr
 ```move=
 {
     let x = 0;
-    use 0x1::Vector; // ERROR!
+    use Std::Vector; // ERROR!
     let v = Vector::empty();
 }
 ```
@@ -245,12 +245,12 @@ For a module, this means aliases introduced by `use` cannot overla
 address 0x42 {
 module Example {
 
-    use 0x1::Vector::{empty as foo, length as foo}; // ERROR!
+    use Std::Vector::{empty as foo, length as foo}; // ERROR!
     //                                        ^^^ duplicate 'foo'
 
-    use 0x1::Vector::empty as bar;
+    use Std::Vector::empty as bar;
 
-    use 0x1::Vector::length as bar; // ERROR!
+    use Std::Vector::length as bar; // ERROR!
     //                         ^^^ duplicate 'bar'
 
 }
@@ -286,13 +286,13 @@ module Example {
     struct WrappedVector { vec: vector<u64> }
 
     fun empty(): WrappedVector {
-        WrappedVector { vec: 0x1::Vector::empty() }
+        WrappedVector { vec: Std::Vector::empty() }
     }
 
     fun example1(): (WrappedVector, WrappedVector) {
         let vec = {
-            use 0x1::Vector::{empty, push_back};
-            // 'empty' now refers to 0x1::Vector::empty
+            use Std::Vector::{empty, push_back};
+            // 'empty' now refers to Std::Vector::empty
 
             let v = empty();
             push_back(&mut v, 0);
@@ -306,7 +306,7 @@ module Example {
     }
 
     fun example2(): (WrappedVector, WrappedVector) {
-        use 0x1::Vector::{empty, push_back};
+        use Std::Vector::{empty, push_back};
         let w: WrappedVector = {
             use 0x42::Example::empty;
             empty()
@@ -333,7 +333,7 @@ An unused `use` will result in an error
 ```move=
 address 0x42 {
 module Example {
-    use 0x1::Vector::{empty, push_back}; // ERROR!
+    use Std::Vector::{empty, push_back}; // ERROR!
     //                       ^^^^^^^^^ unused alias 'push_back'
 
     fun example(): vector<u8> {

--- a/language/documentation/book/src/uses.md
+++ b/language/documentation/book/src/uses.md
@@ -7,8 +7,8 @@ The `use` syntax can be used to create aliases to members in other modules. `use
 There are several different syntax cases for `use`. Starting with the most simple, we have the following for creating aliases to other modules
 
 ```move
-use <named_address|address>::<module name>;
-use <named_address|address>::<module name> as <module alias name>;
+use <address>::<module name>;
+use <address>::<module name> as <module alias name>;
 ```
 
 For example

--- a/language/documentation/book/src/variables.md
+++ b/language/documentation/book/src/variables.md
@@ -101,7 +101,7 @@ module Example {
     fun annotated() {
         let u: u8 = 0;
         let b: vector<u8> = b"hello";
-        let a: address = 0x0;
+        let a: address = @0x0;
         let (x, y): (&u64, &mut u64) = (&0, &mut 1);
         let S { f, g: f2 }: S = S { f: 0, g: 1 };
     }
@@ -677,13 +677,13 @@ let coin2 = coin; // move
 
 let x = 0;
 let b = false;
-let addr = 0x42;
+let addr = @0x42;
 let x_ref = &x;
 let coin_ref = &mut coin2;
 
 let x2 = x; // copy
 let b2 = b; // copy
-let addr2 = 0x42; // copy
+let addr2 = @0x42; // copy
 let x_ref2 = x_ref; // copy
 let coin_ref2 = coin_ref; // copy
 ```

--- a/language/documentation/book/src/vector.md
+++ b/language/documentation/book/src/vector.md
@@ -6,7 +6,7 @@ A `vector<T>` can be instantiated with any type `T`. For example, `vector<u64>`,
 
 ## Operations
 
-`vector` supports the following operations via the `0x1::Vector` module in the Move standard library:
+`vector` supports the following operations via the `Std::Vector` module in the Move standard library:
 
 | Function | Description | Aborts?
 | ---------- | ----------|----------
@@ -24,7 +24,7 @@ More operations may be added overtime
 ## Example
 
 ```move
-use 0x1::Vector;
+use Std::Vector;
 
 let v = Vector::empty<u64>();
 Vector::push_back(&mut v, 5);


### PR DESCRIPTION
This PR does some basic maintenance on the Move book, and adds a draft description of named addresses to the Move book. The commits are structured so you can review them one-one-by-one, or you can review the whole thing (up to you!).

