### PR TITLE
[network] Make NetworkId & NetworkContext copyable

### DIFF
--- a/config/management/genesis/src/validator_builder.rs
+++ b/config/management/genesis/src/validator_builder.rs
@@ -332,7 +332,7 @@ impl ValidatorBuilder {
 
         let vfn_network = NetworkConfig {
             listen_address: diem_config::utils::get_available_port_in_multiaddr(true),
-            network_id: NetworkId::vfn_network(),
+            network_id: NetworkId::Vfn,
             max_outbound_connections: 0,
             identity: Identity::from_storage(
                 FULLNODE_NETWORK_KEY.to_owned(),

--- a/config/management/genesis/src/validator_builder.rs
+++ b/config/management/genesis/src/validator_builder.rs
@@ -332,7 +332,7 @@ impl ValidatorBuilder {
 
         let vfn_network = NetworkConfig {
             listen_address: diem_config::utils::get_available_port_in_multiaddr(true),
-            network_id: NetworkId::Private("vfn".to_owned()),
+            network_id: NetworkId::vfn_network(),
             max_outbound_connections: 0,
             identity: Identity::from_storage(
                 FULLNODE_NETWORK_KEY.to_owned(),

--- a/config/management/operational/src/network_checker.rs
+++ b/config/management/operational/src/network_checker.rs
@@ -213,7 +213,7 @@ fn build_upgrade_context(
     private_key: x25519::PrivateKey,
 ) -> Arc<UpgradeContext> {
     // RoleType doesn't matter, but the `NetworkId` and `PeerId` are used in handshakes
-    let network_context = Arc::new(NetworkContext::new(RoleType::FullNode, network_id, peer_id));
+    let network_context = NetworkContext::new(RoleType::FullNode, network_id, peer_id);
 
     // Let's make sure some protocol can be connected.  In the future we may want to allow for specifics
     let mut supported_protocols = BTreeMap::new();

--- a/config/management/operational/src/network_checker.rs
+++ b/config/management/operational/src/network_checker.rs
@@ -213,11 +213,7 @@ fn build_upgrade_context(
     private_key: x25519::PrivateKey,
 ) -> Arc<UpgradeContext> {
     // RoleType doesn't matter, but the `NetworkId` and `PeerId` are used in handshakes
-    let network_context = Arc::new(NetworkContext::new(
-        RoleType::FullNode,
-        network_id.clone(),
-        peer_id,
-    ));
+    let network_context = Arc::new(NetworkContext::new(RoleType::FullNode, network_id, peer_id));
 
     // Let's make sure some protocol can be connected.  In the future we may want to allow for specifics
     let mut supported_protocols = BTreeMap::new();

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -270,18 +270,18 @@ impl NodeConfig {
         let mut network_ids = HashSet::new();
         if let Some(network) = &mut self.validator_network {
             network.load_validator_network()?;
-            network_ids.insert(network.network_id.clone());
+            network_ids.insert(network.network_id);
         }
         for network in &mut self.full_node_networks {
             network.load_fullnode_network()?;
 
             // Check a validator network is not included in a list of full-node networks
-            let network_id = &network.network_id;
+            let network_id = network.network_id;
             invariant(
                 !matches!(network_id, NetworkId::Validator),
                 "Included a validator network in full_node_networks".into(),
             )?;
-            network_ids.insert(network_id.clone());
+            network_ids.insert(network_id);
         }
         Ok(self)
     }

--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -22,7 +22,7 @@ impl PeerNetworkId {
         }
     }
     pub fn network_id(&self) -> NetworkId {
-        self.network_id.clone()
+        self.network_id
     }
 
     pub fn peer_id(&self) -> PeerId {

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -163,11 +163,6 @@ impl fmt::Display for NetworkId {
 const VFN_NETWORK: &str = "vfn";
 
 impl NetworkId {
-    /// Convenience function to specify the VFN network
-    pub fn vfn_network() -> NetworkId {
-        NetworkId::Vfn
-    }
-
     pub fn is_vfn_network(&self) -> bool {
         self == &NetworkId::Vfn
     }
@@ -245,8 +240,8 @@ mod test {
 
     #[test]
     fn test_ensure_network_id_order() {
-        assert!(NetworkId::Validator < NetworkId::vfn_network());
-        assert!(NetworkId::vfn_network() < NetworkId::Public);
+        assert!(NetworkId::Validator < NetworkId::Vfn);
+        assert!(NetworkId::Vfn < NetworkId::Public);
         assert!(NetworkId::Validator < NetworkId::Public);
     }
 
@@ -265,7 +260,7 @@ mod test {
     #[test]
     fn test_network_context_serialization() {
         let peer_id = PeerId::random();
-        let context = NetworkContext::new(RoleType::Validator, NetworkId::vfn_network(), peer_id);
+        let context = NetworkContext::new(RoleType::Validator, NetworkId::Vfn, peer_id);
         let expected = format!(
             "---\nrole: {}\nnetwork_id: {}\npeer_id: {:x}\n",
             RoleType::Validator,

--- a/config/src/network_id.rs
+++ b/config/src/network_id.rs
@@ -9,7 +9,7 @@ use std::{fmt, str::FromStr};
 /// A grouping of common information between all networking code for logging.
 /// This should greatly reduce the groupings between these given everywhere, and will allow
 /// for logging accordingly.
-#[derive(Clone, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
 pub struct NetworkContext {
     /// The type of node
     role: RoleType,
@@ -58,21 +58,13 @@ impl NetworkContext {
     }
 
     #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
-    pub fn mock_with_peer_id(peer_id: PeerId) -> std::sync::Arc<Self> {
-        std::sync::Arc::new(Self::new(
-            RoleType::Validator,
-            NetworkId::Validator,
-            peer_id,
-        ))
+    pub fn mock_with_peer_id(peer_id: PeerId) -> Self {
+        Self::new(RoleType::Validator, NetworkId::Validator, peer_id)
     }
 
     #[cfg(any(test, feature = "testing", feature = "fuzzing"))]
-    pub fn mock() -> std::sync::Arc<Self> {
-        std::sync::Arc::new(Self::new(
-            RoleType::Validator,
-            NetworkId::Validator,
-            PeerId::random(),
-        ))
+    pub fn mock() -> Self {
+        Self::new(RoleType::Validator, NetworkId::Validator, PeerId::random())
     }
 }
 

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -361,7 +361,7 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
             TimeService::real(),
             Some(&mut event_subscription_service),
         );
-        let network_id = network_config.network_id.clone();
+        let network_id = network_config.network_id;
         // Guarantee there is only one of this network
         if network_ids.contains(&network_id) {
             panic!(
@@ -369,18 +369,18 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
                 network_id
             );
         }
-        network_ids.insert(network_id.clone());
+        network_ids.insert(network_id);
 
         // Create the endpoints to connect the Network to State Sync.
         let (state_sync_sender, state_sync_events) =
             network_builder.add_protocol_handler(state_sync_v1::network::network_endpoint_config());
-        state_sync_network_handles.push((network_id.clone(), state_sync_sender, state_sync_events));
+        state_sync_network_handles.push((network_id, state_sync_sender, state_sync_events));
 
         // Create the endpoints to connect the Network to mempool.
         let (mempool_sender, mempool_events) = network_builder.add_protocol_handler(
             diem_mempool::network::network_endpoint_config(MEMPOOL_NETWORK_CHANNEL_BUFFER_SIZE),
         );
-        mempool_network_handles.push((network_id.clone(), mempool_sender, mempool_events));
+        mempool_network_handles.push((network_id, mempool_sender, mempool_events));
 
         // Perform steps relevant specifically to Validator networks.
         if network_id.is_validator_network() {

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -61,7 +61,7 @@ pub(crate) async fn coordinator<V>(
     ));
     let smp_events: Vec<_> = network_events
         .into_iter()
-        .map(|(network_id, events)| events.map(move |e| (network_id.clone(), e)))
+        .map(|(network_id, events)| events.map(move |e| (network_id, e)))
         .collect();
     let mut events = select_all(smp_events).fuse();
     let mut scheduled_broadcasts = FuturesUnordered::new();

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -511,11 +511,11 @@ mod test {
         let peer_id_1 = PeerId::from_hex_literal("0x1").unwrap();
         let peer_id_2 = PeerId::from_hex_literal("0x2").unwrap();
         let val_1 = (
-            PeerNetworkId::new(NetworkId::vfn_network(), peer_id_1),
+            PeerNetworkId::new(NetworkId::Vfn, peer_id_1),
             PeerRole::Validator,
         );
         let val_2 = (
-            PeerNetworkId::new(NetworkId::vfn_network(), peer_id_2),
+            PeerNetworkId::new(NetworkId::Vfn, peer_id_2),
             PeerRole::Validator,
         );
         let vfn_1 = (

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -53,7 +53,7 @@ pub(crate) fn start_shared_mempool<V>(
     let mut all_network_events = vec![];
     let mut network_senders = HashMap::new();
     for (network_id, network_sender, network_events) in mempool_network_handles.into_iter() {
-        all_network_events.push((network_id.clone(), network_events));
+        all_network_events.push((network_id, network_events));
         network_senders.insert(network_id, network_sender);
     }
 

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -182,7 +182,7 @@ impl NodeInfoTrait for ValidatorFullNodeInfo {
     }
 
     fn primary_network(&self) -> NetworkId {
-        NetworkId::vfn_network()
+        NetworkId::Vfn
     }
 
     fn role(&self) -> RoleType {

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -405,7 +405,7 @@ impl Node {
     ) {
         let metadata = ConnectionMetadata::mock_with_role_and_origin(new_peer, peer_role, origin);
         let network_context = self.network_context(is_primary);
-        let notif = ConnectionNotification::NewPeer(metadata, Arc::new(network_context));
+        let notif = ConnectionNotification::NewPeer(metadata, network_context);
         self.send_connection_event(is_primary, notif)
     }
 

--- a/mempool/src/tests/node.rs
+++ b/mempool/src/tests/node.rs
@@ -551,7 +551,7 @@ fn setup_node_network_interfaces(
             )
         }
         let (network_interface, network_handle) = setup_node_network_interface(PeerNetworkId::new(
-            secondary_network_id.clone(),
+            secondary_network_id,
             node.secondary_peer_id().unwrap(),
         ));
         network_handles.push(network_handle);

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -184,11 +184,7 @@ impl NetworkBuilder {
             AuthenticationMode::MaybeMutual(identity_key)
         };
 
-        let network_context = Arc::new(NetworkContext::new(
-            role,
-            config.network_id.clone(),
-            peer_id,
-        ));
+        let network_context = Arc::new(NetworkContext::new(role, config.network_id, peer_id));
 
         let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -66,7 +66,7 @@ pub struct NetworkBuilder {
     state: State,
     executor: Option<Handle>,
     time_service: TimeService,
-    network_context: Arc<NetworkContext>,
+    network_context: NetworkContext,
     discovery_listeners: Option<Vec<DiscoveryChangeListener>>,
     connectivity_manager_builder: Option<ConnectivityManagerBuilder>,
     health_checker_builder: Option<HealthCheckerBuilder>,
@@ -80,7 +80,7 @@ impl NetworkBuilder {
     pub fn new(
         chain_id: ChainId,
         trusted_peers: Arc<RwLock<PeerSet>>,
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         listen_address: NetworkAddress,
         authentication_mode: AuthenticationMode,
@@ -97,7 +97,7 @@ impl NetworkBuilder {
         // TODO:  construct this in create and pass it to new() as a parameter. The complication is manual construction of NetworkBuilder in various tests.
         let peer_manager_builder = PeerManagerBuilder::create(
             chain_id,
-            network_context.clone(),
+            network_context,
             time_service.clone(),
             listen_address,
             peer_metadata_storage.clone(),
@@ -129,7 +129,7 @@ impl NetworkBuilder {
         chain_id: ChainId,
         seeds: PeerSet,
         trusted_peers: Arc<RwLock<PeerSet>>,
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         listen_address: NetworkAddress,
         authentication_mode: AuthenticationMode,
@@ -184,7 +184,7 @@ impl NetworkBuilder {
             AuthenticationMode::MaybeMutual(identity_key)
         };
 
-        let network_context = Arc::new(NetworkContext::new(role, config.network_id, peer_id));
+        let network_context = NetworkContext::new(role, config.network_id, peer_id);
 
         let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 
@@ -308,8 +308,8 @@ impl NetworkBuilder {
         self
     }
 
-    pub fn network_context(&self) -> Arc<NetworkContext> {
-        self.network_context.clone()
+    pub fn network_context(&self) -> NetworkContext {
+        self.network_context
     }
 
     pub fn conn_mgr_reqs_tx(&self) -> Option<channel::Sender<ConnectivityRequest>> {
@@ -383,7 +383,7 @@ impl NetworkBuilder {
                 let reconfig_events =
                     reconfig_events.expect("Reconfiguration listener is expected!");
                 DiscoveryChangeListener::validator_set(
-                    self.network_context.clone(),
+                    self.network_context,
                     conn_mgr_reqs_tx,
                     pubkey,
                     encryptor,
@@ -391,7 +391,7 @@ impl NetworkBuilder {
                 )
             }
             DiscoveryMethod::File(path, interval_duration) => DiscoveryChangeListener::file(
-                self.network_context.clone(),
+                self.network_context,
                 conn_mgr_reqs_tx,
                 path,
                 *interval_duration,

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -140,11 +140,7 @@ pub fn setup_network() -> DummyNetwork {
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
 
     // Set up the listener network
-    let network_context = Arc::new(NetworkContext::new(
-        role,
-        network_id.clone(),
-        listener_peer_id,
-    ));
+    let network_context = Arc::new(NetworkContext::new(role, network_id, listener_peer_id));
     let mut network_builder = NetworkBuilder::new_for_test(
         chain_id,
         seeds.clone(),

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -140,7 +140,7 @@ pub fn setup_network() -> DummyNetwork {
     let authentication_mode = AuthenticationMode::Mutual(listener_identity_private_key);
 
     // Set up the listener network
-    let network_context = Arc::new(NetworkContext::new(role, network_id, listener_peer_id));
+    let network_context = NetworkContext::new(role, network_id, listener_peer_id);
     let mut network_builder = NetworkBuilder::new_for_test(
         chain_id,
         seeds.clone(),
@@ -165,7 +165,7 @@ pub fn setup_network() -> DummyNetwork {
     let authentication_mode = AuthenticationMode::Mutual(dialer_identity_private_key);
 
     // Set up the dialer network
-    let network_context = Arc::new(NetworkContext::new(role, network_id, dialer_peer_id));
+    let network_context = NetworkContext::new(role, network_id, dialer_peer_id);
 
     let trusted_peers = Arc::new(RwLock::new(HashMap::new()));
 

--- a/network/discovery/src/lib.rs
+++ b/network/discovery/src/lib.rs
@@ -18,7 +18,6 @@ use network::{
 use std::{
     path::Path,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
     time::Duration,
 };
@@ -37,7 +36,7 @@ pub enum DiscoveryError {
 /// A union type for all implementations of `DiscoveryChangeListenerTrait`
 pub struct DiscoveryChangeListener {
     discovery_source: DiscoverySource,
-    network_context: Arc<NetworkContext>,
+    network_context: NetworkContext,
     update_channel: channel::Sender<ConnectivityRequest>,
     source_stream: DiscoveryChangeStream,
 }
@@ -60,14 +59,14 @@ impl Stream for DiscoveryChangeStream {
 
 impl DiscoveryChangeListener {
     pub fn validator_set(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         update_channel: channel::Sender<ConnectivityRequest>,
         expected_pubkey: x25519::PublicKey,
         encryptor: Encryptor<Storage>,
         reconfig_events: ReconfigNotificationListener,
     ) -> Self {
         let source_stream = DiscoveryChangeStream::ValidatorSet(ValidatorSetStream::new(
-            network_context.clone(),
+            network_context,
             expected_pubkey,
             encryptor,
             reconfig_events,
@@ -81,7 +80,7 @@ impl DiscoveryChangeListener {
     }
 
     pub fn file(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         update_channel: channel::Sender<ConnectivityRequest>,
         file_path: &Path,
         interval_duration: Duration,
@@ -105,7 +104,7 @@ impl DiscoveryChangeListener {
     }
 
     async fn run(mut self: Pin<Box<Self>>) {
-        let network_context = self.network_context.clone();
+        let network_context = self.network_context;
         let discovery_source = self.discovery_source;
         let mut update_channel = self.update_channel.clone();
         let source_stream = &mut self.source_stream;

--- a/network/src/connectivity_manager/builder.rs
+++ b/network/src/connectivity_manager/builder.rs
@@ -22,7 +22,7 @@ pub struct ConnectivityManagerBuilder {
 
 impl ConnectivityManagerBuilder {
     pub fn create(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         eligible: Arc<RwLock<PeerSet>>,
         seeds: PeerSet,

--- a/network/src/connectivity_manager/mod.rs
+++ b/network/src/connectivity_manager/mod.rs
@@ -77,7 +77,7 @@ const MAX_CONNECTION_DELAY_JITTER: Duration = Duration::from_millis(100);
 
 /// The ConnectivityManager actor.
 pub struct ConnectivityManager<TBackoff> {
-    network_context: Arc<NetworkContext>,
+    network_context: NetworkContext,
     /// A handle to a time service for easily mocking time-related operations.
     time_service: TimeService,
     /// Nodes which are eligible to join the network.
@@ -251,7 +251,7 @@ where
 {
     /// Creates a new instance of the [`ConnectivityManager`] actor.
     pub fn new(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         eligible: Arc<RwLock<PeerSet>>,
         seeds: PeerSet,
@@ -528,7 +528,7 @@ where
             dial_delay
         );
 
-        let network_context = self.network_context.clone();
+        let network_context = self.network_context;
         // Create future which completes by either dialing after calculated
         // delay or on cancellation.
         let f = async move {
@@ -784,7 +784,7 @@ where
 }
 
 fn log_dial_result(
-    network_context: Arc<NetworkContext>,
+    network_context: NetworkContext,
     peer_id: PeerId,
     addr: NetworkAddress,
     dial_result: DialResult,

--- a/network/src/noise/handshake.rs
+++ b/network/src/noise/handshake.rs
@@ -135,7 +135,7 @@ impl HandshakeAuthMode {
 /// The Noise configuration to be used to perform a protocol upgrade on an underlying socket.
 pub struct NoiseUpgrader {
     /// The validator's network context
-    pub network_context: Arc<NetworkContext>,
+    pub network_context: NetworkContext,
     /// Config for executing Noise handshakes. Includes our static private key.
     noise_config: noise::NoiseConfig,
     /// Handshake authentication can be either mutual or server-only authentication.
@@ -145,7 +145,7 @@ pub struct NoiseUpgrader {
 impl NoiseUpgrader {
     /// Create a new NoiseConfig with the provided keypair and authentication mode.
     pub fn new(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         key: x25519::PrivateKey,
         auth_mode: HandshakeAuthMode,
     ) -> Self {

--- a/network/src/noise/mod.rs
+++ b/network/src/noise/mod.rs
@@ -42,19 +42,19 @@
 //! let trusted_peers = Arc::new(RwLock::new(trusted_peers));
 //!
 //! let client_auth = HandshakeAuthMode::mutual(trusted_peers.clone());
-//! let client_context = Arc::new(NetworkContext::new(
+//! let client_context = NetworkContext::new(
 //!     RoleType::Validator,
 //!     NetworkId::Validator,
 //!     client_peer_id,
-//! ));
+//! );
 //! let client = NoiseUpgrader::new(client_context, client_private, client_auth);
 //!
 //! let server_auth = HandshakeAuthMode::mutual(trusted_peers);
-//! let server_context = Arc::new(NetworkContext::new(
+//! let server_context = NetworkContext::new(
 //!     RoleType::Validator,
 //!     NetworkId::Validator,
 //!     server_peer_id,
-//! ));
+//! );
 //! let server = NoiseUpgrader::new(server_context, server_private, server_auth);
 //!
 //! // use an in-memory socket as example

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -190,7 +190,7 @@ enum TransportPeerManager {
 }
 
 pub struct PeerManagerBuilder {
-    network_context: Arc<NetworkContext>,
+    network_context: NetworkContext,
     time_service: TimeService,
     transport_context: Option<TransportContext>,
     peer_manager_context: Option<PeerManagerContext>,
@@ -204,7 +204,7 @@ impl PeerManagerBuilder {
     #[allow(clippy::too_many_arguments)]
     pub fn create(
         chain_id: ChainId,
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         // TODO(philiphayes): better support multiple listening addrs
         listen_address: NetworkAddress,
@@ -303,7 +303,7 @@ impl PeerManagerBuilder {
                 Some(TransportPeerManager::Tcp(self.build_with_transport(
                     DiemNetTransport::new(
                         DIEM_TCP_TRANSPORT.clone(),
-                        self.network_context.clone(),
+                        self.network_context,
                         self.time_service.clone(),
                         key,
                         auth_mode,
@@ -319,7 +319,7 @@ impl PeerManagerBuilder {
             [Memory(_)] => Some(TransportPeerManager::Memory(self.build_with_transport(
                 DiemNetTransport::new(
                     MemoryTransport,
-                    self.network_context.clone(),
+                    self.network_context,
                     self.time_service.clone(),
                     key,
                     auth_mode,
@@ -369,7 +369,7 @@ impl PeerManagerBuilder {
             executor.clone(),
             self.time_service.clone(),
             transport,
-            self.network_context.clone(),
+            self.network_context,
             // TODO(philiphayes): peer manager should take `Vec<NetworkAddress>`
             // (which could be empty, like in client use case)
             self.listen_address.clone(),
@@ -473,7 +473,7 @@ impl PeerManagerBuilder {
 
 /// Builds a token bucket rate limiter with attached metrics
 fn token_bucket_rate_limiter(
-    network_context: &Arc<NetworkContext>,
+    network_context: &NetworkContext,
     label: &'static str,
     input: Option<RateLimitConfig>,
 ) -> TokenBucketRateLimiter<IpAddr> {

--- a/network/src/peer_manager/transport.rs
+++ b/network/src/peer_manager/transport.rs
@@ -21,7 +21,7 @@ use futures::{
 };
 use netcore::transport::{ConnectionOrigin, Transport};
 use short_hex_str::AsShortHexStr;
-use std::{sync::Arc, time::Instant};
+use std::time::Instant;
 
 #[derive(Debug)]
 pub enum TransportRequest {
@@ -38,7 +38,7 @@ where
     TTransport: Transport,
     TSocket: AsyncRead + AsyncWrite,
 {
-    network_context: Arc<NetworkContext>,
+    network_context: NetworkContext,
     time_service: TimeService,
     /// [`Transport`] that is used to establish connections
     transport: TTransport,
@@ -56,7 +56,7 @@ where
     TSocket: AsyncRead + AsyncWrite + 'static,
 {
     pub fn new(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         transport: TTransport,
         listen_addr: NetworkAddress,

--- a/network/src/peer_manager/types.rs
+++ b/network/src/peer_manager/types.rs
@@ -13,7 +13,7 @@ use diem_config::network_id::NetworkContext;
 use diem_types::{network_address::NetworkAddress, PeerId};
 use futures::channel::oneshot;
 use serde::Serialize;
-use std::{fmt, sync::Arc};
+use std::fmt;
 
 /// Request received by PeerManager from upstream actors.
 #[derive(Debug, Serialize)]
@@ -49,9 +49,9 @@ pub enum ConnectionRequest {
 #[derive(Clone, PartialEq, Serialize)]
 pub enum ConnectionNotification {
     /// Connection with a new peer has been established.
-    NewPeer(ConnectionMetadata, Arc<NetworkContext>),
+    NewPeer(ConnectionMetadata, NetworkContext),
     /// Connection to a peer has been terminated. This could have been triggered from either end.
-    LostPeer(ConnectionMetadata, Arc<NetworkContext>, DisconnectReason),
+    LostPeer(ConnectionMetadata, NetworkContext, DisconnectReason),
 }
 
 impl fmt::Debug for ConnectionNotification {

--- a/network/src/protocols/health_checker/builder.rs
+++ b/network/src/protocols/health_checker/builder.rs
@@ -19,7 +19,7 @@ pub struct HealthCheckerBuilder {
 
 impl HealthCheckerBuilder {
     pub fn new(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         ping_interval_ms: u64,
         ping_timeout_ms: u64,

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -45,7 +45,7 @@ use futures::{
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 use short_hex_str::AsShortHexStr;
-use std::{collections::hash_map::Entry, sync::Arc, time::Duration};
+use std::{collections::hash_map::Entry, time::Duration};
 
 pub mod builder;
 mod interface;
@@ -138,7 +138,7 @@ pub struct Pong(u32);
 
 /// The actor performing health checks by running the Ping protocol
 pub struct HealthChecker {
-    network_context: Arc<NetworkContext>,
+    network_context: NetworkContext,
     /// A handle to a time service for easily mocking time-related operations.
     time_service: TimeService,
     /// Network interface to send requests to the Network Layer
@@ -160,7 +160,7 @@ pub struct HealthChecker {
 impl HealthChecker {
     /// Create new instance of the [`HealthChecker`] actor.
     pub fn new(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         network_interface: HealthCheckNetworkInterface,
         ping_interval: Duration,
@@ -267,7 +267,7 @@ impl HealthChecker {
                         );
 
                         tick_handlers.push(Self::ping_peer(
-                            self.network_context.clone(),
+                            self.network_context,
                             self.network_interface.sender(),
                             peer_id,
                             self.round,
@@ -427,7 +427,7 @@ impl HealthChecker {
     }
 
     async fn ping_peer(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         mut network_tx: HealthCheckerNetworkSender,
         peer_id: PeerId,
         round: u64,

--- a/network/src/protocols/health_checker/test.rs
+++ b/network/src/protocols/health_checker/test.rs
@@ -17,6 +17,7 @@ use crate::{
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_time_service::{MockTimeService, TimeService};
 use futures::{executor::block_on, future};
+use std::sync::Arc;
 
 const PING_INTERVAL: Duration = Duration::from_secs(1);
 const PING_TIMEOUT: Duration = Duration::from_millis(500);

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -77,7 +77,7 @@ mod tests {
         );
         let server_handshake = HandshakeMsg {
             chain_id,
-            network_id: network_id.clone(),
+            network_id,
             supported_protocols,
         };
         let mut supported_protocols = BTreeMap::new();

--- a/network/src/protocols/rpc/mod.rs
+++ b/network/src/protocols/rpc/mod.rs
@@ -72,7 +72,7 @@ use futures::{
 };
 use serde::Serialize;
 use short_hex_str::AsShortHexStr;
-use std::{cmp::PartialEq, collections::HashMap, fmt::Debug, sync::Arc, time::Duration};
+use std::{cmp::PartialEq, collections::HashMap, fmt::Debug, time::Duration};
 
 pub mod error;
 
@@ -163,7 +163,7 @@ impl PartialEq for InboundRpcRequest {
 /// There is one `InboundRpcs` handler per [`Peer`](crate::peer::Peer).
 pub struct InboundRpcs {
     /// The network instance this Peer actor is running under.
-    network_context: Arc<NetworkContext>,
+    network_context: NetworkContext,
     /// A handle to a time service for easily mocking time-related operations.
     time_service: TimeService,
     /// The PeerId of this connection's remote peer. Used for logging.
@@ -182,7 +182,7 @@ pub struct InboundRpcs {
 
 impl InboundRpcs {
     pub fn new(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         remote_peer_id: PeerId,
         inbound_rpc_timeout: Duration,
@@ -331,7 +331,7 @@ impl InboundRpcs {
 /// There is one `OutboundRpcs` handler per [`Peer`](crate::peer::Peer).
 pub struct OutboundRpcs {
     /// The network instance this Peer actor is running under.
-    network_context: Arc<NetworkContext>,
+    network_context: NetworkContext,
     /// A handle to a time service for easily mocking time-related operations.
     time_service: TimeService,
     /// The PeerId of this connection's remote peer. Used for logging.
@@ -358,7 +358,7 @@ pub struct OutboundRpcs {
 
 impl OutboundRpcs {
     pub fn new(
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         remote_peer_id: PeerId,
         max_concurrent_outbound_rpcs: u32,

--- a/network/src/protocols/wire/handshake/v1/mod.rs
+++ b/network/src/protocols/wire/handshake/v1/mod.rs
@@ -241,8 +241,8 @@ impl HandshakeMsg {
         // verify that both peers are on the same type of network
         if self.network_id != other.network_id {
             return Err(HandshakeError::InvalidNetworkId(
-                other.network_id.clone(),
-                self.network_id.clone(),
+                other.network_id,
+                self.network_id,
             ));
         }
 

--- a/network/src/protocols/wire/handshake/v1/test.rs
+++ b/network/src/protocols/wire/handshake/v1/test.rs
@@ -37,11 +37,6 @@ fn represents_same_network() {
     let h2 = handshake_msg.clone();
     h1.perform_handshake(&h2).unwrap();
 
-    // fails: another private network
-    let mut h2 = handshake_msg.clone();
-    h2.network_id = NetworkId::Private("h2".to_string());
-    h1.perform_handshake(&h2).unwrap_err();
-
     // fails: different network
     let mut h2 = handshake_msg.clone();
     h2.network_id = NetworkId::Public;
@@ -67,7 +62,7 @@ fn common_protocols() {
 
     let h1 = HandshakeMsg {
         chain_id,
-        network_id: network_id.clone(),
+        network_id,
         supported_protocols,
     };
 
@@ -81,7 +76,7 @@ fn common_protocols() {
     );
     let h2 = HandshakeMsg {
         chain_id,
-        network_id: network_id.clone(),
+        network_id,
         supported_protocols,
     };
 
@@ -96,7 +91,7 @@ fn common_protocols() {
     // Case 2: No intersecting messaging protocol version.
     let h2 = HandshakeMsg {
         chain_id,
-        network_id: network_id.clone(),
+        network_id,
         supported_protocols: BTreeMap::new(),
     };
     h1.perform_handshake(&h2).unwrap_err();

--- a/network/src/protocols/wire/handshake/v1/test.rs
+++ b/network/src/protocols/wire/handshake/v1/test.rs
@@ -30,7 +30,7 @@ fn protocols_to_from_vec() {
 #[test]
 fn represents_same_network() {
     let mut handshake_msg = HandshakeMsg::new_for_testing();
-    handshake_msg.network_id = NetworkId::vfn_network();
+    handshake_msg.network_id = NetworkId::Vfn;
 
     // succeeds: Positive case
     let h1 = handshake_msg.clone();

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -292,7 +292,7 @@ async fn upgrade_inbound<T: TSocket>(
     let handshake_msg = HandshakeMsg {
         supported_protocols: ctxt.supported_protocols.clone(),
         chain_id: ctxt.chain_id,
-        network_id: ctxt.network_id.clone(),
+        network_id: ctxt.network_id,
     };
     let remote_handshake = exchange_handshake(&handshake_msg, &mut socket)
         .await
@@ -369,7 +369,7 @@ pub async fn upgrade_outbound<T: TSocket>(
     let handshake_msg = HandshakeMsg {
         supported_protocols: ctxt.supported_protocols.clone(),
         chain_id: ctxt.chain_id,
-        network_id: ctxt.network_id.clone(),
+        network_id: ctxt.network_id,
     };
     let remote_handshake = exchange_handshake(&handshake_msg, &mut socket).await?;
 
@@ -443,7 +443,7 @@ where
         supported_protocols.insert(SUPPORTED_MESSAGING_PROTOCOL, application_protocols);
 
         let identity_pubkey = identity_key.public_key();
-        let network_id = network_context.network_id().clone();
+        let network_id = *network_context.network_id();
 
         let upgrade_context = UpgradeContext::new(
             NoiseUpgrader::new(network_context, identity_key, auth_mode),

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -429,7 +429,7 @@ where
 {
     pub fn new(
         base_transport: TTransport,
-        network_context: Arc<NetworkContext>,
+        network_context: NetworkContext,
         time_service: TimeService,
         identity_key: x25519::PrivateKey,
         auth_mode: HandshakeAuthMode,

--- a/state-sync/state-sync-v1/src/bootstrapper.rs
+++ b/state-sync/state-sync-v1/src/bootstrapper.rs
@@ -76,7 +76,7 @@ impl StateSyncBootstrapper {
             .expect("[State Sync] Starting failure: cannot sync with storage!");
         let network_senders: HashMap<_, _> = network
             .iter()
-            .map(|(network_id, sender, _events)| (network_id.clone(), sender.clone()))
+            .map(|(network_id, sender, _events)| (*network_id, sender.clone()))
             .collect();
 
         let coordinator = StateSyncCoordinator::new(

--- a/state-sync/state-sync-v1/src/request_manager.rs
+++ b/state-sync/state-sync-v1/src/request_manager.rs
@@ -477,7 +477,7 @@ impl RequestManager {
         if is_timeout(multicast_start_time, self.multicast_timeout) {
             // Move to the next multicast network level
             let new_multicast_network_level = match self.multicast_network_level {
-                NetworkId::Validator => NetworkId::vfn_network(),
+                NetworkId::Validator => NetworkId::Vfn,
                 _ => NetworkId::Public,
             };
             self.update_multicast_network_level(new_multicast_network_level, Some(version));

--- a/state-sync/state-sync-v1/tests/integration_tests.rs
+++ b/state-sync/state-sync-v1/tests/integration_tests.rs
@@ -1,10 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::test_harness::{
-    default_handler, PFN_NETWORK, VALIDATOR_NETWORK, VFN_NETWORK, VFN_NETWORK_2,
-};
-use diem_config::config::RoleType;
+use crate::test_harness::default_handler;
+use diem_config::{config::RoleType, network_id::NetworkId};
 use diem_types::{transaction::TransactionListWithProof, waypoint::Waypoint, PeerId};
 use netcore::transport::ConnectionOrigin::*;
 use network::protocols::direct_send::Message;
@@ -259,11 +257,11 @@ fn test_lagging_upstream_long_poll() {
     let fullnode_1 = env.get_state_sync_peer(3);
 
     // Get peer ids of nodes (across different networks)
-    let validator_0_peer_id = validator_0.get_peer_id(VALIDATOR_NETWORK.clone());
-    let fullnode_0_peer_id_vfn = fullnode_0.get_peer_id(VFN_NETWORK.clone());
-    let fullnode_0_peer_id_pfn = fullnode_0.get_peer_id(PFN_NETWORK.clone());
-    let fullnode_1_peer_id_vfn = fullnode_1.get_peer_id(VFN_NETWORK.clone());
-    let fullnode_1_peer_id_pfn = fullnode_1.get_peer_id(PFN_NETWORK.clone());
+    let validator_0_peer_id = validator_0.get_peer_id(NetworkId::Validator);
+    let fullnode_0_peer_id_vfn = fullnode_0.get_peer_id(NetworkId::Vfn);
+    let fullnode_0_peer_id_pfn = fullnode_0.get_peer_id(NetworkId::Public);
+    let fullnode_1_peer_id_vfn = fullnode_1.get_peer_id(NetworkId::Vfn);
+    let fullnode_1_peer_id_pfn = fullnode_1.get_peer_id(NetworkId::Public);
 
     // Commit version 400 at the validator
     validator_0.commit(400);
@@ -331,10 +329,8 @@ fn test_fullnode_catch_up_moving_target_epochs() {
     env.start_fullnode_peer(1, true);
 
     // Get peer ids of nodes
-    let validator_peer_id = env
-        .get_state_sync_peer(0)
-        .get_peer_id(VALIDATOR_NETWORK.clone());
-    let fullnode_peer_id = env.get_state_sync_peer(1).get_peer_id(VFN_NETWORK.clone());
+    let validator_peer_id = env.get_state_sync_peer(0).get_peer_id(NetworkId::Validator);
+    let fullnode_peer_id = env.get_state_sync_peer(1).get_peer_id(NetworkId::Vfn);
 
     // Validator and fullnode discover each other.
     send_connection_notifications(&mut env, validator_peer_id, fullnode_peer_id, true);
@@ -404,10 +400,8 @@ fn test_fullnode_catch_up_moving_target() {
     env.start_fullnode_peer(1, true);
 
     // Get peer ids of nodes
-    let validator_peer_id = env
-        .get_state_sync_peer(0)
-        .get_peer_id(VALIDATOR_NETWORK.clone());
-    let fullnode_peer_id = env.get_state_sync_peer(1).get_peer_id(VFN_NETWORK.clone());
+    let validator_peer_id = env.get_state_sync_peer(0).get_peer_id(NetworkId::Validator);
+    let fullnode_peer_id = env.get_state_sync_peer(1).get_peer_id(NetworkId::Vfn);
 
     // Validator and fullnode discover each other.
     send_connection_notifications(&mut env, validator_peer_id, fullnode_peer_id, true);
@@ -488,12 +482,12 @@ fn test_fn_failover() {
     let fullnode_3 = env.get_state_sync_peer(4);
 
     // Grab the nodes peer id's
-    let validator_peer_id = validator.get_peer_id(VFN_NETWORK.clone());
-    let fn_0_vfn_peer_id = fullnode_0.get_peer_id(VFN_NETWORK.clone());
-    let fn_0_pfn_peer_id = fullnode_0.get_peer_id(PFN_NETWORK.clone());
-    let fn_1_pfn_peer_id = fullnode_1.get_peer_id(PFN_NETWORK.clone());
-    let fn_2_pfn_peer_id = fullnode_1.get_peer_id(PFN_NETWORK.clone());
-    let fn_3_pfn_peer_id = fullnode_3.get_peer_id(PFN_NETWORK.clone());
+    let validator_peer_id = validator.get_peer_id(NetworkId::Vfn);
+    let fn_0_vfn_peer_id = fullnode_0.get_peer_id(NetworkId::Vfn);
+    let fn_0_pfn_peer_id = fullnode_0.get_peer_id(NetworkId::Public);
+    let fn_1_pfn_peer_id = fullnode_1.get_peer_id(NetworkId::Public);
+    let fn_2_pfn_peer_id = fullnode_1.get_peer_id(NetworkId::Public);
+    let fn_3_pfn_peer_id = fullnode_3.get_peer_id(NetworkId::Public);
 
     drop(validator);
     drop(fullnode_0);
@@ -717,12 +711,10 @@ fn test_multicast_failover() {
     let fullnode_2 = env.get_state_sync_peer(3);
 
     // Grab the nodes peer id's
-    let validator_peer_id = validator.get_peer_id(VFN_NETWORK.clone());
-    let fn_0_vfn_peer_id = fullnode_0.get_peer_id(VFN_NETWORK.clone());
-    let fn_0_vfn_2_peer_id = fullnode_0.get_peer_id(VFN_NETWORK_2.clone());
-    let fn_0_pfn_peer_id = fullnode_0.get_peer_id(PFN_NETWORK.clone());
-    let fn_1_vfn_2_peer_id = fullnode_1.get_peer_id(VFN_NETWORK_2.clone());
-    let fn_2_pfn_peer_id = fullnode_2.get_peer_id(PFN_NETWORK.clone());
+    let validator_peer_id = validator.get_peer_id(NetworkId::Vfn);
+    let fn_0_vfn_peer_id = fullnode_0.get_peer_id(NetworkId::Vfn);
+    let fn_0_pfn_peer_id = fullnode_0.get_peer_id(NetworkId::Public);
+    let fn_2_pfn_peer_id = fullnode_2.get_peer_id(NetworkId::Public);
 
     drop(validator);
     drop(fullnode_0);
@@ -731,7 +723,6 @@ fn test_multicast_failover() {
 
     // Fullnode 0 discovers validator, fullnode 1 and fullnode 2
     send_connection_notifications(&mut env, validator_peer_id, fn_0_vfn_peer_id, true);
-    send_connection_notifications(&mut env, fn_1_vfn_2_peer_id, fn_0_vfn_2_peer_id, true);
     send_connection_notifications(&mut env, fn_2_pfn_peer_id, fn_0_pfn_peer_id, true);
 
     // Verify that fullnode 0 only broadcasts to the single validator peer
@@ -740,7 +731,7 @@ fn test_multicast_failover() {
         1,
         &[fn_0_vfn_peer_id],
         &[validator_peer_id],
-        &[fn_0_vfn_2_peer_id, fn_0_pfn_peer_id],
+        &[fn_0_pfn_peer_id],
         true,
     );
 
@@ -752,8 +743,8 @@ fn test_multicast_failover() {
     let _ = execute_commit_and_verify_chunk_requests(
         &mut env,
         2,
-        &[fn_0_vfn_2_peer_id, fn_0_vfn_peer_id, fn_0_pfn_peer_id],
-        &[validator_peer_id, fn_1_vfn_2_peer_id, fn_2_pfn_peer_id],
+        &[fn_0_vfn_peer_id, fn_0_pfn_peer_id],
+        &[validator_peer_id, fn_2_pfn_peer_id],
         &[],
         true,
     );
@@ -762,51 +753,47 @@ fn test_multicast_failover() {
     std::thread::sleep(std::time::Duration::from_millis(multicast_timeout_ms));
     env.deliver_msg(validator_peer_id);
     env.deliver_msg(fn_2_pfn_peer_id);
-    env.deliver_msg(fn_1_vfn_2_peer_id);
 
     // Verify that fullnode 0 broadcasts to the validator peer and both fallback peers
     let _ = execute_commit_and_verify_chunk_requests(
         &mut env,
         3,
-        &[fn_0_vfn_peer_id, fn_0_vfn_2_peer_id, fn_0_pfn_peer_id],
-        &[validator_peer_id, fn_1_vfn_2_peer_id, fn_2_pfn_peer_id],
+        &[fn_0_vfn_peer_id, fn_0_pfn_peer_id],
+        &[validator_peer_id, fn_2_pfn_peer_id],
         &[],
         true,
     );
 
     // Deliver chunks from the 3 nodes (PFN delivers before validator)
     env.deliver_msg(fn_2_pfn_peer_id);
-    env.deliver_msg(fn_1_vfn_2_peer_id);
     env.deliver_msg(validator_peer_id);
 
     // Verify that fullnode 0 still broadcasts to the validator peer and both fallback peers
     let _ = execute_commit_and_verify_chunk_requests(
         &mut env,
         4,
-        &[fn_0_vfn_peer_id, fn_0_vfn_2_peer_id, fn_0_pfn_peer_id],
-        &[validator_peer_id, fn_1_vfn_2_peer_id, fn_2_pfn_peer_id],
+        &[fn_0_vfn_peer_id, fn_0_pfn_peer_id],
+        &[validator_peer_id, fn_2_pfn_peer_id],
         &[],
         true,
     );
 
     // Deliver chunks from the 3 nodes (PFN delivers before validator)
     env.deliver_msg(fn_2_pfn_peer_id);
-    env.deliver_msg(fn_1_vfn_2_peer_id);
     env.deliver_msg(validator_peer_id);
 
     // Verify that fullnode 0 still broadcasts to the validator peer and both fallback peers
     let _ = execute_commit_and_verify_chunk_requests(
         &mut env,
         5,
-        &[fn_0_vfn_peer_id, fn_0_vfn_2_peer_id, fn_0_pfn_peer_id],
-        &[validator_peer_id, fn_1_vfn_2_peer_id, fn_2_pfn_peer_id],
+        &[fn_0_vfn_peer_id, fn_0_pfn_peer_id],
+        &[validator_peer_id, fn_2_pfn_peer_id],
         &[],
         true,
     );
 
     // Deliver chunks from all nodes (with the validator as the first responder)
     env.deliver_msg(validator_peer_id);
-    env.deliver_msg(fn_1_vfn_2_peer_id);
     env.deliver_msg(fn_2_pfn_peer_id);
 
     // Verify that fullnode 0 still broadcasts to the validator peer and both fallback peers
@@ -814,15 +801,14 @@ fn test_multicast_failover() {
     let _ = execute_commit_and_verify_chunk_requests(
         &mut env,
         6,
-        &[fn_0_vfn_peer_id, fn_0_vfn_2_peer_id, fn_0_pfn_peer_id],
-        &[validator_peer_id, fn_1_vfn_2_peer_id, fn_2_pfn_peer_id],
+        &[fn_0_vfn_peer_id, fn_0_pfn_peer_id],
+        &[validator_peer_id, fn_2_pfn_peer_id],
         &[],
         true,
     );
 
     // Deliver chunks from all nodes (with the validator as the first responder)
     env.deliver_msg(validator_peer_id);
-    env.deliver_msg(fn_1_vfn_2_peer_id);
     env.deliver_msg(fn_2_pfn_peer_id);
 
     // Verify that fullnode 0 now only broadcasts to the validator
@@ -831,7 +817,7 @@ fn test_multicast_failover() {
         7,
         &[fn_0_vfn_peer_id],
         &[validator_peer_id],
-        &[fn_0_vfn_2_peer_id, fn_0_pfn_peer_id],
+        &[fn_0_pfn_peer_id],
         true,
     );
 }

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -368,11 +368,7 @@ impl StateSyncEnvironment {
         } else {
             let peer = self.peers[index].borrow();
             let auth_mode = AuthenticationMode::Mutual(peer.network_key.clone());
-            let network_context = Arc::new(NetworkContext::new(
-                *role,
-                NetworkId::Validator,
-                peer.peer_id,
-            ));
+            let network_context = NetworkContext::new(*role, NetworkId::Validator, peer.peer_id);
 
             let seeds: HashMap<_, _> = self
                 .peers

--- a/testsuite/generate-format/tests/staged/network.yaml
+++ b/testsuite/generate-format/tests/staged/network.yaml
@@ -51,6 +51,10 @@ NetworkId:
     2:
       private:
         NEWTYPE: STR
+    3:
+      vfn: UNIT
+    4:
+      new_public: UNIT
 NetworkMessage:
   ENUM:
     0:


### PR DESCRIPTION
## Motivation

I made a mistake when I first created NetworkId, making it have to be cloned everywhere because of the contained string.  This made it more unwieldy and a bunch of extra work around using the NetworkId.

Now, we can copy and make everything much easier, no longer copying around the string "vfn".  Additionally, cleans up some code and we are able to get rid of the `Arc<NetworkContext>` to just `NetworkContext`.

## Migration Plan

1. Deploy all validators and VFNs with this version (serializing to old format).
2. Change code to output serialization to new format
3. Remove old format compatibility (or even move to using the `Invalid` slot instead of the current `Vfn` slot for readability purposes

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Take a look at my backwards compatible tests for serialization.  They cause some pain around having an unused value in the enum, but everything works outside of that!

## Related PRs

Related to https://github.com/diem/diem/pull/9191 and thinking about how we can standardize identifiers across networks.  This PR definitely is blocked on that one (due to the ton of merge conflicts that are going to happen