### PR TITLE
[State Sync] Add a new Storage Service implementation (server-side)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8051,6 +8051,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "storage-service-server"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bcs",
+ "claim",
+ "diem-crypto",
+ "diem-infallible",
+ "diem-types",
+ "diem-workspace-hack",
+ "move-core-types",
+ "serde",
+ "storage-interface",
+ "storage-service-types",
+ "thiserror",
+]
+
+[[package]]
+name = "storage-service-types"
+version = "0.1.0"
+dependencies = [
+ "diem-types",
+ "diem-workspace-hack",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,8 @@ members = [
     "state-sync/inter-component/mempool-notifications",
     "state-sync/state-sync-v1",
     "state-sync/state-sync-v2",
+    "state-sync/storage-service/server",
+    "state-sync/storage-service/types",
     "storage/accumulator",
     "storage/backup/backup-cli",
     "storage/backup/backup-service",

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "storage-service-server"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "The Diem storage service (server-side)"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+serde = { version = "1.0.124", default-features = false }
+thiserror = "1.0.24"
+
+diem-infallible = { path = "../../../common/infallible" }
+diem-types = { path = "../../../types" }
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+storage-interface = { path = "../../../storage/storage-interface" }
+storage-service-types = { path = "../types" }
+
+[dev-dependencies]
+anyhow = "1.0.38"
+bcs = "0.1.2"
+claim = "0.5.0"
+
+diem-crypto = { path = "../../../crypto/crypto" }
+diem-types = { path = "../../../types" }
+move-core-types = { path = "../../../language/move-core/types" }
+storage-interface = { path = "../../../storage/storage-interface" }

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -1,0 +1,242 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use diem_infallible::RwLock;
+use diem_types::{epoch_change::EpochChangeProof, transaction::TransactionListWithProof};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use storage_interface::DbReaderWriter;
+use storage_service_types::{
+    DataSummary, EpochEndingLedgerInfoRequest, ProtocolMetadata, ServerProtocolVersion,
+    StorageServerSummary, StorageServiceError, StorageServiceRequest, StorageServiceResponse,
+    TransactionsWithProofRequest,
+};
+use thiserror::Error;
+
+#[cfg(test)]
+mod tests;
+
+// TODO(joshlind): make these configurable.
+/// Storage server constants.
+pub const MAX_TRANSACTION_CHUNK_SIZE: u64 = 1000;
+pub const STORAGE_SERVER_VERSION: u64 = 1;
+
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Serialize)]
+pub enum Error {
+    #[error("Storage error encountered: {0}")]
+    StorageErrorEncountered(String),
+    #[error("Unexpected error encountered: {0}")]
+    UnexpectedErrorEncountered(String),
+}
+
+/// The server-side implementation of the storage service. This provides all the
+/// functionality required to handle storage service requests (i.e., from clients).
+pub struct StorageServiceServer<T> {
+    storage: T,
+}
+
+impl<T: StorageReaderInterface> StorageServiceServer<T> {
+    pub fn new(storage: T) -> Self {
+        Self { storage }
+    }
+
+    pub fn handle_request(
+        &self,
+        request: StorageServiceRequest,
+    ) -> Result<StorageServiceResponse, Error> {
+        let response = match request {
+            StorageServiceRequest::GetEpochEndingLedgerInfos(request) => {
+                self.get_epoch_ending_ledger_infos(request)
+            }
+            StorageServiceRequest::GetServerProtocolVersion => self.get_server_protocol_version(),
+            StorageServiceRequest::GetStorageServerSummary => self.get_storage_server_summary(),
+            StorageServiceRequest::GetTransactionsWithProof(request) => {
+                self.get_transactions_with_proof(request)
+            }
+        };
+
+        // If any requests resulted in an unexpected error, return an InternalStorageError to the
+        // client and log the actual error.
+        if let Err(_error) = response {
+            // TODO(joshlind): add logging support to this library so we can log _error
+            Ok(StorageServiceResponse::StorageServiceError(
+                StorageServiceError::InternalError,
+            ))
+        } else {
+            response
+        }
+    }
+
+    fn get_epoch_ending_ledger_infos(
+        &self,
+        request: EpochEndingLedgerInfoRequest,
+    ) -> Result<StorageServiceResponse, Error> {
+        let epoch_change_proof = self
+            .storage
+            .get_epoch_ending_ledger_infos(request.start_epoch, request.expected_end_epoch)?;
+
+        Ok(StorageServiceResponse::EpochEndingLedgerInfos(
+            epoch_change_proof,
+        ))
+    }
+
+    fn get_server_protocol_version(&self) -> Result<StorageServiceResponse, Error> {
+        let server_protocol_version = ServerProtocolVersion {
+            protocol_version: STORAGE_SERVER_VERSION,
+        };
+        Ok(StorageServiceResponse::ServerProtocolVersion(
+            server_protocol_version,
+        ))
+    }
+
+    fn get_storage_server_summary(&self) -> Result<StorageServiceResponse, Error> {
+        let storage_server_summary = StorageServerSummary {
+            protocol_metadata: ProtocolMetadata {
+                max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
+            },
+            data_summary: self.storage.get_data_summary()?,
+        };
+
+        Ok(StorageServiceResponse::StorageServerSummary(
+            storage_server_summary,
+        ))
+    }
+
+    fn get_transactions_with_proof(
+        &self,
+        request: TransactionsWithProofRequest,
+    ) -> Result<StorageServiceResponse, Error> {
+        let transactions_with_proof = self.storage.get_transactions_with_proof(
+            request.proof_version,
+            request.start_version,
+            request.expected_num_transactions,
+            request.include_events,
+        )?;
+
+        Ok(StorageServiceResponse::TransactionsWithProof(
+            transactions_with_proof,
+        ))
+    }
+}
+
+/// The interface into local storage (e.g., the Diem DB) used by the storage
+/// server to handle client requests.
+pub trait StorageReaderInterface {
+    /// Returns a data summary of the underlying storage state.
+    fn get_data_summary(&self) -> Result<DataSummary, Error>;
+
+    /// Returns a list of transactions with a proof relative to the
+    /// `proof_version`. The transaction list is expected to contain *at most*
+    /// `expected_num_transactions` and start at `start_version`.
+    /// If `include_events` is true, events are also returned.
+    fn get_transactions_with_proof(
+        &self,
+        proof_version: u64,
+        start_version: u64,
+        expected_num_transactions: u64,
+        include_events: bool,
+    ) -> Result<TransactionListWithProof, Error>;
+
+    /// Returns a list of epoch ending ledger infos, starting at `start_epoch`
+    /// and ending *at most* at the `expected_end_epoch`.
+    fn get_epoch_ending_ledger_infos(
+        &self,
+        start_epoch: u64,
+        expected_end_epoch: u64,
+    ) -> Result<EpochChangeProof, Error>;
+
+    // TODO(joshlind): support me!
+    //
+    // Returns a list of transaction outputs with a proof relative to the
+    // `proof_version`. The transaction output list is expected to contain
+    // *at most* `expected_num_transaction_outputs` and start at `start_version`.
+    //fn get_transaction_outputs_with_proof(
+    //    &self,
+    //    proof_version: u64,
+    //    start_version: u64,
+    //    expected_num_transaction_outputs: u64,
+    //) -> Result<TransactionOutputListWithProof, Error>;
+
+    // TODO(joshlind): support me!
+    //
+    // Returns an AccountStateChunk holding a list of account states
+    // starting at the specified account key with *at most*
+    // `expected_num_account_states`.
+    //fn get_account_states_chunk(
+    //    version,
+    //    start_account_key,
+    //    expected_num_account_states: u64,
+    //) -> Result<AccountStateChunk, Error>
+}
+
+/// The underlying implementation of the StorageReaderInterface, used by the
+/// storage server.
+pub struct StorageReader {
+    storage: Arc<RwLock<DbReaderWriter>>,
+}
+
+impl StorageReader {
+    pub fn new(storage: Arc<RwLock<DbReaderWriter>>) -> Self {
+        Self { storage }
+    }
+}
+
+impl StorageReaderInterface for StorageReader {
+    fn get_data_summary(&self) -> Result<DataSummary, Error> {
+        // Fetch the latest ledger info
+        let latest_ledger_info_with_sigs = self
+            .storage
+            .read()
+            .reader
+            .get_latest_ledger_info()
+            .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+        let latest_ledger_info = latest_ledger_info_with_sigs.ledger_info();
+
+        // Return the relevant data summary
+        // TODO(joshlind): Update the DiemDB to support fetching the lowest txn version and epoch!
+        let data_summary = DataSummary {
+            highest_transaction_version: latest_ledger_info.version(),
+            lowest_transaction_version: 0,
+            highest_epoch: latest_ledger_info.epoch(),
+            lowest_epoch: 0,
+        };
+        Ok(data_summary)
+    }
+
+    fn get_transactions_with_proof(
+        &self,
+        proof_version: u64,
+        start_version: u64,
+        expected_num_transactions: u64,
+        include_events: bool,
+    ) -> Result<TransactionListWithProof, Error> {
+        let transaction_list_with_proof = self
+            .storage
+            .read()
+            .reader
+            .get_transactions(
+                start_version,
+                expected_num_transactions,
+                proof_version,
+                include_events,
+            )
+            .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+        Ok(transaction_list_with_proof)
+    }
+
+    fn get_epoch_ending_ledger_infos(
+        &self,
+        start_epoch: u64,
+        expected_end_epoch: u64,
+    ) -> Result<EpochChangeProof, Error> {
+        let epoch_change_proof = self
+            .storage
+            .read()
+            .reader
+            .get_epoch_ending_ledger_infos(start_epoch, expected_end_epoch)
+            .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+        Ok(epoch_change_proof)
+    }
+}

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -1,0 +1,446 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use crate::{StorageReader, StorageServiceServer};
+use anyhow::Result;
+use claim::{assert_none, assert_some};
+use diem_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
+use diem_infallible::RwLock;
+use diem_types::{
+    account_address::AccountAddress,
+    account_state_blob::{AccountStateBlob, AccountStateWithProof},
+    block_info::BlockInfo,
+    chain_id::ChainId,
+    contract_event::{ContractEvent, EventByVersionWithProof, EventWithProof},
+    epoch_change::EpochChangeProof,
+    event::EventKey,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    proof::{SparseMerkleProof, TransactionListProof},
+    state_proof::StateProof,
+    transaction::{
+        AccountTransactionsWithProof, RawTransaction, Script, SignedTransaction, Transaction,
+        TransactionListWithProof, TransactionPayload, TransactionToCommit, TransactionWithProof,
+        Version,
+    },
+};
+use move_core_types::language_storage::TypeTag;
+use std::{collections::BTreeMap, sync::Arc};
+use storage_interface::{DbReader, DbReaderWriter, DbWriter, Order, StartupInfo, TreeState};
+use storage_service_types::{
+    DataSummary, EpochEndingLedgerInfoRequest, ProtocolMetadata, ServerProtocolVersion,
+    StorageServerSummary, StorageServiceRequest, StorageServiceResponse,
+    TransactionsWithProofRequest,
+};
+
+// TODO(joshlind): Expand these test cases to better test storage interaction
+// and functionality. This will likely require a better mock db abstraction.
+
+#[test]
+fn test_get_server_protocol_version() {
+    // Create a storage service server
+    let storage_server = create_storage_server();
+
+    // Process a request to fetch the protocol version
+    let version_request = StorageServiceRequest::GetServerProtocolVersion;
+    let version_response = storage_server.handle_request(version_request).unwrap();
+
+    // Verify the response is correct
+    let expected_protocol_version = ServerProtocolVersion {
+        protocol_version: 1,
+    };
+    assert_eq!(
+        version_response,
+        StorageServiceResponse::ServerProtocolVersion(expected_protocol_version)
+    );
+}
+
+#[test]
+fn test_get_storage_server_summary() {
+    // Create a storage service server
+    let storage_server = create_storage_server();
+
+    // Process a request to fetch the storage summary
+    let summary_request = StorageServiceRequest::GetStorageServerSummary;
+    let summary_response = storage_server.handle_request(summary_request).unwrap();
+
+    // Verify the response is correct
+    let expected_server_summary = StorageServerSummary {
+        protocol_metadata: ProtocolMetadata {
+            max_transaction_chunk_size: 1000,
+        },
+        data_summary: DataSummary {
+            highest_transaction_version: 100,
+            lowest_transaction_version: 0,
+            highest_epoch: 10,
+            lowest_epoch: 0,
+        },
+    };
+    assert_eq!(
+        summary_response,
+        StorageServiceResponse::StorageServerSummary(expected_server_summary)
+    );
+}
+
+#[test]
+fn test_get_transactions_with_proof_events() {
+    // Create a storage service server
+    let storage_server = create_storage_server();
+
+    // Create a request to fetch transactions with a proof
+    let start_version = 0;
+    let expected_num_transactions = 10;
+    let transactions_proof_request =
+        StorageServiceRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+            proof_version: 100,
+            start_version,
+            expected_num_transactions,
+            include_events: true,
+        });
+
+    // Process the request
+    let transactions_proof_response = storage_server
+        .handle_request(transactions_proof_request)
+        .unwrap();
+
+    // Verify the response is correct
+    match transactions_proof_response {
+        StorageServiceResponse::TransactionsWithProof(transactions_with_proof) => {
+            assert_eq!(
+                transactions_with_proof.transactions.len(),
+                expected_num_transactions as usize
+            );
+            assert_eq!(
+                transactions_with_proof.first_transaction_version,
+                Some(start_version)
+            );
+            assert_some!(transactions_with_proof.events);
+        }
+        result => {
+            panic!("Expected transactions with proof but got: {:?}", result);
+        }
+    };
+}
+
+#[test]
+fn test_get_transactions_with_proof_no_events() {
+    // Create a storage service server
+    let storage_server = create_storage_server();
+
+    // Create a request to fetch transactions with a proof (excluding events)
+    let start_version = 10;
+    let expected_num_transactions = 20;
+    let transactions_proof_request =
+        StorageServiceRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
+            proof_version: 1000,
+            start_version,
+            expected_num_transactions,
+            include_events: false,
+        });
+
+    // Process the request
+    let transactions_proof_response = storage_server
+        .handle_request(transactions_proof_request)
+        .unwrap();
+
+    // Verify the response is correct
+    match transactions_proof_response {
+        StorageServiceResponse::TransactionsWithProof(transactions_with_proof) => {
+            assert_eq!(
+                transactions_with_proof.transactions.len(),
+                expected_num_transactions as usize
+            );
+            assert_eq!(
+                transactions_with_proof.first_transaction_version,
+                Some(start_version)
+            );
+            assert_none!(transactions_with_proof.events);
+        }
+        result => {
+            panic!("Expected transactions with proof but got: {:?}", result);
+        }
+    };
+}
+
+#[test]
+fn test_get_epoch_ending_ledger_infos() {
+    // Create a storage service server
+    let storage_server = create_storage_server();
+
+    // Create a request to fetch transactions with a proof (excluding events)
+    let start_epoch = 11;
+    let expected_end_epoch = 21;
+    let epoch_ending_li_request =
+        StorageServiceRequest::GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest {
+            start_epoch,
+            expected_end_epoch,
+        });
+
+    // Process the request
+    let epoch_ending_li_response = storage_server
+        .handle_request(epoch_ending_li_request)
+        .unwrap();
+
+    // Verify the response is correct
+    match epoch_ending_li_response {
+        StorageServiceResponse::EpochEndingLedgerInfos(epoch_change_proof) => {
+            assert_eq!(
+                epoch_change_proof.ledger_info_with_sigs.len(),
+                (expected_end_epoch - start_epoch + 1) as usize
+            );
+            assert_eq!(epoch_change_proof.more, false);
+
+            for (i, epoch_ending_li) in epoch_change_proof.ledger_info_with_sigs.iter().enumerate()
+            {
+                assert_eq!(
+                    epoch_ending_li.ledger_info().epoch(),
+                    (i as u64) + start_epoch
+                );
+            }
+        }
+        result => {
+            panic!("Expected epoch ending ledger infos but got: {:?}", result);
+        }
+    };
+}
+
+fn create_storage_server() -> StorageServiceServer<StorageReader> {
+    let storage = Arc::new(RwLock::new(DbReaderWriter::new(MockDbReaderWriter)));
+    let storage_reader = StorageReader::new(storage);
+    StorageServiceServer::new(storage_reader)
+}
+
+fn create_test_event(sequence_number: u64) -> ContractEvent {
+    ContractEvent::new(
+        EventKey::new_from_address(&AccountAddress::random(), 0),
+        sequence_number,
+        TypeTag::Bool,
+        bcs::to_bytes(&0).unwrap(),
+    )
+}
+
+fn create_test_transaction(sequence_number: u64) -> Transaction {
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+
+    let transaction_payload = TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+    let raw_transaction = RawTransaction::new(
+        AccountAddress::random(),
+        sequence_number,
+        transaction_payload,
+        0,
+        0,
+        "".into(),
+        0,
+        ChainId::new(10),
+    );
+    let signed_transaction = SignedTransaction::new(
+        raw_transaction.clone(),
+        public_key,
+        private_key.sign(&raw_transaction),
+    );
+
+    Transaction::UserTransaction(signed_transaction)
+}
+
+fn create_test_ledger_info_with_sigs(epoch: u64, version: u64) -> LedgerInfoWithSignatures {
+    // Create a mock ledger info with signatures
+    let ledger_info = LedgerInfo::new(
+        BlockInfo::new(
+            epoch,
+            0,
+            HashValue::zero(),
+            HashValue::zero(),
+            version,
+            0,
+            None,
+        ),
+        HashValue::zero(),
+    );
+    LedgerInfoWithSignatures::new(ledger_info, BTreeMap::new())
+}
+
+/// This is a mock of the DbReader and DbWriter for unit testing.
+struct MockDbReaderWriter;
+
+impl DbReader for MockDbReaderWriter {
+    fn get_epoch_ending_ledger_infos(
+        &self,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Result<EpochChangeProof> {
+        let mut ledger_info_with_sigs = vec![];
+        for epoch in start_epoch..end_epoch + 1 {
+            ledger_info_with_sigs.push(create_test_ledger_info_with_sigs(epoch, 0));
+        }
+
+        Ok(EpochChangeProof {
+            ledger_info_with_sigs,
+            more: false,
+        })
+    }
+
+    fn get_transactions(
+        &self,
+        start_version: Version,
+        batch_size: u64,
+        _ledger_version: Version,
+        fetch_events: bool,
+    ) -> Result<TransactionListWithProof> {
+        // Create mock events
+        let events = if fetch_events {
+            let mut events = vec![];
+            for i in 0..batch_size {
+                events.push(vec![create_test_event(i)]);
+            }
+            Some(events)
+        } else {
+            None
+        };
+
+        // Create mock transactions
+        let mut transactions = vec![];
+        for i in 0..batch_size {
+            transactions.push(create_test_transaction(i))
+        }
+
+        Ok(TransactionListWithProof {
+            transactions,
+            events,
+            first_transaction_version: Some(start_version),
+            proof: TransactionListProof::new_empty(),
+        })
+    }
+
+    /// Returns events by given event key
+    fn get_events(
+        &self,
+        _event_key: &EventKey,
+        _start: u64,
+        _order: Order,
+        _limit: u64,
+    ) -> Result<Vec<(u64, ContractEvent)>> {
+        unimplemented!()
+    }
+
+    /// Returns events by given event key
+    fn get_events_with_proofs(
+        &self,
+        _event_key: &EventKey,
+        _start: u64,
+        _order: Order,
+        _limit: u64,
+        _known_version: Option<u64>,
+    ) -> Result<Vec<EventWithProof>> {
+        unimplemented!()
+    }
+
+    fn get_block_timestamp(&self, _version: u64) -> Result<u64> {
+        unimplemented!()
+    }
+
+    fn get_event_by_version_with_proof(
+        &self,
+        _event_key: &EventKey,
+        _version: u64,
+        _proof_version: u64,
+    ) -> Result<EventByVersionWithProof> {
+        unimplemented!()
+    }
+
+    fn get_latest_account_state(
+        &self,
+        _address: AccountAddress,
+    ) -> Result<Option<AccountStateBlob>> {
+        unimplemented!()
+    }
+
+    /// Returns the latest ledger info.
+    fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures> {
+        Ok(create_test_ledger_info_with_sigs(10, 100))
+    }
+
+    fn get_startup_info(&self) -> Result<Option<StartupInfo>> {
+        unimplemented!()
+    }
+
+    fn get_account_transaction(
+        &self,
+        _address: AccountAddress,
+        _seq_num: u64,
+        _include_events: bool,
+        _ledger_version: Version,
+    ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
+    fn get_account_transactions(
+        &self,
+        _address: AccountAddress,
+        _start_seq_num: u64,
+        _limit: u64,
+        _include_events: bool,
+        _ledger_version: Version,
+    ) -> Result<AccountTransactionsWithProof> {
+        unimplemented!()
+    }
+
+    fn get_state_proof_with_ledger_info(
+        &self,
+        _known_version: u64,
+        _ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<StateProof> {
+        unimplemented!()
+    }
+
+    fn get_state_proof(&self, _known_version: u64) -> Result<StateProof> {
+        unimplemented!()
+    }
+
+    fn get_account_state_with_proof(
+        &self,
+        _address: AccountAddress,
+        _version: Version,
+        _ledger_version: Version,
+    ) -> Result<AccountStateWithProof> {
+        unimplemented!()
+    }
+
+    fn get_account_state_with_proof_by_version(
+        &self,
+        _address: AccountAddress,
+        _version: Version,
+    ) -> Result<(
+        Option<AccountStateBlob>,
+        SparseMerkleProof<AccountStateBlob>,
+    )> {
+        unimplemented!()
+    }
+
+    fn get_latest_state_root(&self) -> Result<(Version, HashValue)> {
+        unimplemented!()
+    }
+
+    fn get_latest_tree_state(&self) -> Result<TreeState> {
+        unimplemented!()
+    }
+
+    fn get_epoch_ending_ledger_info(
+        &self,
+        _known_version: u64,
+    ) -> Result<LedgerInfoWithSignatures> {
+        unimplemented!()
+    }
+}
+
+impl DbWriter for MockDbReaderWriter {
+    fn save_transactions(
+        &self,
+        _txns_to_commit: &[TransactionToCommit],
+        _first_version: Version,
+        _ledger_info_with_sigs: Option<&LedgerInfoWithSignatures>,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+}

--- a/state-sync/storage-service/types/Cargo.toml
+++ b/state-sync/storage-service/types/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "storage-service-types"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "Common types offered by the Diem storage service"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+diem-types = { path = "../../../types" }
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+
+[dev-dependencies]

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -1,0 +1,82 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+use diem_types::{epoch_change::EpochChangeProof, transaction::TransactionListWithProof};
+
+/// A storage service request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StorageServiceRequest {
+    GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest), // Fetches a list of epoch ending ledger infos
+    GetServerProtocolVersion, // Fetches the protocol version run by the server
+    GetStorageServerSummary,  // Fetches a summary of the storage server state
+    GetTransactionsWithProof(TransactionsWithProofRequest), // Fetches a list of transactions with a proof
+}
+
+/// A storage service response.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StorageServiceResponse {
+    EpochEndingLedgerInfos(EpochChangeProof),
+    ServerProtocolVersion(ServerProtocolVersion),
+    StorageServiceError(StorageServiceError),
+    StorageServerSummary(StorageServerSummary),
+    TransactionsWithProof(TransactionListWithProof),
+}
+
+/// A storage service request for fetching a transaction list with a
+/// corresponding proof.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransactionsWithProofRequest {
+    pub proof_version: u64, // The version the proof should be relative to
+    pub start_version: u64, // The starting version of the transaction list
+    pub expected_num_transactions: u64, // Expected number of transactions in the list
+    pub include_events: bool, // Whether or not to include events in the response
+}
+
+/// A storage service request for fetching a list of epoch ending ledger infos.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EpochEndingLedgerInfoRequest {
+    pub start_epoch: u64,
+    pub expected_end_epoch: u64,
+}
+
+/// A storage service error that can be returned to the client on a failure
+/// to process a service request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StorageServiceError {
+    InternalError,
+}
+
+/// The protocol version run by this server. Clients request this first to
+/// identify what API calls and data requests the server supports.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ServerProtocolVersion {
+    pub protocol_version: u64, // The storage server version run by this instance.
+}
+
+/// A storage server summary, containing a summary of the information held
+/// by the corresponding server instance. This is useful for identifying the
+/// data that a server instance can provide, as well as relevant metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StorageServerSummary {
+    pub protocol_metadata: ProtocolMetadata,
+    pub data_summary: DataSummary,
+}
+
+/// A summary of the protocol metadata for the storage service instance, such as
+/// the maximum chunk sizes supported for different requests.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProtocolMetadata {
+    pub max_transaction_chunk_size: u64, // The max number of transaction the server can return in a single chunk
+}
+
+/// A summary of the data actually held by the storage service instance.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DataSummary {
+    pub highest_transaction_version: u64, // The highest transaction version currently synced
+    pub lowest_transaction_version: u64,  // The lowest transaction version currently stored
+
+    pub highest_epoch: u64, // The highest epoch currently synced
+    pub lowest_epoch: u64,  // The lowest epoch currently stored
+}

--- a/x.toml
+++ b/x.toml
@@ -233,6 +233,8 @@ members = [
     "smoke-test",
     "socket-bench-server",
     "state-sync-v2", # Will be removed once state sync v2 is plugged into diem-node.
+    "storage-service-server", # Will be removed once the storage service is plugged into diem-node.
+    "storage-service-types", # Will be removed once the storage service is plugged into diem-node.
     "test-generation",
     "x",
     "x-core",


### PR DESCRIPTION
## Motivation

This PR adds a new server-side implementation for the Storage Service. The Storage Service is an inter-node service allowing Diem nodes to request storage data (e.g., transactions and proofs) directly from other nodes over the Diem network. This PR sets up the framework (template) for this service by implementing the plumbing between request/response processing from the server-side, as well as outlines the required interface between the server and local Diem DB. 

To achieve this, the PR offers 2 commits:
1. Add the new server implementation (as a library to later be exposed over the network)
2. Add several (simple) tests for the server implementation. These will need to be improved and expanded in the future.

Notes:
- The implementation offered here is by no means complete (and you'll notice many TODOs). Instead, this PR is meant to set up the framework so that we can start building on the server-side implementation and make the Storage Service a living thing 😄

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A set of simple unit tests have been added for this functionality.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906