### PR TITLE
[move-prover] Do not generate or use inline attr for uninterpreted functions

### DIFF
--- a/language/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/language/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -553,9 +553,9 @@ function {:inline} $1_Signer_spec_address_of(signer: $signer): int
     $addr#$signer(signer)
 }
 
-function {:inline} $1_Signer_is_txn_signer(s: $signer): bool;
+function $1_Signer_is_txn_signer(s: $signer): bool;
 
-function {:inline} $1_Signer_is_txn_signer_addr(a: int): bool;
+function $1_Signer_is_txn_signer_addr(a: int): bool;
 
 
 // ==================================================================================

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -269,9 +269,11 @@ impl<'env> SpecTranslator<'env> {
         self.writer.set_location(&fun.loc);
         let boogie_name = boogie_spec_fun_name(module_env, id, &self.type_inst);
         let param_list = mem_params.chain(params).join(", ");
+        let attrs = if fun.uninterpreted { "" } else { "{:inline}" };
         emit!(
             self.writer,
-            "function {{:inline}} {}({}): {}",
+            "function {} {}({}): {}",
+            attrs,
             boogie_name,
             param_list,
             result_type


### PR DESCRIPTION
Both the code generator attached a `{:inline}` attribute to uninterpreted user spec functions, as well as the prelude declared is_txn_signer like this.

Closes #8995.

## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Manual

## Related PRs

NA