### PR TITLE
[move-prover] Move generation of well-formed assumptions into its own processor

### DIFF
--- a/language/move-prover/bytecode/src/function_data_builder.rs
+++ b/language/move-prover/bytecode/src/function_data_builder.rs
@@ -180,6 +180,11 @@ impl<'env> FunctionDataBuilder<'env> {
         self.emit(f(attr_id))
     }
 
+    /// Emits a Bytecode::Prop based on given kind and expression.
+    pub fn emit_prop(&mut self, kind: PropKind, exp: Exp) {
+        self.emit_with(move |id| Bytecode::Prop(id, kind, exp));
+    }
+
     /// Sets the debug comment which should be associated with the next instruction
     /// emitted with `self.emit_with(|id| ..)`.
     pub fn set_next_debug_comment(&mut self, comment: String) {

--- a/language/move-prover/bytecode/src/lib.rs
+++ b/language/move-prover/bytecode/src/lib.rs
@@ -43,6 +43,7 @@ pub mod stackless_control_flow_graph;
 pub mod usage_analysis;
 pub mod verification_analysis;
 pub mod verification_analysis_v2;
+pub mod well_formed_instrumentation;
 
 /// Print function targets for testing and debugging.
 pub fn print_targets_for_test(

--- a/language/move-prover/bytecode/src/pipeline_factory.rs
+++ b/language/move-prover/bytecode/src/pipeline_factory.rs
@@ -22,6 +22,7 @@ use crate::{
     spec_instrumentation::SpecInstrumentationProcessor,
     usage_analysis::UsageProcessor,
     verification_analysis::VerificationAnalysisProcessor,
+    well_formed_instrumentation::WellFormedInstrumentationProcessor,
 };
 
 pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetPipeline {
@@ -41,9 +42,11 @@ pub fn default_pipeline_with_options(options: &ProverOptions) -> FunctionTargetP
         LoopAnalysisProcessor::new(),
         // spec instrumentation
         SpecInstrumentationProcessor::new(),
-        DataInvariantInstrumentationProcessor::new(),
         GlobalInvariantAnalysisProcessor::new(),
         GlobalInvariantInstrumentationProcessor::new(),
+        WellFormedInstrumentationProcessor::new(),
+        DataInvariantInstrumentationProcessor::new(),
+        // monomorphization
         MonoAnalysisProcessor::new(),
     ];
 

--- a/language/move-prover/bytecode/src/usage_analysis.rs
+++ b/language/move-prover/bytecode/src/usage_analysis.rs
@@ -297,7 +297,7 @@ impl<'a> TransferFunctions for MemoryUsageAnalysis<'a> {
 }
 
 impl<'a> MemoryUsageAnalysis<'a> {
-    /// Compute usage information for the given spec. This spec is injected in later
+    /// Compute usage information for the given spec. This spec maybe injected in later
     /// phases into the code, but we need to account for it's memory usage already here
     /// as spec injection itself depends on this information.
     fn compute_spec_usage(&self, spec: &Spec, state: &mut UsageState) {

--- a/language/move-prover/bytecode/src/well_formed_instrumentation.rs
+++ b/language/move-prover/bytecode/src/well_formed_instrumentation.rs
@@ -1,0 +1,125 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transformation which injects well-formed assumptions at top-level entry points of verified
+//! functions. These assumptions are both about parameters and any memory referred to by
+//! the code. For ghost memory, the transformation also assumes initial values if provided.
+//!
+//! This needs to be run *after* function specifications and global invariants have been
+//! injected because only then we know all accessed memory.
+//!
+//! This phase need to be run *before* data invariant instrumentation, because the latter relies
+//! on the well-formed assumptions, augmenting them with the data invariant.
+//! Because data invariants cannot refer to global memory, they are not relevant for memory
+//! usage, and their injection therefore can happen after this phase.
+
+use crate::{
+    function_data_builder::FunctionDataBuilder,
+    function_target::FunctionData,
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::PropKind,
+    usage_analysis::UsageProcessor,
+};
+use move_model::{
+    ast::{Operation, QuantKind},
+    exp_generator::ExpGenerator,
+    model::FunctionEnv,
+    ty::BOOL_TYPE,
+};
+use num::{BigUint, Zero};
+
+pub struct WellFormedInstrumentationProcessor {}
+
+impl WellFormedInstrumentationProcessor {
+    pub fn new() -> Box<Self> {
+        Box::new(Self {})
+    }
+}
+
+impl FunctionTargetProcessor for WellFormedInstrumentationProcessor {
+    fn process(
+        &self,
+        targets: &mut FunctionTargetsHolder,
+        fun_env: &FunctionEnv<'_>,
+        data: FunctionData,
+    ) -> FunctionData {
+        if !data.variant.is_verified() {
+            // only need to do this for verified functions
+            return data;
+        }
+        // Rerun usage analysis for this function.
+        let usage = UsageProcessor::analyze(targets, fun_env, &data);
+        let mut builder = FunctionDataBuilder::new(fun_env, data);
+        builder.set_loc(fun_env.get_loc().at_start());
+        let old_code = std::mem::take(&mut builder.data.code);
+
+        // Inject well-formedness assumptions for parameters.
+        for param in 0..builder.fun_env.get_parameter_count() {
+            let exp = builder.mk_call(
+                &BOOL_TYPE,
+                Operation::WellFormed,
+                vec![builder.mk_temporary(param)],
+            );
+            builder.emit_prop(PropKind::Assume, exp);
+        }
+
+        // Inject well-formedness assumption for used memory.
+        for mem in usage.accessed.all.clone() {
+            let struct_env = builder.global_env().get_struct_qid(mem.to_qualified_id());
+            if struct_env.is_native_or_intrinsic() {
+                // If this is native or intrinsic memory, skip this.
+                continue;
+            }
+            let exp = builder
+                .mk_inst_mem_quant_opt(QuantKind::Forall, &mem, &mut |val| {
+                    Some(builder.mk_call(&BOOL_TYPE, Operation::WellFormed, vec![val]))
+                })
+                .expect("quant defined");
+            builder.emit_prop(PropKind::Assume, exp);
+
+            // If this is ghost memory, assume it exists, and if it has an initializer,
+            // assume it has this value.
+            if let Some(spec_var) = struct_env.get_ghost_memory_spec_var() {
+                let mem_ty = mem.to_type();
+                let zero_addr = builder.mk_address_const(BigUint::zero());
+                let exists = builder.mk_call_with_inst(
+                    &BOOL_TYPE,
+                    vec![mem_ty.clone()],
+                    Operation::Exists(None),
+                    vec![zero_addr.clone()],
+                );
+                builder.emit_prop(PropKind::Assume, exists);
+                let svar_module = builder.global_env().get_module(spec_var.module_id);
+                let svar = svar_module.get_spec_var(spec_var.id);
+                if let Some(init) = &svar.init {
+                    let mem_val = builder.mk_call_with_inst(
+                        &mem_ty,
+                        mem.inst.clone(),
+                        Operation::Pack(mem.module_id, mem.id),
+                        vec![init.clone()],
+                    );
+                    let mem_access = builder.mk_call_with_inst(
+                        &mem_ty,
+                        vec![mem_ty.clone()],
+                        Operation::Global(None),
+                        vec![zero_addr],
+                    );
+                    let eq_with_init =
+                        builder.mk_bool_call(Operation::Identical, vec![mem_access, mem_val]);
+                    builder.emit_prop(PropKind::Assume, eq_with_init);
+                }
+            }
+        }
+
+        // Append the old code
+        for bc in old_code {
+            builder.emit(bc);
+        }
+
+        builder.data
+    }
+
+    fn name(&self) -> String {
+        "entry_point_instrumenter".to_string()
+    }
+}

--- a/language/move-prover/bytecode/tests/global_invariant_analysis/disable_in_body.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_analysis/disable_in_body.exp
@@ -19,15 +19,13 @@ fun DisableInv::foo($t0|s: signer) {
      var $t1: bool
      var $t2: DisableInv::R2
      var $t3: num
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<DisableInv::R2>(): WellFormed($rsc)
-  2: $t1 := false
-  3: $t2 := pack DisableInv::R2($t1)
-  4: move_to<DisableInv::R2>($t2, $t0) on_abort goto 7 with $t3
-  5: label L1
-  6: return ()
-  7: label L2
-  8: abort($t3)
+  0: $t1 := false
+  1: $t2 := pack DisableInv::R2($t1)
+  2: move_to<DisableInv::R2>($t2, $t0) on_abort goto 5 with $t3
+  3: label L1
+  4: return ()
+  5: label L2
+  6: abort($t3)
 }
 
 
@@ -41,7 +39,7 @@ DisableInv::foo: [
       ]
     ]
   }
-  4: move_to<DisableInv::R2>($t2, $t0) on_abort goto L2 with $t3 {}
+  2: move_to<DisableInv::R2>($t2, $t0) on_abort goto L2 with $t3 {}
   exitpoint {
     assert @0 = [
       <> -> [

--- a/language/move-prover/bytecode/tests/global_invariant_analysis/mutual_inst.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_analysis/mutual_inst.exp
@@ -94,17 +94,13 @@ public fun S::publish_u64_bool($t0|account: signer, $t1|x: u64, $t2|y: bool) {
      var $t3: u8
      var $t4: S::Storage<u64, bool>
      var $t5: num
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume WellFormed($t2)
-  3: assume forall $rsc: ResourceDomain<S::Storage<u64, bool>>(): WellFormed($rsc)
-  4: $t3 := 0
-  5: $t4 := pack S::Storage<u64, bool>($t1, $t2, $t3)
-  6: move_to<S::Storage<u64, bool>>($t4, $t0) on_abort goto 9 with $t5
-  7: label L1
-  8: return ()
-  9: label L2
- 10: abort($t5)
+  0: $t3 := 0
+  1: $t4 := pack S::Storage<u64, bool>($t1, $t2, $t3)
+  2: move_to<S::Storage<u64, bool>>($t4, $t0) on_abort goto 5 with $t5
+  3: label L1
+  4: return ()
+  5: label L2
+  6: abort($t5)
 }
 
 
@@ -113,17 +109,13 @@ public fun S::publish_u64_y<#0>($t0|account: signer, $t1|x: u64, $t2|y: #0) {
      var $t3: u8
      var $t4: S::Storage<u64, #0>
      var $t5: num
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume WellFormed($t2)
-  3: assume forall $rsc: ResourceDomain<S::Storage<u64, #0>>(): WellFormed($rsc)
-  4: $t3 := 1
-  5: $t4 := pack S::Storage<u64, #0>($t1, $t2, $t3)
-  6: move_to<S::Storage<u64, #0>>($t4, $t0) on_abort goto 9 with $t5
-  7: label L1
-  8: return ()
-  9: label L2
- 10: abort($t5)
+  0: $t3 := 1
+  1: $t4 := pack S::Storage<u64, #0>($t1, $t2, $t3)
+  2: move_to<S::Storage<u64, #0>>($t4, $t0) on_abort goto 5 with $t5
+  3: label L1
+  4: return ()
+  5: label L2
+  6: abort($t5)
 }
 
 
@@ -132,17 +124,13 @@ public fun S::publish_x_bool<#0>($t0|account: signer, $t1|x: #0, $t2|y: bool) {
      var $t3: u8
      var $t4: S::Storage<#0, bool>
      var $t5: num
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume WellFormed($t2)
-  3: assume forall $rsc: ResourceDomain<S::Storage<#0, bool>>(): WellFormed($rsc)
-  4: $t3 := 2
-  5: $t4 := pack S::Storage<#0, bool>($t1, $t2, $t3)
-  6: move_to<S::Storage<#0, bool>>($t4, $t0) on_abort goto 9 with $t5
-  7: label L1
-  8: return ()
-  9: label L2
- 10: abort($t5)
+  0: $t3 := 2
+  1: $t4 := pack S::Storage<#0, bool>($t1, $t2, $t3)
+  2: move_to<S::Storage<#0, bool>>($t4, $t0) on_abort goto 5 with $t5
+  3: label L1
+  4: return ()
+  5: label L2
+  6: abort($t5)
 }
 
 
@@ -166,17 +154,13 @@ public fun S::publish_x_y<#0, #1>($t0|account: signer, $t1|x: #0, $t2|y: #1) {
      var $t3: u8
      var $t4: S::Storage<#0, #1>
      var $t5: num
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume WellFormed($t2)
-  3: assume forall $rsc: ResourceDomain<S::Storage<#0, #1>>(): WellFormed($rsc)
-  4: $t3 := 3
-  5: $t4 := pack S::Storage<#0, #1>($t1, $t2, $t3)
-  6: move_to<S::Storage<#0, #1>>($t4, $t0) on_abort goto 9 with $t5
-  7: label L1
-  8: return ()
-  9: label L2
- 10: abort($t5)
+  0: $t3 := 3
+  1: $t4 := pack S::Storage<#0, #1>($t1, $t2, $t3)
+  2: move_to<S::Storage<#0, #1>>($t4, $t0) on_abort goto 5 with $t5
+  3: label L1
+  4: return ()
+  5: label L2
+  6: abort($t5)
 }
 
 
@@ -187,19 +171,16 @@ public fun A::good($t0|account1: signer, $t1|account2: signer) {
      var $t4: num
      var $t5: u64
      var $t6: bool
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume forall $rsc: ResourceDomain<S::Storage<u64, bool>>(): WellFormed($rsc)
-  3: $t2 := 1
-  4: $t3 := true
-  5: S::publish_x_y<u64, bool>($t0, $t2, $t3) on_abort goto 11 with $t4
-  6: $t5 := 1
-  7: $t6 := true
-  8: S::publish_x_y<u64, bool>($t1, $t5, $t6) on_abort goto 11 with $t4
-  9: label L1
- 10: return ()
- 11: label L2
- 12: abort($t4)
+  0: $t2 := 1
+  1: $t3 := true
+  2: S::publish_x_y<u64, bool>($t0, $t2, $t3) on_abort goto 8 with $t4
+  3: $t5 := 1
+  4: $t6 := true
+  5: S::publish_x_y<u64, bool>($t1, $t5, $t6) on_abort goto 8 with $t4
+  6: label L1
+  7: return ()
+  8: label L2
+  9: abort($t4)
 }
 
 
@@ -228,7 +209,7 @@ S::publish_u64_bool: [
       ]
     ]
   }
