### PR TITLE
[diemdb] add API get_transaction_by_hash

### DIFF
--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -102,6 +102,15 @@ impl DbReader<DpnProto> for FakeDb {
         unimplemented!();
     }
 
+    fn get_transaction_by_hash(
+        &self,
+        _hash: HashValue,
+        _ledger_version: Version,
+        _fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
     fn get_events(
         &self,
         _event_key: &EventKey,

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -271,6 +271,15 @@ impl DbReader<DpnProto> for MockDiemDB {
         })
     }
 
+    fn get_transaction_by_hash(
+        &self,
+        _hash: HashValue,
+        _ledger_version: Version,
+        _fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
     fn get_events(
         &self,
         key: &EventKey,

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -396,6 +396,15 @@ impl DbReader<DpnProto> for MockDbReaderWriter {
         })
     }
 
+    fn get_transaction_by_hash(
+        &self,
+        _hash: HashValue,
+        _ledger_version: Version,
+        _fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
     /// Returns events by given event key
     fn get_events(
         &self,

--- a/storage/diemdb/src/diemdb_test.rs
+++ b/storage/diemdb/src/diemdb_test.rs
@@ -482,6 +482,17 @@ fn verify_committed_transactions(
         // Fetch and verify transaction itself.
         let txn = txn_to_commit.transaction().as_signed_user_txn().unwrap();
         let txn_with_proof = db
+            .get_transaction_by_hash(txn_to_commit.transaction().hash(), ledger_version, true)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            txn_with_proof.transaction.hash(),
+            txn_to_commit.transaction().hash()
+        );
+        txn_with_proof
+            .verify_user_txn(ledger_info, cur_ver, txn.sender(), txn.sequence_number())
+            .unwrap();
+        let txn_with_proof = db
             .get_transaction_with_proof(cur_ver, ledger_version, true)
             .unwrap();
         txn_with_proof

--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -701,6 +701,19 @@ impl DbReader<DpnProto> for DiemDB {
         })
     }
 
+    /// This API is best-effort in that it CANNOT provide absense proof.
+    fn get_transaction_by_hash(
+        &self,
+        hash: HashValue,
+        ledger_version: Version,
+        fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof>> {
+        self.transaction_store
+            .get_transaction_version_by_hash(&hash, ledger_version)?
+            .map(|v| self.get_transaction_with_proof(v, ledger_version, fetch_events))
+            .transpose()
+    }
+
     // ======================= State Synchronizer Internal APIs ===================================
     /// Gets a batch of transactions for the purpose of synchronizing state to another node.
     ///

--- a/storage/storage-client/src/lib.rs
+++ b/storage/storage-client/src/lib.rs
@@ -161,6 +161,15 @@ impl DbReader<DpnProto> for StorageClient {
         unimplemented!()
     }
 
+    fn get_transaction_by_hash(
+        &self,
+        _hash: HashValue,
+        _ledger_version: Version,
+        _fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
     fn get_events(
         &self,
         _key: &EventKey,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -191,6 +191,16 @@ pub trait DbReader<PS: ProtocolSpec>: Send + Sync {
         fetch_events: bool,
     ) -> Result<TransactionListWithProof<PS::TransactionInfo>>;
 
+    /// See [`DiemDB::get_transaction_by_hash`].
+    ///
+    /// [`DiemDB::get_transaction_by_hash`]: ../diemdb/struct.DiemDB.html#method.get_transaction_by_hash
+    fn get_transaction_by_hash(
+        &self,
+        hash: HashValue,
+        ledger_version: Version,
+        fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof<PS::TransactionInfo>>>;
+
     /// Returns events by given event key
     fn get_events(
         &self,

--- a/storage/storage-interface/src/mock.rs
+++ b/storage/storage-interface/src/mock.rs
@@ -50,6 +50,15 @@ impl DbReader<DpnProto> for MockDbReaderWriter {
         unimplemented!()
     }
 
+    fn get_transaction_by_hash(
+        &self,
+        _hash: HashValue,
+        _ledger_version: Version,
+        _fetch_events: bool,
+    ) -> Result<Option<TransactionWithProof>> {
+        unimplemented!()
+    }
+
     /// Returns events by given event key
     fn get_events(
         &self,


### PR DESCRIPTION
## Motivation

Store the hash->version to db and add the API to get the transaction by hash.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

current coverage.

