### PR TITLE
[forge] Always scale down cluster first before each test run

### DIFF
--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -97,8 +97,9 @@ impl Factory for K8sFactory {
         node_num: NonZeroUsize,
         version: &Version,
     ) -> Result<Box<dyn Swarm>> {
-        set_eks_nodegroup_size(self.cluster_name.clone(), node_num.get(), true)?;
         uninstall_from_k8s_cluster()?;
+        set_eks_nodegroup_size(self.cluster_name.clone(), 0, true)?;
+        set_eks_nodegroup_size(self.cluster_name.clone(), node_num.get(), true)?;
         clean_k8s_cluster(
             self.helm_repo.clone(),
             node_num.get(),


### PR DESCRIPTION
Sometimes, post test cleanup may accidentally get into faulty status. We should always scale down cluster first before test as well to prevent this case not affect subsequent test run

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
