### PR TITLE
[api] add the api integration/smoke tests to smoke-test suite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7807,6 +7807,7 @@ dependencies = [
  "proptest",
  "rand 0.8.3",
  "regex",
+ "reqwest",
  "serde_yaml",
  "tokio",
  "walkdir",

--- a/api/README.md
+++ b/api/README.md
@@ -1,3 +1,12 @@
 # API
 
 This module provides REST API for client applications to query the Diem blockchain.
+
+
+## Testing
+
+Run integration/smoke tests in `testsuite/smoke-test`
+
+```
+cargo test --test "forge" "api::"
+```

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -79,7 +79,7 @@ pub struct NodeConfig {
     pub metrics: DeprecatedConfig,
     #[serde(default)]
     pub json_rpc: JsonRpcConfig,
-    #[serde(default, skip_serializing)]
+    #[serde(default)]
     pub api: ApiConfig,
     #[serde(default)]
     pub state_sync: StateSyncConfig,

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -15,6 +15,7 @@ bcs = "0.1.2"
 proptest = "1.0.0"
 tokio = { version = "1.8.1", features = ["full"] }
 walkdir = "2.3.1"
+reqwest = { version = "0.11.2", features = ["json"] }
 
 compiler = { path = "../../language/compiler" }
 diem-config = { path = "../../config" }

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod event_fetcher;
 pub mod fullnode;
 pub mod replay_tooling;
+pub mod rest_api;
 pub mod scripts_and_modules;
 pub mod transaction;
 pub mod verifying_client;

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -1,0 +1,21 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use forge::{PublicUsageContext, PublicUsageTest, Result, Test};
+
+pub struct GetIndex;
+
+impl Test for GetIndex {
+    fn name(&self) -> &'static str {
+        "api::get-index"
+    }
+}
+
+impl PublicUsageTest for GetIndex {
+    fn run<'t>(&self, ctx: &mut PublicUsageContext<'t>) -> Result<()> {
+        let resp = reqwest::blocking::get(ctx.rest_api_url().to_owned())?;
+        assert_eq!(reqwest::StatusCode::OK, resp.status());
+
+        Ok(())
+    }
+}

--- a/testsuite/smoke-test/tests/forge.rs
+++ b/testsuite/smoke-test/tests/forge.rs
@@ -6,6 +6,7 @@ use smoke_test::{
     event_fetcher::EventFetcher,
     fullnode::LaunchFullnode,
     replay_tooling::ReplayTooling,
+    rest_api::GetIndex,
     scripts_and_modules::{ExecuteCustomModuleAndScript, MalformedScript},
     transaction::ExternalTransactionSigner,
     verifying_client::{VerifyingClientEquivalence, VerifyingGetLatestMetadata, VerifyingSubmit},
@@ -20,6 +21,7 @@ fn main() -> Result<()> {
             &VerifyingSubmit,
             &VerifyingClientEquivalence,
             &VerifyingGetLatestMetadata,
+            &GetIndex,
         ])
         .with_admin_tests(&[&MalformedScript, &ExecuteCustomModuleAndScript])
         .with_network_tests(&[&LaunchFullnode]);


### PR DESCRIPTION
Add one simple api integration test to ensure diem-node integration works as expected.

see #9193 for more context of new api service.

## Related PRs

#9144