-  6: move_to<S::Storage<u64, bool>>($t4, $t0) on_abort goto L2 with $t5 {
+  2: move_to<S::Storage<u64, bool>>($t4, $t0) on_abort goto L2 with $t5 {
     assert @0 = [
       <> -> [
         <>
@@ -275,7 +256,7 @@ S::publish_u64_y: [
       ]
     ]
   }
-  6: move_to<S::Storage<u64, #0>>($t4, $t0) on_abort goto L2 with $t5 {
+  2: move_to<S::Storage<u64, #0>>($t4, $t0) on_abort goto L2 with $t5 {
     assert @0 = [
       <bool> -> [
         <>
@@ -322,7 +303,7 @@ S::publish_x_bool: [
       ]
     ]
   }
-  6: move_to<S::Storage<#0, bool>>($t4, $t0) on_abort goto L2 with $t5 {
+  2: move_to<S::Storage<#0, bool>>($t4, $t0) on_abort goto L2 with $t5 {
     assert @0 = [
       <u64> -> [
         <>
@@ -369,7 +350,7 @@ S::publish_x_y: [
       ]
     ]
   }
-  6: move_to<S::Storage<#0, #1>>($t4, $t0) on_abort goto L2 with $t5 {
+  2: move_to<S::Storage<#0, #1>>($t4, $t0) on_abort goto L2 with $t5 {
     assert @0 = [
       <u64, bool> -> [
         <>

--- a/language/move-prover/bytecode/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
@@ -56,37 +56,34 @@ fun Demo::f1($t0|addr: address) {
      var $t7: u8
      var $t8: &mut Demo::S1<u64>
      var $t9: &mut u8
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<Demo::S1<bool>>(): WellFormed($rsc)
-  2: assume forall $rsc: ResourceDomain<Demo::S1<u64>>(): WellFormed($rsc)
-  3: $t1 := exists<Demo::S1<bool>>($t0)
-  4: if ($t1) goto 7 else goto 5
-  5: label L1
-  6: goto 14
-  7: label L0
-  8: $t2 := 0
-  9: $t3 := borrow_global<Demo::S1<bool>>($t0) on_abort goto 29 with $t4
- 10: $t5 := borrow_field<Demo::S1<bool>>.v($t3)
- 11: write_ref($t5, $t2)
- 12: write_back[Reference($t3).v (u8)]($t5)
- 13: write_back[Demo::S1<bool>@]($t3)
- 14: label L2
- 15: $t6 := exists<Demo::S1<u64>>($t0)
- 16: if ($t6) goto 19 else goto 17
- 17: label L4
- 18: goto 26
- 19: label L3
- 20: $t7 := 0
- 21: $t8 := borrow_global<Demo::S1<u64>>($t0) on_abort goto 29 with $t4
- 22: $t9 := borrow_field<Demo::S1<u64>>.v($t8)
- 23: write_ref($t9, $t7)
- 24: write_back[Reference($t8).v (u8)]($t9)
- 25: write_back[Demo::S1<u64>@]($t8)
- 26: label L5
- 27: label L6
- 28: return ()
- 29: label L7
- 30: abort($t4)
+  0: $t1 := exists<Demo::S1<bool>>($t0)
+  1: if ($t1) goto 4 else goto 2
+  2: label L1
+  3: goto 11
+  4: label L0
+  5: $t2 := 0
+  6: $t3 := borrow_global<Demo::S1<bool>>($t0) on_abort goto 26 with $t4
+  7: $t5 := borrow_field<Demo::S1<bool>>.v($t3)
+  8: write_ref($t5, $t2)
+  9: write_back[Reference($t3).v (u8)]($t5)
+ 10: write_back[Demo::S1<bool>@]($t3)
+ 11: label L2
+ 12: $t6 := exists<Demo::S1<u64>>($t0)
+ 13: if ($t6) goto 16 else goto 14
+ 14: label L4
+ 15: goto 23
+ 16: label L3
+ 17: $t7 := 0
+ 18: $t8 := borrow_global<Demo::S1<u64>>($t0) on_abort goto 26 with $t4
+ 19: $t9 := borrow_field<Demo::S1<u64>>.v($t8)
+ 20: write_ref($t9, $t7)
+ 21: write_back[Reference($t8).v (u8)]($t9)
+ 22: write_back[Demo::S1<u64>@]($t8)
+ 23: label L5
+ 24: label L6
+ 25: return ()
+ 26: label L7
+ 27: abort($t4)
 }
 
 
@@ -101,14 +98,14 @@ Demo::f1: [
       ]
     ]
   }
-  13: write_back[Demo::S1<bool>@]($t3) {
+  10: write_back[Demo::S1<bool>@]($t3) {
     assert @0 = [
       <> -> [
         <bool, *error*>
       ]
     ]
   }
-  25: write_back[Demo::S1<u64>@]($t8) {
+  22: write_back[Demo::S1<u64>@]($t8) {
     assert @0 = [
       <> -> [
         <u64, *error*>

--- a/language/move-prover/bytecode/tests/global_invariant_instrumentation/borrow.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_instrumentation/borrow.exp
@@ -39,21 +39,19 @@ public fun Test::borrow($t0|a: address) {
      var $t7: &mut u64
      # global invariant at tests/global_invariant_instrumentation/borrow.move:7:9+57
   0: assume forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
-  1: assume WellFormed($t0)
-  2: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
-  3: $t2 := borrow_global<Test::R>($t0) on_abort goto 14 with $t3
-  4: $t4 := get_field<Test::R>.x($t2)
-  5: $t5 := 1
-  6: $t6 := +($t4, $t5) on_abort goto 14 with $t3
-  7: $t7 := borrow_field<Test::R>.x($t2)
-  8: write_ref($t7, $t6)
-  9: write_back[Reference($t2).x (u64)]($t7)
- 10: write_back[Test::R@]($t2)
+  1: $t2 := borrow_global<Test::R>($t0) on_abort goto 12 with $t3
+  2: $t4 := get_field<Test::R>.x($t2)
+  3: $t5 := 1
+  4: $t6 := +($t4, $t5) on_abort goto 12 with $t3
+  5: $t7 := borrow_field<Test::R>.x($t2)
+  6: write_ref($t7, $t6)
+  7: write_back[Reference($t2).x (u64)]($t7)
+  8: write_back[Test::R@]($t2)
      # global invariant at tests/global_invariant_instrumentation/borrow.move:7:9+57
      # VC: global memory invariant does not hold at tests/global_invariant_instrumentation/borrow.move:7:9+57
- 11: assert forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
- 12: label L1
- 13: return ()
- 14: label L2
- 15: abort($t3)
+  9: assert forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
+ 10: label L1
+ 11: return ()
+ 12: label L2
+ 13: abort($t3)
 }

--- a/language/move-prover/bytecode/tests/global_invariant_instrumentation/move.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_instrumentation/move.exp
@@ -31,18 +31,16 @@ public fun Test::publish($t0|s: signer) {
      var $t3: num
      # global invariant at tests/global_invariant_instrumentation/move.move:7:9+57
   0: assume forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
-  1: assume WellFormed($t0)
-  2: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
-  3: $t1 := 1
-  4: $t2 := pack Test::R($t1)
-  5: move_to<Test::R>($t2, $t0) on_abort goto 9 with $t3
+  1: $t1 := 1
+  2: $t2 := pack Test::R($t1)
+  3: move_to<Test::R>($t2, $t0) on_abort goto 7 with $t3
      # global invariant at tests/global_invariant_instrumentation/move.move:7:9+57
      # VC: global memory invariant does not hold at tests/global_invariant_instrumentation/move.move:7:9+57
-  6: assert forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
-  7: label L1
-  8: return ()
-  9: label L2
- 10: abort($t3)
+  4: assert forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
+  5: label L1
+  6: return ()
+  7: label L2
+  8: abort($t3)
 }
 
 
@@ -52,14 +50,12 @@ public fun Test::remove($t0|a: address): Test::R {
      var $t2: num
      # global invariant at tests/global_invariant_instrumentation/move.move:7:9+57
   0: assume forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
-  1: assume WellFormed($t0)
-  2: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
-  3: $t1 := move_from<Test::R>($t0) on_abort goto 7 with $t2
+  1: $t1 := move_from<Test::R>($t0) on_abort goto 5 with $t2
      # global invariant at tests/global_invariant_instrumentation/move.move:7:9+57
      # VC: global memory invariant does not hold at tests/global_invariant_instrumentation/move.move:7:9+57
-  4: assert forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
-  5: label L1
-  6: return $t1
-  7: label L2
-  8: abort($t2)
+  2: assert forall a: TypeDomain<address>(): Gt(select Test::R.x(global<Test::R>(a)), 0)
+  3: label L1
+  4: return $t1
+  5: label L2
+  6: abort($t2)
 }

--- a/language/move-prover/bytecode/tests/global_invariant_instrumentation/update.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_instrumentation/update.exp
@@ -37,23 +37,21 @@ public fun Test::incr($t0|a: address) {
      var $t5: u64
      var $t6: u64
      var $t7: &mut u64
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
-  2: $t2 := borrow_global<Test::R>($t0) on_abort goto 14 with $t3
-  3: $t4 := get_field<Test::R>.x($t2)
-  4: $t5 := 1
-  5: $t6 := +($t4, $t5) on_abort goto 14 with $t3
-  6: $t7 := borrow_field<Test::R>.x($t2)
-  7: write_ref($t7, $t6)
-  8: write_back[Reference($t2).x (u64)]($t7)
+  0: $t2 := borrow_global<Test::R>($t0) on_abort goto 12 with $t3
+  1: $t4 := get_field<Test::R>.x($t2)
+  2: $t5 := 1
+  3: $t6 := +($t4, $t5) on_abort goto 12 with $t3
+  4: $t7 := borrow_field<Test::R>.x($t2)
+  5: write_ref($t7, $t6)
+  6: write_back[Reference($t2).x (u64)]($t7)
      # state save for global update invariants
-  9: @1 := save_mem(Test::R)
- 10: write_back[Test::R@]($t2)
+  7: @1 := save_mem(Test::R)
+  8: write_back[Test::R@]($t2)
      # global invariant at tests/global_invariant_instrumentation/update.move:7:9+82
      # VC: global memory invariant does not hold at tests/global_invariant_instrumentation/update.move:7:9+82
- 11: assert forall a: TypeDomain<address>(): Lt(select Test::R.x(global[@1]<Test::R>(a)), select Test::R.x(global<Test::R>(a)))
- 12: label L1
- 13: return ()
- 14: label L2
- 15: abort($t3)
+  9: assert forall a: TypeDomain<address>(): Lt(select Test::R.x(global[@1]<Test::R>(a)), select Test::R.x(global<Test::R>(a)))
+ 10: label L1
+ 11: return ()
+ 12: label L2
+ 13: abort($t3)
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -176,32 +176,29 @@ fun Test::resource_with_old($t0|val: u64) {
 fun Test::branching_result($t0|is_div: bool, $t1|a: u64, $t2|b: u64): u64 {
      var $t3|tmp#$3: u64
      var $t4: num
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume WellFormed($t2)
-  3: if ($t0) goto 6 else goto 4
-  4: label L1
-  5: goto 9
-  6: label L0
-  7: $t3 := /($t1, $t2) on_abort goto 17 with $t4
-  8: goto 11
-  9: label L2
- 10: $t3 := *($t1, $t2) on_abort goto 17 with $t4
- 11: label L3
- 12: label L4
+  0: if ($t0) goto 3 else goto 1
+  1: label L1
+  2: goto 6
+  3: label L0
+  4: $t3 := /($t1, $t2) on_abort goto 14 with $t4
+  5: goto 8
+  6: label L2
+  7: $t3 := *($t1, $t2) on_abort goto 14 with $t4
+  8: label L3
+  9: label L4
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:27:6+50
- 13: assert Not(And($t0, Eq<u64>($t2, 0)))
+ 10: assert Not(And($t0, Eq<u64>($t2, 0)))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:28:6+35
- 14: assert Implies($t0, Eq<u64>($t3, Div($t1, $t2)))
+ 11: assert Implies($t0, Eq<u64>($t3, Div($t1, $t2)))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:29:6+36
- 15: assert Implies(Not($t0), Eq<u64>($t3, Mul($t1, $t2)))
- 16: return $t3
- 17: label L5
+ 12: assert Implies(Not($t0), Eq<u64>($t3, Mul($t1, $t2)))
+ 13: return $t3
+ 14: label L5
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/fun_spec.move:26:2+165
- 18: assert And($t0, Eq<u64>($t2, 0))
+ 15: assert And($t0, Eq<u64>($t2, 0))
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/fun_spec.move:26:2+165
- 19: assert And(And($t0, Eq<u64>($t2, 0)), Eq(-1, $t4))
- 20: abort($t4)
+ 16: assert And(And($t0, Eq<u64>($t2, 0)), Eq(-1, $t4))
+ 17: abort($t4)
 }
 
 
@@ -212,33 +209,31 @@ fun Test::implicit_and_explicit_abort($t0|a: u64, $t1|b: u64): u64 {
      var $t4: u64
      var $t5: num
      var $t6: u64
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: $t2 := 0
-  3: $t3 := !=($t1, $t2)
-  4: if ($t3) goto 7 else goto 5
-  5: label L1
-  6: goto 11
-  7: label L0
-  8: $t4 := 22
-  9: $t5 := move($t4)
- 10: goto 18
- 11: label L2
- 12: $t6 := /($t0, $t1) on_abort goto 18 with $t5
- 13: label L3
+  0: $t2 := 0
+  1: $t3 := !=($t1, $t2)
+  2: if ($t3) goto 5 else goto 3
+  3: label L1
+  4: goto 9
+  5: label L0
+  6: $t4 := 22
+  7: $t5 := move($t4)
+  8: goto 16
+  9: label L2
+ 10: $t6 := /($t0, $t1) on_abort goto 16 with $t5
+ 11: label L3
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:9:6+25
- 14: assert Not(Eq<u64>($t1, 0))
+ 12: assert Not(Eq<u64>($t1, 0))
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:10:6+17
- 15: assert Not(Eq<u64>($t0, 0))
+ 13: assert Not(Eq<u64>($t0, 0))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:11:6+24
- 16: assert Eq<u64>($t6, Div($t0, $t1))
- 17: return $t6
- 18: label L4
+ 14: assert Eq<u64>($t6, Div($t0, $t1))
+ 15: return $t6
+ 16: label L4
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/fun_spec.move:8:2+121
- 19: assert Or(Eq<u64>($t1, 0), Eq<u64>($t0, 0))
+ 17: assert Or(Eq<u64>($t1, 0), Eq<u64>($t0, 0))
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/fun_spec.move:8:2+121
- 20: assert Or(And(Eq<u64>($t1, 0), Eq(22, $t5)), Eq<u64>($t0, 0))
- 21: abort($t5)
+ 18: assert Or(And(Eq<u64>($t1, 0), Eq(22, $t5)), Eq<u64>($t0, 0))
+ 19: abort($t5)
 }
 
 
@@ -247,24 +242,22 @@ fun Test::multiple_results($t0|a: u64, $t1|b: u64): (u64, u64) {
      var $t2: u64
      var $t3: num
      var $t4: u64
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: $t2 := /($t0, $t1) on_abort goto 9 with $t3
-  3: $t4 := %($t0, $t1) on_abort goto 9 with $t3
-  4: label L1
+  0: $t2 := /($t0, $t1) on_abort goto 7 with $t3
+  1: $t4 := %($t0, $t1) on_abort goto 7 with $t3
+  2: label L1
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:18:6+40
-  5: assert Not(Eq<u64>($t1, 0))
+  3: assert Not(Eq<u64>($t1, 0))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:19:6+26
-  6: assert Eq<u64>($t2, Div($t0, $t1))
+  4: assert Eq<u64>($t2, Div($t0, $t1))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:20:6+26
-  7: assert Eq<u64>($t4, Mod($t0, $t1))
-  8: return ($t2, $t4)
-  9: label L2
+  5: assert Eq<u64>($t4, Mod($t0, $t1))
+  6: return ($t2, $t4)
+  7: label L2
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/fun_spec.move:17:2+136
- 10: assert Eq<u64>($t1, 0)
+  8: assert Eq<u64>($t1, 0)
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/fun_spec.move:17:2+136
- 11: assert And(Eq<u64>($t1, 0), Eq(-1, $t3))
- 12: abort($t3)
+  9: assert And(Eq<u64>($t1, 0), Eq(-1, $t3))
+ 10: abort($t3)
 }
 
 
@@ -278,54 +271,51 @@ fun Test::mut_ref_param($t0|r: &mut Test::R): u64 {
      var $t6: u64
      var $t7: num
      var $t8: &mut u64
-  0: assume WellFormed($t0)
-  1: $t2 := read_ref($t0)
-  2: $t3 := get_field<Test::R>.v($t0)
-  3: $t4 := get_field<Test::R>.v($t0)
-  4: $t5 := 1
-  5: $t6 := -($t4, $t5) on_abort goto 15 with $t7
-  6: $t8 := borrow_field<Test::R>.v($t0)
-  7: write_ref($t8, $t6)
-  8: write_back[Reference($t0).v (u64)]($t8)
-  9: trace_local[r]($t0)
- 10: label L1
+  0: $t2 := read_ref($t0)
+  1: $t3 := get_field<Test::R>.v($t0)
+  2: $t4 := get_field<Test::R>.v($t0)
+  3: $t5 := 1
+  4: $t6 := -($t4, $t5) on_abort goto 14 with $t7
+  5: $t8 := borrow_field<Test::R>.v($t0)
+  6: write_ref($t8, $t6)
+  7: write_back[Reference($t0).v (u64)]($t8)
+  8: trace_local[r]($t0)
+  9: label L1
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:67:6+42
- 11: assert Not(Eq<u64>(select Test::R.v($t2), 0))
+ 10: assert Not(Eq<u64>(select Test::R.v($t2), 0))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:68:6+27
- 12: assert Eq<u64>($t3, select Test::R.v($t2))
+ 11: assert Eq<u64>($t3, select Test::R.v($t2))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:69:6+28
- 13: assert Eq<u64>(select Test::R.v($t0), Add(select Test::R.v($t2), 1))
- 14: return $t3
- 15: label L2
+ 12: assert Eq<u64>(select Test::R.v($t0), Add(select Test::R.v($t2), 1))
+ 13: return $t3
+ 14: label L2
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/fun_spec.move:66:2+138
- 16: assert Eq<u64>(select Test::R.v($t2), 0)
+ 15: assert Eq<u64>(select Test::R.v($t2), 0)
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/fun_spec.move:66:2+138
- 17: assert And(Eq<u64>(select Test::R.v($t2), 0), Eq(-1, $t7))
- 18: abort($t7)
+ 16: assert And(Eq<u64>(select Test::R.v($t2), 0), Eq(-1, $t7))
+ 17: abort($t7)
 }
 
 
 [variant verification]
 fun Test::ref_param($t0|r: Test::R): u64 {
      var $t1: u64
-  0: assume WellFormed($t0)
-  1: $t1 := get_field<Test::R>.v($t0)
-  2: label L1
+  0: $t1 := get_field<Test::R>.v($t0)
+  1: label L1
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:51:6+22
-  3: assert Eq<u64>($t1, select Test::R.v($t0))
-  4: return $t1
+  2: assert Eq<u64>($t1, select Test::R.v($t0))
+  3: return $t1
 }
 
 
 [variant verification]
 fun Test::ref_param_return_ref($t0|r: Test::R): u64 {
      var $t1: u64
-  0: assume WellFormed($t0)
-  1: $t1 := get_field<Test::R>.v($t0)
-  2: label L1
+  0: $t1 := get_field<Test::R>.v($t0)
+  1: label L1
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:58:6+22
-  3: assert Eq<u64>($t1, select Test::R.v($t0))
-  4: return $t1
+  2: assert Eq<u64>($t1, select Test::R.v($t0))
+  3: return $t1
 }
 
 
@@ -342,46 +332,44 @@ fun Test::resource_with_old($t0|val: u64) {
      var $t9: u64
      var $t10: u64
      var $t11: &mut u64
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
-  2: assume Gt($t0, 0)
-  3: assume CanModify<Test::R>(0)
-  4: @0 := save_mem(Test::R)
-  5: $t2 := 0x0
-  6: $t3 := exists<Test::R>($t2)
-  7: $t4 := !($t3)
-  8: if ($t4) goto 11 else goto 9
-  9: label L1
- 10: goto 15
- 11: label L0
- 12: $t5 := 33
- 13: $t6 := move($t5)
- 14: goto 30
- 15: label L2
- 16: $t7 := 0x0
+  0: assume Gt($t0, 0)
+  1: assume CanModify<Test::R>(0)
+  2: @0 := save_mem(Test::R)
+  3: $t2 := 0x0
+  4: $t3 := exists<Test::R>($t2)
+  5: $t4 := !($t3)
+  6: if ($t4) goto 9 else goto 7
+  7: label L1
+  8: goto 13
+  9: label L0
+ 10: $t5 := 33
+ 11: $t6 := move($t5)
+ 12: goto 28
+ 13: label L2
+ 14: $t7 := 0x0
      # VC: caller does not have permission to modify `Test::R` at given address at tests/spec_instrumentation/fun_spec.move:36:14+17
- 17: assert CanModify<Test::R>($t7)
- 18: $t8 := borrow_global<Test::R>($t7) on_abort goto 30 with $t6
- 19: $t9 := get_field<Test::R>.v($t8)
- 20: $t10 := +($t9, $t0) on_abort goto 30 with $t6
- 21: $t11 := borrow_field<Test::R>.v($t8)
- 22: write_ref($t11, $t10)
- 23: write_back[Reference($t8).v (u64)]($t11)
- 24: write_back[Test::R@]($t8)
- 25: label L3
+ 15: assert CanModify<Test::R>($t7)
+ 16: $t8 := borrow_global<Test::R>($t7) on_abort goto 28 with $t6
+ 17: $t9 := get_field<Test::R>.v($t8)
+ 18: $t10 := +($t9, $t0) on_abort goto 28 with $t6
+ 19: $t11 := borrow_field<Test::R>.v($t8)
+ 20: write_ref($t11, $t10)
+ 21: write_back[Reference($t8).v (u64)]($t11)
+ 22: write_back[Test::R@]($t8)
+ 23: label L3
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:41:6+35
- 26: assert Not(Not(exists[@0]<Test::R>(0)))
+ 24: assert Not(Not(exists[@0]<Test::R>(0)))
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:42:6+58
- 27: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 25: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:43:6+58
- 28: assert Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(global[@0]<Test::R>(0)), $t0))
- 29: return ()
- 30: label L4
+ 26: assert Eq<u64>(select Test::R.v(global<Test::R>(0)), Add(select Test::R.v(global[@0]<Test::R>(0)), $t0))
+ 27: return ()
+ 28: label L4
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/fun_spec.move:39:2+250
- 31: assert Or(Not(exists[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 29: assert Or(Not(exists[@0]<Test::R>(0)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/fun_spec.move:39:2+250
- 32: assert Or(And(Not(exists[@0]<Test::R>(0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
- 33: abort($t6)
+ 30: assert Or(And(Not(exists[@0]<Test::R>(0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>(0)), $t0), 18446744073709551615))
+ 31: abort($t6)
 }
 
 

--- a/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/generics.exp
@@ -25,18 +25,16 @@ fun Generics::remove_u64($t0|a: address): Generics::R<u64> {
 fun Generics::remove<#0>($t0|a: address): Generics::R<#0> {
      var $t1: Generics::R<#0>
      var $t2: num
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<Generics::R<#0>>(): WellFormed($rsc)
-  2: assume CanModify<Generics::R<#0>>($t0)
+  0: assume CanModify<Generics::R<#0>>($t0)
      # VC: caller does not have permission to modify `Generics::R<#0>` at given address at tests/spec_instrumentation/generics.move:11:9+9
-  3: assert CanModify<Generics::R<#0>>($t0)
-  4: $t1 := move_from<Generics::R<#0>>($t0) on_abort goto 8 with $t2
-  5: label L1
+  1: assert CanModify<Generics::R<#0>>($t0)
+  2: $t1 := move_from<Generics::R<#0>>($t0) on_abort goto 6 with $t2
+  3: label L1
      # VC: post-condition does not hold at tests/spec_instrumentation/generics.move:20:9+25
-  6: assert Not(exists<Generics::R<#0>>($t0))
-  7: return $t1
-  8: label L2
-  9: abort($t2)
+  4: assert Not(exists<Generics::R<#0>>($t0))
+  5: return $t1
+  6: label L2
+  7: abort($t2)
 }
 
 
@@ -45,28 +43,26 @@ fun Generics::remove_u64($t0|a: address): Generics::R<u64> {
      var $t1: Generics::R<u64>
      var $t2: bool
      var $t3: num
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<Generics::R<u64>>(): WellFormed($rsc)
-  2: assume CanModify<Generics::R<u64>>($t0)
+  0: assume CanModify<Generics::R<u64>>($t0)
      # VC: caller does not have permission to modify `Generics::R<u64>` at given address at tests/spec_instrumentation/generics.move:24:9+14
-  3: assert CanModify<Generics::R<u64>>($t0)
-  4: $t1 := opaque begin: Generics::remove<u64>($t0)
-  5: havoc[val]($t2)
-  6: if ($t2) goto 7 else goto 10
-  7: label L4
-  8: trace_abort($t3)
-  9: goto 18
- 10: label L3
- 11: modifies global<Generics::R<u64>>($t0)
- 12: assume WellFormed($t1)
- 13: assume Not(exists<Generics::R<u64>>($t0))
- 14: $t1 := opaque end: Generics::remove<u64>($t0)
- 15: label L1
+  1: assert CanModify<Generics::R<u64>>($t0)
+  2: $t1 := opaque begin: Generics::remove<u64>($t0)
+  3: havoc[val]($t2)
+  4: if ($t2) goto 5 else goto 8
+  5: label L4
+  6: trace_abort($t3)
+  7: goto 16
+  8: label L3
+  9: modifies global<Generics::R<u64>>($t0)
+ 10: assume WellFormed($t1)
+ 11: assume Not(exists<Generics::R<u64>>($t0))
+ 12: $t1 := opaque end: Generics::remove<u64>($t0)
+ 13: label L1
      # VC: post-condition does not hold at tests/spec_instrumentation/generics.move:20:9+25
- 16: assert Not(exists<Generics::R<u64>>($t0))
- 17: return $t1
- 18: label L2
- 19: abort($t3)
+ 14: assert Not(exists<Generics::R<u64>>($t0))
+ 15: return $t1
+ 16: label L2
+ 17: abort($t3)
 }
 
 

--- a/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/modifies.exp
@@ -174,28 +174,26 @@ public fun A::mutate_at($t0|addr: address) {
      var $t3: num
      var $t4: u64
      var $t5: &mut u64
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
-  2: assume CanModify<A::S>($t0)
-  3: @1 := save_mem(A::S)
+  0: assume CanModify<A::S>($t0)
+  1: @1 := save_mem(A::S)
      # VC: caller does not have permission to modify `A::S` at given address at tests/spec_instrumentation/modifies.move:18:17+17
-  4: assert CanModify<A::S>($t0)
-  5: $t2 := borrow_global<A::S>($t0) on_abort goto 15 with $t3
-  6: $t4 := 2
-  7: $t5 := borrow_field<A::S>.x($t2)
-  8: write_ref($t5, $t4)
-  9: write_back[Reference($t2).x (u64)]($t5)
- 10: write_back[A::S@]($t2)
- 11: label L1
+  2: assert CanModify<A::S>($t0)
+  3: $t2 := borrow_global<A::S>($t0) on_abort goto 13 with $t3
+  4: $t4 := 2
+  5: $t5 := borrow_field<A::S>.x($t2)
+  6: write_ref($t5, $t4)
+  7: write_back[Reference($t2).x (u64)]($t5)
+  8: write_back[A::S@]($t2)
+  9: label L1
      # VC: function does not abort under this condition at tests/spec_instrumentation/modifies.move:24:9+27
- 12: assert Not(Not(exists[@1]<A::S>($t0)))
+ 10: assert Not(Not(exists[@1]<A::S>($t0)))
      # VC: post-condition does not hold at tests/spec_instrumentation/modifies.move:23:9+31
- 13: assert Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
- 14: return ()
- 15: label L2
+ 11: assert Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
+ 12: return ()
+ 13: label L2
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/modifies.move:21:5+162
- 16: assert Not(exists[@1]<A::S>($t0))
- 17: abort($t3)
+ 14: assert Not(exists[@1]<A::S>($t0))
+ 15: abort($t3)
 }
 
 
@@ -205,21 +203,19 @@ public fun A::read_at($t0|addr: address): u64 {
      var $t2: A::S
      var $t3: num
      var $t4: u64
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
-  2: @0 := save_mem(A::S)
-  3: $t2 := get_global<A::S>($t0) on_abort goto 9 with $t3
-  4: $t4 := get_field<A::S>.x($t2)
-  5: label L1
+  0: @0 := save_mem(A::S)
+  1: $t2 := get_global<A::S>($t0) on_abort goto 7 with $t3
+  2: $t4 := get_field<A::S>.x($t2)
+  3: label L1
      # VC: function does not abort under this condition at tests/spec_instrumentation/modifies.move:13:9+27
-  6: assert Not(Not(exists[@0]<A::S>($t0)))
+  4: assert Not(Not(exists[@0]<A::S>($t0)))
      # VC: post-condition does not hold at tests/spec_instrumentation/modifies.move:14:9+36
-  7: assert Eq<u64>($t4, select A::S.x(global<A::S>($t0)))
-  8: return $t4
-  9: label L2
+  5: assert Eq<u64>($t4, select A::S.x(global<A::S>($t0)))
+  6: return $t4
+  7: label L2
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/modifies.move:11:5+131
- 10: assert Not(exists[@0]<A::S>($t0))
- 11: abort($t3)
+  8: assert Not(exists[@0]<A::S>($t0))
+  9: abort($t3)
 }
 
 
@@ -234,39 +230,35 @@ public fun B::move_from_test_incorrect($t0|addr1: address, $t1|addr2: address): 
      var $t8: B::T
      var $t9: u64
      var $t10: bool
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
-  3: assume forall $rsc: ResourceDomain<B::T>(): WellFormed($rsc)
-  4: assume CanModify<B::T>($t1)
-  5: $t5 := opaque begin: A::read_at($t1)
-  6: assume Identical($t6, Not(exists<A::S>($t1)))
-  7: if ($t6) goto 8 else goto 11
-  8: label L4
-  9: trace_abort($t7)
- 10: goto 30
- 11: label L3
- 12: assume WellFormed($t5)
- 13: assume Eq<u64>($t5, select A::S.x(global<A::S>($t1)))
- 14: $t5 := opaque end: A::read_at($t1)
+  0: assume CanModify<B::T>($t1)
+  1: $t5 := opaque begin: A::read_at($t1)
+  2: assume Identical($t6, Not(exists<A::S>($t1)))
+  3: if ($t6) goto 4 else goto 7
+  4: label L4
+  5: trace_abort($t7)
+  6: goto 26
+  7: label L3
+  8: assume WellFormed($t5)
+  9: assume Eq<u64>($t5, select A::S.x(global<A::S>($t1)))
+ 10: $t5 := opaque end: A::read_at($t1)
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:65:17+9
- 15: assert CanModify<B::T>($t0)
- 16: $t8 := move_from<B::T>($t0) on_abort goto 30 with $t7
- 17: $t9 := opaque begin: A::read_at($t1)
- 18: assume Identical($t10, Not(exists<A::S>($t1)))
- 19: if ($t10) goto 20 else goto 23
- 20: label L6
- 21: trace_abort($t7)
- 22: goto 30
- 23: label L5
- 24: assume WellFormed($t9)
- 25: assume Eq<u64>($t9, select A::S.x(global<A::S>($t1)))
- 26: $t9 := opaque end: A::read_at($t1)
- 27: assert Eq<u64>($t5, $t9)
- 28: label L1
- 29: return $t8
- 30: label L2
- 31: abort($t7)
+ 11: assert CanModify<B::T>($t0)
+ 12: $t8 := move_from<B::T>($t0) on_abort goto 26 with $t7
+ 13: $t9 := opaque begin: A::read_at($t1)
+ 14: assume Identical($t10, Not(exists<A::S>($t1)))
+ 15: if ($t10) goto 16 else goto 19
+ 16: label L6
+ 17: trace_abort($t7)
+ 18: goto 26
+ 19: label L5
+ 20: assume WellFormed($t9)
+ 21: assume Eq<u64>($t9, select A::S.x(global<A::S>($t1)))
+ 22: $t9 := opaque end: A::read_at($t1)
+ 23: assert Eq<u64>($t5, $t9)
+ 24: label L1
+ 25: return $t8
+ 26: label L2
+ 27: abort($t7)
 }
 
 
@@ -281,41 +273,37 @@ public fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
      var $t8: B::T
      var $t9: u64
      var $t10: bool
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
-  3: assume forall $rsc: ResourceDomain<B::T>(): WellFormed($rsc)
-  4: assume CanModify<B::T>($t1)
-  5: $t4 := opaque begin: A::read_at($t1)
-  6: assume Identical($t5, Not(exists<A::S>($t1)))
-  7: if ($t5) goto 8 else goto 11
-  8: label L4
-  9: trace_abort($t6)
- 10: goto 32
- 11: label L3
- 12: assume WellFormed($t4)
- 13: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
- 14: $t4 := opaque end: A::read_at($t1)
- 15: $t7 := 2
- 16: $t8 := pack B::T($t7)
+  0: assume CanModify<B::T>($t1)
+  1: $t4 := opaque begin: A::read_at($t1)
+  2: assume Identical($t5, Not(exists<A::S>($t1)))
+  3: if ($t5) goto 4 else goto 7
+  4: label L4
+  5: trace_abort($t6)
+  6: goto 28
+  7: label L3
+  8: assume WellFormed($t4)
+  9: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
+ 10: $t4 := opaque end: A::read_at($t1)
+ 11: $t7 := 2
+ 12: $t8 := pack B::T($t7)
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:52:9+7
- 17: assert CanModify<B::T>($t0)
- 18: move_to<B::T>($t8, $t0) on_abort goto 32 with $t6
- 19: $t9 := opaque begin: A::read_at($t1)
- 20: assume Identical($t10, Not(exists<A::S>($t1)))
- 21: if ($t10) goto 22 else goto 25
- 22: label L6
- 23: trace_abort($t6)
- 24: goto 32
- 25: label L5
- 26: assume WellFormed($t9)
- 27: assume Eq<u64>($t9, select A::S.x(global<A::S>($t1)))
- 28: $t9 := opaque end: A::read_at($t1)
- 29: assert Eq<u64>($t4, $t9)
- 30: label L1
- 31: return ()
- 32: label L2
- 33: abort($t6)
+ 13: assert CanModify<B::T>($t0)
+ 14: move_to<B::T>($t8, $t0) on_abort goto 28 with $t6
+ 15: $t9 := opaque begin: A::read_at($t1)
+ 16: assume Identical($t10, Not(exists<A::S>($t1)))
+ 17: if ($t10) goto 18 else goto 21
+ 18: label L6
+ 19: trace_abort($t6)
+ 20: goto 28
+ 21: label L5
+ 22: assume WellFormed($t9)
+ 23: assume Eq<u64>($t9, select A::S.x(global<A::S>($t1)))
+ 24: $t9 := opaque end: A::read_at($t1)
+ 25: assert Eq<u64>($t4, $t9)
+ 26: label L1
+ 27: return ()
+ 28: label L2
+ 29: abort($t6)
 }
 
 
@@ -329,48 +317,45 @@ public fun B::mutate_S_test1_incorrect($t0|addr1: address, $t1|addr2: address) {
      var $t7: bool
      var $t8: u64
      var $t9: bool
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
-  3: assume Neq<address>($t0, $t1)
-  4: assume CanModify<A::S>($t1)
-  5: $t4 := opaque begin: A::read_at($t1)
-  6: assume Identical($t5, Not(exists<A::S>($t1)))
-  7: if ($t5) goto 8 else goto 11
-  8: label L4
-  9: trace_abort($t6)
- 10: goto 39
- 11: label L3
- 12: assume WellFormed($t4)
- 13: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
- 14: $t4 := opaque end: A::read_at($t1)
+  0: assume Neq<address>($t0, $t1)
+  1: assume CanModify<A::S>($t1)
+  2: $t4 := opaque begin: A::read_at($t1)
+  3: assume Identical($t5, Not(exists<A::S>($t1)))
+  4: if ($t5) goto 5 else goto 8
+  5: label L4
+  6: trace_abort($t6)
+  7: goto 36
+  8: label L3
+  9: assume WellFormed($t4)
+ 10: assume Eq<u64>($t4, select A::S.x(global<A::S>($t1)))
+ 11: $t4 := opaque end: A::read_at($t1)
      # VC: caller does not have permission to modify `A::S` at given address at tests/spec_instrumentation/modifies.move:79:9+19
- 15: assert CanModify<A::S>($t0)
- 16: opaque begin: A::mutate_at($t0)
- 17: assume Identical($t7, Not(exists<A::S>($t0)))
- 18: if ($t7) goto 19 else goto 22
- 19: label L6
- 20: trace_abort($t6)
- 21: goto 39
- 22: label L5
- 23: modifies global<A::S>($t0)
- 24: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
- 25: opaque end: A::mutate_at($t0)
- 26: $t8 := opaque begin: A::read_at($t1)
- 27: assume Identical($t9, Not(exists<A::S>($t1)))
- 28: if ($t9) goto 29 else goto 32
- 29: label L8
- 30: trace_abort($t6)
- 31: goto 39
- 32: label L7
- 33: assume WellFormed($t8)
- 34: assume Eq<u64>($t8, select A::S.x(global<A::S>($t1)))
- 35: $t8 := opaque end: A::read_at($t1)
- 36: assert Eq<u64>($t4, $t8)
- 37: label L1
- 38: return ()
- 39: label L2
- 40: abort($t6)
+ 12: assert CanModify<A::S>($t0)
+ 13: opaque begin: A::mutate_at($t0)
+ 14: assume Identical($t7, Not(exists<A::S>($t0)))
+ 15: if ($t7) goto 16 else goto 19
+ 16: label L6
+ 17: trace_abort($t6)
+ 18: goto 36
+ 19: label L5
+ 20: modifies global<A::S>($t0)
+ 21: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
+ 22: opaque end: A::mutate_at($t0)
+ 23: $t8 := opaque begin: A::read_at($t1)
+ 24: assume Identical($t9, Not(exists<A::S>($t1)))
+ 25: if ($t9) goto 26 else goto 29
+ 26: label L8
+ 27: trace_abort($t6)
+ 28: goto 36
+ 29: label L7
+ 30: assume WellFormed($t8)
+ 31: assume Eq<u64>($t8, select A::S.x(global<A::S>($t1)))
+ 32: $t8 := opaque end: A::read_at($t1)
+ 33: assert Eq<u64>($t4, $t8)
+ 34: label L1
+ 35: return ()
+ 36: label L2
+ 37: abort($t6)
 }
 
 
@@ -384,46 +369,44 @@ public fun B::mutate_S_test2_incorrect($t0|addr: address) {
      var $t6: bool
      var $t7: u64
      var $t8: bool
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
-  2: assume CanModify<A::S>($t0)
-  3: $t3 := opaque begin: A::read_at($t0)
-  4: assume Identical($t4, Not(exists<A::S>($t0)))
-  5: if ($t4) goto 6 else goto 9
-  6: label L4
-  7: trace_abort($t5)
-  8: goto 37
-  9: label L3
- 10: assume WellFormed($t3)
- 11: assume Eq<u64>($t3, select A::S.x(global<A::S>($t0)))
- 12: $t3 := opaque end: A::read_at($t0)
+  0: assume CanModify<A::S>($t0)
+  1: $t3 := opaque begin: A::read_at($t0)
+  2: assume Identical($t4, Not(exists<A::S>($t0)))
+  3: if ($t4) goto 4 else goto 7
+  4: label L4
+  5: trace_abort($t5)
+  6: goto 35
+  7: label L3
+  8: assume WellFormed($t3)
+  9: assume Eq<u64>($t3, select A::S.x(global<A::S>($t0)))
+ 10: $t3 := opaque end: A::read_at($t0)
      # VC: caller does not have permission to modify `A::S` at given address at tests/spec_instrumentation/modifies.move:92:9+18
- 13: assert CanModify<A::S>($t0)
- 14: opaque begin: A::mutate_at($t0)
- 15: assume Identical($t6, Not(exists<A::S>($t0)))
- 16: if ($t6) goto 17 else goto 20
- 17: label L6
- 18: trace_abort($t5)
- 19: goto 37
- 20: label L5
- 21: modifies global<A::S>($t0)
- 22: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
- 23: opaque end: A::mutate_at($t0)
- 24: $t7 := opaque begin: A::read_at($t0)
- 25: assume Identical($t8, Not(exists<A::S>($t0)))
- 26: if ($t8) goto 27 else goto 30
- 27: label L8
- 28: trace_abort($t5)
- 29: goto 37
- 30: label L7
- 31: assume WellFormed($t7)
- 32: assume Eq<u64>($t7, select A::S.x(global<A::S>($t0)))
- 33: $t7 := opaque end: A::read_at($t0)
- 34: assert Eq<u64>($t3, $t7)
- 35: label L1
- 36: return ()
- 37: label L2
- 38: abort($t5)
+ 11: assert CanModify<A::S>($t0)
+ 12: opaque begin: A::mutate_at($t0)
+ 13: assume Identical($t6, Not(exists<A::S>($t0)))
+ 14: if ($t6) goto 15 else goto 18
+ 15: label L6
+ 16: trace_abort($t5)
+ 17: goto 35
+ 18: label L5
+ 19: modifies global<A::S>($t0)
+ 20: assume Eq<u64>(select A::S.x(global<A::S>($t0)), 2)
+ 21: opaque end: A::mutate_at($t0)
+ 22: $t7 := opaque begin: A::read_at($t0)
+ 23: assume Identical($t8, Not(exists<A::S>($t0)))
+ 24: if ($t8) goto 25 else goto 28
+ 25: label L8
+ 26: trace_abort($t5)
+ 27: goto 35
+ 28: label L7
+ 29: assume WellFormed($t7)
+ 30: assume Eq<u64>($t7, select A::S.x(global<A::S>($t0)))
+ 31: $t7 := opaque end: A::read_at($t0)
+ 32: assert Eq<u64>($t3, $t7)
+ 33: label L1
+ 34: return ()
+ 35: label L2
+ 36: abort($t5)
 }
 
 
@@ -440,44 +423,40 @@ public fun B::mutate_at_test_incorrect($t0|addr1: address, $t1|addr2: address) {
      var $t10: &mut u64
      var $t11: u64
      var $t12: bool
-  0: assume WellFormed($t0)
-  1: assume WellFormed($t1)
-  2: assume forall $rsc: ResourceDomain<A::S>(): WellFormed($rsc)
-  3: assume forall $rsc: ResourceDomain<B::T>(): WellFormed($rsc)
-  4: assume CanModify<B::T>($t1)
-  5: $t5 := opaque begin: A::read_at($t1)
-  6: assume Identical($t6, Not(exists<A::S>($t1)))
-  7: if ($t6) goto 8 else goto 11
-  8: label L4
-  9: trace_abort($t7)
- 10: goto 35
- 11: label L3
- 12: assume WellFormed($t5)
- 13: assume Eq<u64>($t5, select A::S.x(global<A::S>($t1)))
- 14: $t5 := opaque end: A::read_at($t1)
+  0: assume CanModify<B::T>($t1)
+  1: $t5 := opaque begin: A::read_at($t1)
+  2: assume Identical($t6, Not(exists<A::S>($t1)))
+  3: if ($t6) goto 4 else goto 7
+  4: label L4
+  5: trace_abort($t7)
+  6: goto 31
+  7: label L3
+  8: assume WellFormed($t5)
+  9: assume Eq<u64>($t5, select A::S.x(global<A::S>($t1)))
+ 10: $t5 := opaque end: A::read_at($t1)
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:38:17+17
- 15: assert CanModify<B::T>($t0)
- 16: $t8 := borrow_global<B::T>($t0) on_abort goto 35 with $t7
- 17: $t9 := 2
- 18: $t10 := borrow_field<B::T>.x($t8)
- 19: write_ref($t10, $t9)
- 20: write_back[Reference($t8).x (u64)]($t10)
- 21: write_back[B::T@]($t8)
- 22: $t11 := opaque begin: A::read_at($t1)
- 23: assume Identical($t12, Not(exists<A::S>($t1)))
- 24: if ($t12) goto 25 else goto 28
- 25: label L6
- 26: trace_abort($t7)
- 27: goto 35
- 28: label L5
- 29: assume WellFormed($t11)
- 30: assume Eq<u64>($t11, select A::S.x(global<A::S>($t1)))
- 31: $t11 := opaque end: A::read_at($t1)
- 32: assert Eq<u64>($t5, $t11)
- 33: label L1
- 34: return ()
- 35: label L2
- 36: abort($t7)
+ 11: assert CanModify<B::T>($t0)
+ 12: $t8 := borrow_global<B::T>($t0) on_abort goto 31 with $t7
+ 13: $t9 := 2
+ 14: $t10 := borrow_field<B::T>.x($t8)
+ 15: write_ref($t10, $t9)
+ 16: write_back[Reference($t8).x (u64)]($t10)
+ 17: write_back[B::T@]($t8)
+ 18: $t11 := opaque begin: A::read_at($t1)
+ 19: assume Identical($t12, Not(exists<A::S>($t1)))
+ 20: if ($t12) goto 21 else goto 24
+ 21: label L6
+ 22: trace_abort($t7)
+ 23: goto 31
+ 24: label L5
+ 25: assume WellFormed($t11)
+ 26: assume Eq<u64>($t11, select A::S.x(global<A::S>($t1)))
+ 27: $t11 := opaque end: A::read_at($t1)
+ 28: assert Eq<u64>($t5, $t11)
+ 29: label L1
+ 30: return ()
+ 31: label L2
+ 32: abort($t7)
 }
 
 

--- a/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/opaque_call.exp
@@ -82,48 +82,46 @@ fun Test::get_and_incr($t0|addr: address): u64 {
      var $t10: u64
      var $t11: u64
      var $t12: &mut u64
-  0: assume WellFormed($t0)
-  1: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
-  2: assume Neq<address>($t0, 0)
-  3: assume CanModify<Test::R>($t0)
-  4: @0 := save_mem(Test::R)
-  5: $t3 := exists<Test::R>($t0)
-  6: $t4 := !($t3)
-  7: if ($t4) goto 10 else goto 8
-  8: label L1
-  9: goto 14
- 10: label L0
- 11: $t5 := 33
- 12: $t6 := move($t5)
- 13: goto 31
- 14: label L2
+  0: assume Neq<address>($t0, 0)
+  1: assume CanModify<Test::R>($t0)
+  2: @0 := save_mem(Test::R)
+  3: $t3 := exists<Test::R>($t0)
+  4: $t4 := !($t3)
+  5: if ($t4) goto 8 else goto 6
+  6: label L1
+  7: goto 12
+  8: label L0
+  9: $t5 := 33
+ 10: $t6 := move($t5)
+ 11: goto 29
+ 12: label L2
      # VC: caller does not have permission to modify `Test::R` at given address at tests/spec_instrumentation/opaque_call.move:8:14+17
- 15: assert CanModify<Test::R>($t0)
- 16: $t7 := borrow_global<Test::R>($t0) on_abort goto 31 with $t6
- 17: $t8 := get_field<Test::R>.v($t7)
- 18: $t9 := get_field<Test::R>.v($t7)
- 19: $t10 := 1
- 20: $t11 := +($t9, $t10) on_abort goto 31 with $t6
- 21: $t12 := borrow_field<Test::R>.v($t7)
- 22: write_ref($t12, $t11)
- 23: write_back[Reference($t7).v (u64)]($t12)
- 24: write_back[Test::R@]($t7)
- 25: label L3
+ 13: assert CanModify<Test::R>($t0)
+ 14: $t7 := borrow_global<Test::R>($t0) on_abort goto 29 with $t6
+ 15: $t8 := get_field<Test::R>.v($t7)
+ 16: $t9 := get_field<Test::R>.v($t7)
+ 17: $t10 := 1
+ 18: $t11 := +($t9, $t10) on_abort goto 29 with $t6
+ 19: $t12 := borrow_field<Test::R>.v($t7)
+ 20: write_ref($t12, $t11)
+ 21: write_back[Reference($t7).v (u64)]($t12)
+ 22: write_back[Test::R@]($t7)
+ 23: label L3
      # VC: function does not abort under this condition at tests/spec_instrumentation/opaque_call.move:16:6+35
- 26: assert Not(Not(exists[@0]<Test::R>($t0)))
+ 24: assert Not(Not(exists[@0]<Test::R>($t0)))
      # VC: function does not abort under this condition at tests/spec_instrumentation/opaque_call.move:17:6+56
- 27: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 25: assert Not(Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      # VC: post-condition does not hold at tests/spec_instrumentation/opaque_call.move:19:6+56
- 28: assert Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@0]<Test::R>($t0)), 1))
+ 26: assert Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@0]<Test::R>($t0)), 1))
      # VC: post-condition does not hold at tests/spec_instrumentation/opaque_call.move:20:6+36
- 29: assert Eq<u64>($t8, select Test::R.v(global<Test::R>($t0)))
- 30: return $t8
- 31: label L4
+ 27: assert Eq<u64>($t8, select Test::R.v(global<Test::R>($t0)))
+ 28: return $t8
+ 29: label L4
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/opaque_call.move:13:2+308
- 32: assert Or(Not(exists[@0]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 30: assert Or(Not(exists[@0]<Test::R>($t0)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/opaque_call.move:13:2+308
- 33: assert Or(And(Not(exists[@0]<Test::R>($t0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
- 34: abort($t6)
+ 31: assert Or(And(Not(exists[@0]<Test::R>($t0)), Eq(33, $t6)), Ge(Add(select Test::R.v(global[@0]<Test::R>($t0)), 1), 18446744073709551615))
+ 32: abort($t6)
 }
 
 
@@ -136,56 +134,55 @@ fun Test::incr_twice() {
      var $t4: address
      var $t5: u64
      var $t6: bool
-  0: assume forall $rsc: ResourceDomain<Test::R>(): WellFormed($rsc)
-  1: @1 := save_mem(Test::R)
-  2: $t0 := 0x1
+  0: @1 := save_mem(Test::R)
+  1: $t0 := 0x1
      # VC: precondition does not hold at this call at tests/spec_instrumentation/opaque_call.move:15:6+22
-  3: assert Neq<address>($t0, 0)
-  4: $t1 := opaque begin: Test::get_and_incr($t0)
-  5: assume Identical($t2, Or(Not(exists<Test::R>($t0)), Ge(Add(select Test::R.v(global<Test::R>($t0)), 1), 18446744073709551615)))
-  6: if ($t2) goto 7 else goto 11
-  7: label L4
-  8: assume Or(And(Not(exists<Test::R>($t0)), Eq(33, $t3)), Ge(Add(select Test::R.v(global<Test::R>($t0)), 1), 18446744073709551615))
-  9: trace_abort($t3)
- 10: goto 40
- 11: label L3
- 12: @2 := save_mem(Test::R)
- 13: modifies global<Test::R>($t0)
- 14: assume WellFormed($t1)
- 15: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@2]<Test::R>($t0)), 1))
- 16: assume Eq<u64>($t1, select Test::R.v(global<Test::R>($t0)))
- 17: $t1 := opaque end: Test::get_and_incr($t0)
- 18: destroy($t1)
- 19: $t4 := 0x1
+  2: assert Neq<address>($t0, 0)
+  3: $t1 := opaque begin: Test::get_and_incr($t0)
+  4: assume Identical($t2, Or(Not(exists<Test::R>($t0)), Ge(Add(select Test::R.v(global<Test::R>($t0)), 1), 18446744073709551615)))
+  5: if ($t2) goto 6 else goto 10
+  6: label L4
+  7: assume Or(And(Not(exists<Test::R>($t0)), Eq(33, $t3)), Ge(Add(select Test::R.v(global<Test::R>($t0)), 1), 18446744073709551615))
+  8: trace_abort($t3)
+  9: goto 39
+ 10: label L3
+ 11: @2 := save_mem(Test::R)
+ 12: modifies global<Test::R>($t0)
+ 13: assume WellFormed($t1)
+ 14: assume Eq<u64>(select Test::R.v(global<Test::R>($t0)), Add(select Test::R.v(global[@2]<Test::R>($t0)), 1))
+ 15: assume Eq<u64>($t1, select Test::R.v(global<Test::R>($t0)))
+ 16: $t1 := opaque end: Test::get_and_incr($t0)
+ 17: destroy($t1)
+ 18: $t4 := 0x1
      # VC: precondition does not hold at this call at tests/spec_instrumentation/opaque_call.move:15:6+22
- 20: assert Neq<address>($t4, 0)
- 21: $t5 := opaque begin: Test::get_and_incr($t4)
- 22: assume Identical($t6, Or(Not(exists<Test::R>($t4)), Ge(Add(select Test::R.v(global<Test::R>($t4)), 1), 18446744073709551615)))
- 23: if ($t6) goto 24 else goto 28
- 24: label L6
- 25: assume Or(And(Not(exists<Test::R>($t4)), Eq(33, $t3)), Ge(Add(select Test::R.v(global<Test::R>($t4)), 1), 18446744073709551615))
- 26: trace_abort($t3)
- 27: goto 40
- 28: label L5
- 29: @3 := save_mem(Test::R)
- 30: modifies global<Test::R>($t4)
- 31: assume WellFormed($t5)
- 32: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@3]<Test::R>($t4)), 1))
- 33: assume Eq<u64>($t5, select Test::R.v(global<Test::R>($t4)))
- 34: $t5 := opaque end: Test::get_and_incr($t4)
- 35: destroy($t5)
- 36: label L1
+ 19: assert Neq<address>($t4, 0)
+ 20: $t5 := opaque begin: Test::get_and_incr($t4)
+ 21: assume Identical($t6, Or(Not(exists<Test::R>($t4)), Ge(Add(select Test::R.v(global<Test::R>($t4)), 1), 18446744073709551615)))
+ 22: if ($t6) goto 23 else goto 27
+ 23: label L6
+ 24: assume Or(And(Not(exists<Test::R>($t4)), Eq(33, $t3)), Ge(Add(select Test::R.v(global<Test::R>($t4)), 1), 18446744073709551615))
+ 25: trace_abort($t3)
+ 26: goto 39
+ 27: label L5
+ 28: @3 := save_mem(Test::R)
+ 29: modifies global<Test::R>($t4)
+ 30: assume WellFormed($t5)
+ 31: assume Eq<u64>(select Test::R.v(global<Test::R>($t4)), Add(select Test::R.v(global[@3]<Test::R>($t4)), 1))
+ 32: assume Eq<u64>($t5, select Test::R.v(global<Test::R>($t4)))
+ 33: $t5 := opaque end: Test::get_and_incr($t4)
+ 34: destroy($t5)
+ 35: label L1
      # VC: function does not abort under this condition at tests/spec_instrumentation/opaque_call.move:28:6+35
- 37: assert Not(Not(exists[@1]<Test::R>(1)))
+ 36: assert Not(Not(exists[@1]<Test::R>(1)))
      # VC: post-condition does not hold at tests/spec_instrumentation/opaque_call.move:29:6+56
- 38: assert Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(global[@1]<Test::R>(1)), 2))
- 39: return ()
- 40: label L2
+ 37: assert Eq<u64>(select Test::R.v(global<Test::R>(1)), Add(select Test::R.v(global[@1]<Test::R>(1)), 2))
+ 38: return ()
+ 39: label L2
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/opaque_call.move:27:2+123
- 41: assert Not(exists[@1]<Test::R>(1))
+ 40: assert Not(exists[@1]<Test::R>(1))
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/opaque_call.move:27:2+123
- 42: assert And(Not(exists[@1]<Test::R>(1)), Eq(33, $t3))
- 43: abort($t3)
+ 41: assert And(Not(exists[@1]<Test::R>(1)), Eq(33, $t3))
+ 42: abort($t3)
 }
 
 

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -23,6 +23,7 @@ use bytecode::{
     spec_instrumentation::SpecInstrumentationProcessor,
     usage_analysis::UsageProcessor,
     verification_analysis::VerificationAnalysisProcessor,
+    well_formed_instrumentation::WellFormedInstrumentationProcessor,
 };
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use move_command_line_common::testing::EXP_EXT;
@@ -139,6 +140,8 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(UsageProcessor::new());
             pipeline.add_processor(VerificationAnalysisProcessor::new());
             pipeline.add_processor(SpecInstrumentationProcessor::new());
+            pipeline.add_processor(GlobalInvariantAnalysisProcessor::new());
+            pipeline.add_processor(WellFormedInstrumentationProcessor::new());
             pipeline.add_processor(DataInvariantInstrumentationProcessor::new());
             Ok(Some(pipeline))
         }
@@ -154,7 +157,6 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(UsageProcessor::new());
             pipeline.add_processor(VerificationAnalysisProcessor::new());
             pipeline.add_processor(SpecInstrumentationProcessor::new());
-            pipeline.add_processor(DataInvariantInstrumentationProcessor::new());
             pipeline.add_processor(GlobalInvariantAnalysisProcessor::new());
             Ok(Some(pipeline))
         }
@@ -170,7 +172,6 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(UsageProcessor::new());
             pipeline.add_processor(VerificationAnalysisProcessor::new());
             pipeline.add_processor(SpecInstrumentationProcessor::new());
-            pipeline.add_processor(DataInvariantInstrumentationProcessor::new());
             pipeline.add_processor(GlobalInvariantAnalysisProcessor::new());
             pipeline.add_processor(GlobalInvariantInstrumentationProcessor::new());
             Ok(Some(pipeline))
@@ -185,6 +186,9 @@ fn get_tested_transformation_pipeline(
             pipeline.add_processor(UsageProcessor::new());
             pipeline.add_processor(VerificationAnalysisProcessor::new());
             pipeline.add_processor(SpecInstrumentationProcessor::new());
+            pipeline.add_processor(GlobalInvariantAnalysisProcessor::new());
+            pipeline.add_processor(WellFormedInstrumentationProcessor::new());
+            pipeline.add_processor(DataInvariantInstrumentationProcessor::new());
             pipeline.add_processor(MonoAnalysisProcessor::new());
             Ok(Some(pipeline))
         }

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
@@ -66,7 +66,6 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
 42 │ │     }
    │ ╰─────^
    │
-   =     at tests/sources/functional/aborts_if_with_code.move:41
    =     at tests/sources/functional/aborts_if_with_code.move:29: conditional_abort_invalid
    =         x = <redacted>
    =         y = <redacted>
@@ -86,7 +85,6 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
 51 │ │     }
    │ ╰─────^
    │
-   =     at tests/sources/functional/aborts_if_with_code.move:50
    =     at tests/sources/functional/aborts_if_with_code.move:45: exec_failure_invalid
    =         x = <redacted>
    =     at tests/sources/functional/aborts_if_with_code.move:46: exec_failure_invalid

--- a/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
+++ b/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
@@ -5,7 +5,6 @@ error: post-condition does not hold
 19 │         ensures len(BCS::serialize(mv1)) == len(BCS::serialize(mv2));
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/address_serialization_constant_size.move:20
    =     at tests/sources/functional/address_serialization_constant_size.move:15: serialized_move_values_diff_len_incorrect
    =         mv1 = <redacted>
    =         mv2 = <redacted>

--- a/language/move-prover/tests/sources/functional/choice.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/choice.cvc4_exp
@@ -24,7 +24,6 @@ error: post-condition does not hold
 21 │         ensures result == TRACE(choose x: u64 where x >= 4 && x <= 5);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/choice.move:21
    =     at tests/sources/functional/choice.move:15: simple_incorrect
    =         b = <redacted>
    =     at tests/sources/functional/choice.move:16: simple_incorrect
@@ -40,7 +39,6 @@ error: post-condition does not hold
 98 │         ensures result == TRACE(choose y: u64 where y > x);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/choice.move:98
    =     at tests/sources/functional/choice.move:93: test_choice_dup_expected_fail
    =         x = <redacted>
    =     at tests/sources/functional/choice.move:94: test_choice_dup_expected_fail

--- a/language/move-prover/tests/sources/functional/choice.exp
+++ b/language/move-prover/tests/sources/functional/choice.exp
@@ -24,7 +24,6 @@ error: post-condition does not hold
 21 │         ensures result == TRACE(choose x: u64 where x >= 4 && x <= 5);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/choice.move:21
    =     at tests/sources/functional/choice.move:15: simple_incorrect
    =         b = <redacted>
    =     at tests/sources/functional/choice.move:16: simple_incorrect
@@ -40,7 +39,6 @@ error: post-condition does not hold
 98 │         ensures result == TRACE(choose y: u64 where y > x);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/choice.move:98
    =     at tests/sources/functional/choice.move:93: test_choice_dup_expected_fail
    =         x = <redacted>
    =     at tests/sources/functional/choice.move:94: test_choice_dup_expected_fail

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -48,15 +48,15 @@ error: global memory invariant does not hold
 174 │     invariant global<R>(@0).v <= limit;
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:196: limit_change_invalid
+    =     at tests/sources/functional/global_vars.move:184: limit_change_invalid
     =         s = <redacted>
-    =     at tests/sources/functional/global_vars.move:197: limit_change_invalid
+    =     at tests/sources/functional/global_vars.move:185: limit_change_invalid
     =     at tests/sources/functional/global_vars.move:176: publish
     =         s = <redacted>
     =     at tests/sources/functional/global_vars.move:177: publish
     =     at tests/sources/functional/global_vars.move:178: publish
-    =     at tests/sources/functional/global_vars.move:198: limit_change_invalid
-    =     at tests/sources/functional/global_vars.move:200
+    =     at tests/sources/functional/global_vars.move:186: limit_change_invalid
+    =     at tests/sources/functional/global_vars.move:188
     =     at tests/sources/functional/global_vars.move:174
 
 error: post-condition does not hold
@@ -93,6 +93,6 @@ error: global memory invariant does not hold
 174 │     invariant global<R>(@0).v <= limit;
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:188: update_invalid
-    =     at tests/sources/functional/global_vars.move:189: update_invalid
+    =     at tests/sources/functional/global_vars.move:180: update_invalid
+    =     at tests/sources/functional/global_vars.move:181: update_invalid
     =     at tests/sources/functional/global_vars.move:174

--- a/language/move-prover/tests/sources/functional/global_vars.move
+++ b/language/move-prover/tests/sources/functional/global_vars.move
@@ -176,21 +176,9 @@ module 0x42::TestGlobalVars {
     fun publish(s: &signer) {
         move_to<R>(s, R{v: 2});
     }
-    spec publish {
-        // TODO: this hack is currently required because spec_instrumentation does not inject assumptions for
-        //   memory used only by invariants which are injected into the code, but not the original code.
-        //   This is a general bug not related to spec vars. Since the function `publish` does not directly
-        //   reference `limit, but only the invariant which is injected, memory usage analysis does not
-        //   report this dependency on limit. The below forces the analysis to see this dependency.
-        ensures limit == limit;
-    }
 
     fun update_invalid() acquires R {
         borrow_global_mut<R>(@0).v = 3;
-    }
-    spec update_invalid {
-        // TODO: see above
-        ensures limit == limit;
     }
 
     fun limit_change_invalid(s: &signer) {

--- a/language/move-prover/tests/sources/functional/global_vars.no_opaque_exp
+++ b/language/move-prover/tests/sources/functional/global_vars.no_opaque_exp
@@ -48,15 +48,15 @@ error: global memory invariant does not hold
 174 │     invariant global<R>(@0).v <= limit;
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:196: limit_change_invalid
+    =     at tests/sources/functional/global_vars.move:184: limit_change_invalid
     =         s = <redacted>
-    =     at tests/sources/functional/global_vars.move:197: limit_change_invalid
+    =     at tests/sources/functional/global_vars.move:185: limit_change_invalid
     =     at tests/sources/functional/global_vars.move:176: publish
     =         s = <redacted>
     =     at tests/sources/functional/global_vars.move:177: publish
     =     at tests/sources/functional/global_vars.move:178: publish
-    =     at tests/sources/functional/global_vars.move:198: limit_change_invalid
-    =     at tests/sources/functional/global_vars.move:200
+    =     at tests/sources/functional/global_vars.move:186: limit_change_invalid
+    =     at tests/sources/functional/global_vars.move:188
     =     at tests/sources/functional/global_vars.move:174
 
 error: post-condition does not hold
@@ -98,6 +98,6 @@ error: global memory invariant does not hold
 174 │     invariant global<R>(@0).v <= limit;
     │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/global_vars.move:188: update_invalid
-    =     at tests/sources/functional/global_vars.move:189: update_invalid
+    =     at tests/sources/functional/global_vars.move:180: update_invalid
+    =     at tests/sources/functional/global_vars.move:181: update_invalid
     =     at tests/sources/functional/global_vars.move:174

--- a/language/move-prover/tests/sources/functional/hash_model.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/hash_model.cvc4_exp
@@ -5,7 +5,6 @@ error: post-condition does not hold
 25 │         ensures len(result_1) > 0 ==> result_1[0] <= max_u8();
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/hash_model.move:25
    =     at tests/sources/functional/hash_model.move:13: hash_test1
    =         v1 = <redacted>
    =         v2 = <redacted>
@@ -29,7 +28,6 @@ error: post-condition does not hold
 48 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/hash_model.move:48
    =     at tests/sources/functional/hash_model.move:39: hash_test1_incorrect
    =         v1 = <redacted>
    =         v2 = <redacted>
@@ -50,7 +48,6 @@ error: post-condition does not hold
 91 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/hash_model.move:91
    =     at tests/sources/functional/hash_model.move:82: hash_test2_incorrect
    =         v1 = <redacted>
    =         v2 = <redacted>
@@ -71,7 +68,6 @@ error: post-condition does not hold
 68 │         ensures len(result_1) > 0 ==> result_1[0] <= max_u8();
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/hash_model.move:68
    =     at tests/sources/functional/hash_model.move:56: hash_test3
    =         v1 = <redacted>
    =         v2 = <redacted>

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -5,7 +5,6 @@ error: post-condition does not hold
 48 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/hash_model.move:48
    =     at tests/sources/functional/hash_model.move:39: hash_test1_incorrect
    =         v1 = <redacted>
    =         v2 = <redacted>
@@ -26,7 +25,6 @@ error: post-condition does not hold
 91 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/hash_model.move:91
    =     at tests/sources/functional/hash_model.move:82: hash_test2_incorrect
    =         v1 = <redacted>
    =         v2 = <redacted>

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -5,7 +5,6 @@ error: post-condition does not hold
 22 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8(); // should be <=
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/hash_model_invalid.move:22
    =     at tests/sources/functional/hash_model_invalid.move:11: hash_test1
    =         v1 = <redacted>
    =         v2 = <redacted>
@@ -26,7 +25,6 @@ error: post-condition does not hold
 35 │         ensures len(result_1) > 0 ==> result_1[0] < max_u8();
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/hash_model_invalid.move:35
    =     at tests/sources/functional/hash_model_invalid.move:26: hash_test2
    =         v1 = <redacted>
    =         v2 = <redacted>

--- a/language/move-prover/tests/sources/functional/invariants_resources.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/invariants_resources.cvc4_exp
@@ -5,7 +5,6 @@ error: post-condition does not hold
 23 │         ensures result > 0;
    │         ^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/invariants_resources.move:23
    =     at tests/sources/functional/invariants_resources.move:19: get
    =         a = <redacted>
    =     at tests/sources/functional/invariants_resources.move:20: get
@@ -19,7 +18,6 @@ error: post-condition does not hold
 31 │         ensures result < 1;
    │         ^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/invariants_resources.move:31
    =     at tests/sources/functional/invariants_resources.move:27: get_invalid
    =         a = <redacted>
    =     at tests/sources/functional/invariants_resources.move:28: get_invalid

--- a/language/move-prover/tests/sources/functional/invariants_resources.exp
+++ b/language/move-prover/tests/sources/functional/invariants_resources.exp
@@ -5,7 +5,6 @@ error: post-condition does not hold
 31 │         ensures result < 1;
    │         ^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/invariants_resources.move:31
    =     at tests/sources/functional/invariants_resources.move:27: get_invalid
    =         a = <redacted>
    =     at tests/sources/functional/invariants_resources.move:28: get_invalid

--- a/language/move-prover/tests/sources/functional/mono.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/mono.cvc4_exp
@@ -34,7 +34,6 @@ error: post-condition does not hold
 71 │     spec vec_addr { ensures result[0] != @0x1; }
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:71
    =     at tests/sources/functional/mono.move:70: vec_addr
    =         x = <redacted>
    =         result = <redacted>
@@ -46,7 +45,6 @@ error: post-condition does not hold
 73 │     spec vec_bool { ensures result[0] != true; }
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:73
    =     at tests/sources/functional/mono.move:72: vec_bool
    =         x = <redacted>
    =         result = <redacted>
@@ -58,7 +56,6 @@ error: post-condition does not hold
 69 │     spec vec_int { ensures result[0] != 1; }
    │                    ^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:69
    =     at tests/sources/functional/mono.move:68: vec_int
    =         x = <redacted>
    =         result = <redacted>
@@ -70,7 +67,6 @@ error: post-condition does not hold
 77 │     spec vec_struct_addr { ensures result[0].x != @0x1; }
    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:77
    =     at tests/sources/functional/mono.move:76: vec_struct_addr
    =         x = <redacted>
    =         result = <redacted>
@@ -82,7 +78,6 @@ error: post-condition does not hold
 75 │     spec vec_struct_int { ensures result[0].x != 1; }
    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:75
    =     at tests/sources/functional/mono.move:74: vec_struct_int
    =         x = <redacted>
    =         result = <redacted>
@@ -94,7 +89,6 @@ error: post-condition does not hold
 82 │     spec vec_vec { ensures len(result[0]) != 0; }
    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:82
    =     at tests/sources/functional/mono.move:79: vec_vec
    =         x = <redacted>
    =     at tests/sources/functional/mono.move:80: vec_vec

--- a/language/move-prover/tests/sources/functional/mono.exp
+++ b/language/move-prover/tests/sources/functional/mono.exp
@@ -5,7 +5,6 @@ error: post-condition does not hold
 71 │     spec vec_addr { ensures result[0] != @0x1; }
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:71
    =     at tests/sources/functional/mono.move:70: vec_addr
    =         x = <redacted>
    =         result = <redacted>
@@ -17,7 +16,6 @@ error: post-condition does not hold
 73 │     spec vec_bool { ensures result[0] != true; }
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:73
    =     at tests/sources/functional/mono.move:72: vec_bool
    =         x = <redacted>
    =         result = <redacted>
@@ -29,7 +27,6 @@ error: post-condition does not hold
 69 │     spec vec_int { ensures result[0] != 1; }
    │                    ^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:69
    =     at tests/sources/functional/mono.move:68: vec_int
    =         x = <redacted>
    =         result = <redacted>
@@ -41,7 +38,6 @@ error: post-condition does not hold
 77 │     spec vec_struct_addr { ensures result[0].x != @0x1; }
    │                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:77
    =     at tests/sources/functional/mono.move:76: vec_struct_addr
    =         x = <redacted>
    =         result = <redacted>
@@ -53,7 +49,6 @@ error: post-condition does not hold
 75 │     spec vec_struct_int { ensures result[0].x != 1; }
    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:75
    =     at tests/sources/functional/mono.move:74: vec_struct_int
    =         x = <redacted>
    =         result = <redacted>
@@ -65,7 +60,6 @@ error: post-condition does not hold
 82 │     spec vec_vec { ensures len(result[0]) != 0; }
    │                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/mono.move:82
    =     at tests/sources/functional/mono.move:79: vec_vec
    =         x = <redacted>
    =     at tests/sources/functional/mono.move:80: vec_vec

--- a/language/move-prover/tests/sources/functional/mut_ref.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref.exp
@@ -5,7 +5,6 @@ error: data invariant does not hold
 8 │     spec T { invariant value > 0; }
   │              ^^^^^^^^^^^^^^^^^^^^
   │
-  =     at tests/sources/functional/mut_ref.move:127
   =     at tests/sources/functional/mut_ref.move:113: call_return_ref_different_path_vec2_incorrect
   =         b = <redacted>
   =     at tests/sources/functional/mut_ref.move:114: call_return_ref_different_path_vec2_incorrect

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -25,7 +25,6 @@ error: post-condition does not hold
 47 │         ensures result == i + 2;
    │         ^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/schema_exp.move:58
    =     at tests/sources/functional/schema_exp.move:53: baz_incorrect
    =         i = <redacted>
    =     at tests/sources/functional/schema_exp.move:54: baz_incorrect

--- a/language/move-prover/tests/sources/functional/serialize_model.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.cvc4_exp
@@ -5,7 +5,6 @@ error: post-condition does not hold
 21 │         ensures len(result_1) > 0 ==> result_1[0] <= max_u8();
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/serialize_model.move:21
    =     at tests/sources/functional/serialize_model.move:10: bcs_test1
    =         v1 = <redacted>
    =         v2 = <redacted>
@@ -28,7 +27,6 @@ error: post-condition does not hold
 34 │         ensures result_1 == result_2;
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/serialize_model.move:35
    =     at tests/sources/functional/serialize_model.move:26: bcs_test1_incorrect
    =         v1 = <redacted>
    =         v2 = <redacted>

--- a/language/move-prover/tests/sources/functional/serialize_model.exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.exp
@@ -5,7 +5,6 @@ error: post-condition does not hold
 34 │         ensures result_1 == result_2;
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/serialize_model.move:35
    =     at tests/sources/functional/serialize_model.move:26: bcs_test1_incorrect
    =         v1 = <redacted>
    =         v2 = <redacted>

--- a/language/move-prover/tests/sources/functional/verify_vector.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/verify_vector.cvc4_exp
@@ -167,7 +167,6 @@ error: unknown assertion failed
 234 │            assert !(exists x in v: x==e);
     │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_vector.move:240
     =     at tests/sources/functional/verify_vector.move:221: verify_contains
     =         v = <redacted>
     =         e = <redacted>
@@ -187,7 +186,6 @@ error: induction case of the loop invariant does not hold
 226 │                invariant !(exists j in 0..i: v[j]==e);
     │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_vector.move:240
     =     at tests/sources/functional/verify_vector.move:221: verify_contains
     =         v = <redacted>
     =         e = <redacted>
@@ -208,7 +206,6 @@ error: induction case of the loop invariant does not hold
 192 │                 invariant !(exists j in 0..i: v[j]==e);
     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_vector.move:206
     =     at tests/sources/functional/verify_vector.move:187: verify_index_of
     =         v = <redacted>
     =         e = <redacted>
@@ -229,7 +226,6 @@ error: post-condition does not hold
 203 │         ensures result_1 == (exists x in v: x==e); // whether v contains e or not
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_vector.move:206
     =     at tests/sources/functional/verify_vector.move:187: verify_index_of
     =         v = <redacted>
     =         e = <redacted>
@@ -252,7 +248,6 @@ error: post-condition does not hold
 205 │         ensures result_1 ==> (forall i in 0..result_2: v[i]!=e); // ensure the smallest index
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_vector.move:206
     =     at tests/sources/functional/verify_vector.move:187: verify_index_of
     =         v = <redacted>
     =         e = <redacted>
@@ -277,7 +272,6 @@ error: post-condition does not hold
 216 │         ensures result_1 ==> (forall i in 0..result_2: v[i]!=e); // ensure the smallest index
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_vector.move:217
     =     at tests/sources/functional/verify_vector.move:209: verify_model_index_of
     =         v = <redacted>
     =         e = <redacted>
@@ -296,7 +290,6 @@ error: induction case of the loop invariant does not hold
 266 │                 invariant forall k in j..i: v[k] == old(v)[k+1];
     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_vector.move:282
     =     at tests/sources/functional/verify_vector.move:254: verify_remove
     =         v = <redacted>
     =         j = <redacted>
@@ -334,7 +327,6 @@ error: induction case of the loop invariant does not hold
 267 │                 invariant forall k in i+1..len(v): v[k] == old(v)[k];
     │                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/verify_vector.move:282
     =     at tests/sources/functional/verify_vector.move:254: verify_remove
     =         v = <redacted>
     =         j = <redacted>


### PR DESCRIPTION
This moves the generation of well-formed assumptions out of spec instrumentation into its own processor. The processor runs *after* global invariant instrumentation, so it sees all memory including that which is only used by injected invariants.

This fixes a bug unearthed during the development of specification variables. Namely, if a global invariant uses memory which is not used by the function in which it is injected, we missed to generate the right assumptions for this memory, because usage analysis happens before invariants are injected. In the new model, we run usage analysis again after all specs have been injected, in the new pipeline step `WellFormedInstrumentationProcessor`.

Updates in baselines are caused by slightly different source locations resulting from the new processor and change in order of processing.


## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Remove work around in global_vars.move test

## Related PRs

NA
