### PR TITLE
[diem node] add option to specify genesis modules for testing

### DIFF
--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -101,6 +101,7 @@ pub fn load_test_environment<R>(
     config_path: Option<PathBuf>,
     random_ports: bool,
     publishing_option: Option<VMPublishingOption>,
+    genesis_modules: Vec<Vec<u8>>,
     rng: R,
 ) where
     R: ::rand::RngCore + ::rand::CryptoRng,
@@ -119,12 +120,10 @@ pub fn load_test_environment<R>(
     maybe_config.push("validator_node_template.yaml");
     let template = NodeConfig::load_config(maybe_config)
         .unwrap_or_else(|_| NodeConfig::default_for_validator());
-    let mut builder = diem_genesis_tool::validator_builder::ValidatorBuilder::new(
-        &config_path,
-        diem_framework_releases::current_module_blobs().to_vec(),
-    )
-    .template(template)
-    .randomize_first_validator_ports(random_ports);
+    let mut builder =
+        diem_genesis_tool::validator_builder::ValidatorBuilder::new(&config_path, genesis_modules)
+            .template(template)
+            .randomize_first_validator_ports(random_ports);
     if let Some(publishing_option) = publishing_option {
         builder = builder.publishing_option(publishing_option);
     }

--- a/language/diem-framework/releases/src/lib.rs
+++ b/language/diem-framework/releases/src/lib.rs
@@ -6,7 +6,7 @@ use diem_types::transaction::ScriptFunction;
 use include_dir::{include_dir, Dir};
 use move_binary_format::file_format::CompiledModule;
 use move_command_line_common::files::{
-    extension_equals, MOVE_COMPILED_EXTENSION, MOVE_ERROR_DESC_EXTENSION,
+    extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_ERROR_DESC_EXTENSION,
 };
 use once_cell::sync::Lazy;
 use std::{convert::TryFrom, path::PathBuf};
@@ -54,6 +54,17 @@ pub fn load_modules_from_release(release_name: &str) -> Result<Vec<Vec<u8>>> {
         }
         None => bail!("release {} not found", release_name),
     }
+}
+
+/// Load the serialized modules from the specified paths.
+pub fn load_modules_from_paths(paths: &[PathBuf]) -> Vec<Vec<u8>> {
+    find_filenames(paths, |path| {
+        extension_equals(path, MOVE_COMPILED_EXTENSION)
+    })
+    .expect("module loading failed")
+    .iter()
+    .map(|file_name| std::fs::read(file_name).unwrap())
+    .collect::<Vec<_>>()
 }
 
 /// Load the error descriptions from the specified release.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds an option to diem-node to specify the modules to be included in genesis for testing. If no paths are supplied, Diem Framework modules are used. You can run the node like this:
```
cargo run -- --test --genesis-modules <file1> <dir1> <file2> <dir2>
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

