### PR TITLE
[ci] workaround gha mounting a new home dir.

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -29,7 +29,8 @@ runs:
     - name: reconfigure container for gha runner
       shell: bash
       run: |
-        echo 'CARGO_HOME=/opt/cargo/' | tee -a $GITHUB_ENV
+        echo 'CARGO_HOME=/opt/cargo' | tee -a $GITHUB_ENV
+        echo 'RUSTUP_HOME=/opt/rustup' | tee -a $GITHUB_ENV
         if [[ "$(uname -s)" == "Darwin" ]]; then
           sudo dscl . append /Groups/wheel GroupMembership $USER
           sudo mkdir -p /opt/cargo || true
@@ -43,18 +44,19 @@ runs:
 
         # prepare move lang prover tooling.
         # By setting these values the dev-setup.sh script can detect already installed executables (and check versions).
-        echo 'Z3_EXE='${HOME}/bin/z3 | tee -a $GITHUB_ENV
-        echo 'CVC4_EXE='${HOME}/bin/cvc4 | tee -a $GITHUB_ENV
-        echo 'DOTNET_ROOT='${HOME}/.dotnet/ | tee -a $GITHUB_ENV
-        echo 'BOOGIE_EXE='${HOME}/.dotnet/tools/boogie | tee -a $GITHUB_ENV
+        echo 'Z3_EXE='/opt/bin/z3 | tee -a $GITHUB_ENV
+        echo 'CVC4_EXE='/opt/bin/cvc4 | tee -a $GITHUB_ENV
+        echo 'DOTNET_ROOT='/opt/dotnet/ | tee -a $GITHUB_ENV
+        echo 'BOOGIE_EXE='/opt/dotnet/tools/boogie | tee -a $GITHUB_ENV
         echo 'MVP_TEST_ON_CI'='1' | tee -a $GITHUB_ENV
-        echo "$HOME/bin" | tee -a $GITHUB_PATH
-        echo "$HOME/.dotnet" | tee -a $GITHUB_PATH
+        echo "/opt/bin" | tee -a $GITHUB_PATH
+        echo "/opt/dotnet" | tee -a $GITHUB_PATH
+        echo "/opt/dotnet/tools" | tee -a $GITHUB_PATH
         echo "/opt/cargo/bin" | tee -a $GITHUB_PATH
         echo '/usr/lib/golang/bin' | tee -a $GITHUB_PATH
     - name: install common dependencies (should be ~ 10 seconds in a linux build, on mac it's a beast.)
       shell: bash
-      run: scripts/dev_setup.sh -t -o -b -p -y -s
+      run: scripts/dev_setup.sh -t -o -b -p -y -s -n
     - id: rust-environment
       shell: bash
       run: |

--- a/docker/ci/alpine/Dockerfile
+++ b/docker/ci/alpine/Dockerfile
@@ -5,40 +5,49 @@ WORKDIR /diem
 COPY rust-toolchain /diem/rust-toolchain
 COPY scripts/dev_setup.sh /diem/scripts/dev_setup.sh
 
-RUN apk add bash=5.1.4-r0 --no-cache
+ENV HOME "/github/home"
+#Needed for sccache to function, and to work around home dir being blatted.
+ENV CARGO_HOME "/opt/cargo"
+ENV RUSTUP_HOME "/opt/rustup"
 
-# Batch mode and all operations tooling
-RUN scripts/dev_setup.sh -t -o -y -b -p -s
-ENV PATH "/root/.cargo/bin:/root/bin/:$PATH"
+RUN apk add bash=5.1.4-r0 --no-cache && \
+    mkdir -p /github/home && \
+    mkdir -p /opt/cargo/ && \
+    mkdir -p /opt/git/ && \
+    /diem/scripts/dev_setup.sh -t -o -b -p -y -s -n
+
+ENV DOTNET_ROOT "/opt/dotnet"
+ENV Z3_EXE "/opt/bin/z3"
+ENV CVC4_EXE "/opt/bin/cvc4"
+ENV BOOGIE_EXE "/opt/dotnet/tools/boogie"
+ENV PATH "/opt/cargo/bin:/usr/lib/golang/bin:/opt/bin:${DOTNET_ROOT}:${DOTNET_ROOT}/tools:$PATH"
 
 FROM setup_ci_alpine as tested_ci_alpine
 
 # Compile a small rust tool?  But we already have in dev_setup (sccache/grcov)...?
 # Test that all commands we need are installed and on the PATH
-RUN [ -x "$(command -v shellcheck)" ] \
-    && [ -x "$(command -v hadolint)" ] \
-    && [ -x "$(command -v vault)" ] \
-    && [ -x "$(command -v terraform)" ] \
-    && [ -x "$(command -v kubectl)" ] \
-    && [ -x "$(command -v rustup)" ] \
-    && [ -x "$(command -v cargo)" ] \
-    && [ -x "$(command -v cargo-guppy)" ] \
-    && [ -x "$(command -v sccache)" ] \
-    && [ -x "$(command -v grcov)" ] \
-    && [ -x "$(command -v helm)" ] \
-    && [ -x "$(command -v aws)" ] \
-    && [ -x "$(command -v z3)" ] \
-    && [ -x "$(command -v tidy)" ] \
-    && [ -x "$(command -v xsltproc)" ] \
-    && [ -x "$(command -v "$HOME/.dotnet/tools/boogie")" ] \
-    && [ -x "$(xargs rustup which cargo --toolchain < /diem/rust-toolchain )" ] \
-    && [ -x "$(command -v tidy)" ] \
-    && [ -x "$(command -v xsltproc)" ] \
-    && [ -x "$(command -v javac)" ] \
-    && [ -x "$(command -v clang)" ] \
-    && [ -x "$(command -v python3)" ] \
-    && [ -x "$(command -v go)" ] \
-    && [ -x "$(command -v npm)" ]
+RUN [ -x "$(set -x; command -v shellcheck)" ] \
+    && [ -x "$(set -x; command -v hadolint)" ] \
+    && [ -x "$(set -x; command -v vault)" ] \
+    && [ -x "$(set -x; command -v terraform)" ] \
+    && [ -x "$(set -x; command -v kubectl)" ] \
+    && [ -x "$(set -x; command -v rustup)" ] \
+    && [ -x "$(set -x; command -v cargo)" ] \
+    && [ -x "$(set -x; command -v cargo-guppy)" ] \
+    && [ -x "$(set -x; command -v sccache)" ] \
+    && [ -x "$(set -x; command -v grcov)" ] \
+    && [ -x "$(set -x; command -v helm)" ] \
+    && [ -x "$(set -x; command -v aws)" ] \
+    && [ -x "$(set -x; command -v z3)" ] \
+    && [ -x "$(set -x; command -v "$BOOGIE_EXE")" ] \
+    && [ -x "$(set -x; xargs rustup which cargo --toolchain < /diem/rust-toolchain )" ] \
+    && [ -x "$(set -x; command -v tidy)" ] \
+    && [ -x "$(set -x; command -v xsltproc)" ] \
+    && [ -x "$(set -x; command -v javac)" ] \
+    && [ -x "$(set -x; command -v clang)" ] \
+    && [ -x "$(set -x; command -v python3)" ] \
+    && [ -x "$(set -x; command -v go)" ] \
+    && [ -x "$(set -x; command -v npm)" ]
 
 # should be a no-op, but since sccache failes to execute, sccache is rebuilt.
 RUN scripts/dev_setup.sh -t -o -y -b -p -s

--- a/docker/ci/arch/Dockerfile
+++ b/docker/ci/arch/Dockerfile
@@ -5,38 +5,51 @@ WORKDIR /diem
 COPY rust-toolchain /diem/rust-toolchain
 COPY scripts/dev_setup.sh /diem/scripts/dev_setup.sh
 
+ENV HOME "/github/home"
+#Needed for sccache to function, and to work around home dir being blatted.
+ENV CARGO_HOME "/opt/cargo"
+ENV RUSTUP_HOME "/opt/rustup"
+
 # WORKAROUND for glibc 2.33 and old Docker
 # See https://github.com/actions/virtual-environments/issues/2658
 # Thanks to https://github.com/lxqt/lxqt-panel/pull/1562
 RUN patched_glibc=glibc-linux4-2.33-4-x86_64.pkg.tar.zst && \
     curl -LO "https://repo.archlinuxcn.org/x86_64/$patched_glibc" && \
-    bsdtar -C / -xvf "$patched_glibc"
+    bsdtar -C / -xvf "$patched_glibc" && \
+    mkdir -p /github/home && \
+    mkdir -p /opt/cargo/ && \
+    mkdir -p /opt/git/ && \
+    /diem/scripts/dev_setup.sh -t -o -b -p -y -n && \
+    pacman -Scc --noconfirm
 
-# Batch mode and all operations tooling
-RUN scripts/dev_setup.sh -t -o -y -b -p && pacman -Scc --noconfirm
-ENV PATH "/root/.cargo/bin:/root/bin/:$PATH"
+ENV DOTNET_ROOT "/opt/dotnet"
+ENV Z3_EXE "/opt/bin/z3"
+ENV CVC4_EXE "/opt/bin/cvc4"
+ENV BOOGIE_EXE "/opt/dotnet/tools/boogie"
+ENV PATH "/opt/cargo/bin:/usr/lib/golang/bin:/opt/bin:${DOTNET_ROOT}:${DOTNET_ROOT}/tools:$PATH"
+
 
 FROM setup_ci_arch as tested_ci_arch
 
 # Compile a small rust tool?  But we already have in dev_setup (sccache/grcov)...?
 # Test that all commands we need are installed and on the PATH
-RUN [ -x "$(command -v shellcheck)" ] \
-    && [ -x "$(command -v hadolint)" ] \
-    && [ -x "$(command -v vault)" ] \
-    && [ -x "$(command -v terraform)" ] \
-    && [ -x "$(command -v kubectl)" ] \
-    && [ -x "$(command -v rustup)" ] \
-    && [ -x "$(command -v cargo)" ] \
-    && [ -x "$(command -v cargo-guppy)" ] \
-    && [ -x "$(command -v sccache)" ] \
-    && [ -x "$(command -v grcov)" ] \
-    && [ -x "$(command -v helm)" ] \
-    && [ -x "$(command -v aws)" ] \
-    && [ -x "$(command -v z3)" ] \
-    && [ -x "$(command -v "$HOME/.dotnet/tools/boogie")" ] \
-    && [ -x "$(xargs rustup which cargo --toolchain < /diem/rust-toolchain )" ] \
-    && [ -x "$(command -v tidy)" ] \
-    && [ -x "$(command -v xsltproc)" ]
+RUN [ -x "$(set -x; command -v shellcheck)" ] \
+    && [ -x "$(set -x; command -v hadolint)" ] \
+    && [ -x "$(set -x; command -v vault)" ] \
+    && [ -x "$(set -x; command -v terraform)" ] \
+    && [ -x "$(set -x; command -v kubectl)" ] \
+    && [ -x "$(set -x; command -v rustup)" ] \
+    && [ -x "$(set -x; command -v cargo)" ] \
+    && [ -x "$(set -x; command -v cargo-guppy)" ] \
+    && [ -x "$(set -x; command -v sccache)" ] \
+    && [ -x "$(set -x; command -v grcov)" ] \
+    && [ -x "$(set -x; command -v helm)" ] \
+    && [ -x "$(set -x; command -v aws)" ] \
+    && [ -x "$(set -x; command -v z3)" ] \
+    && [ -x "$(set -x; command -v "$BOOGIE_EXE")" ] \
+    && [ -x "$(set -x; xargs rustup which cargo --toolchain < /diem/rust-toolchain )" ] \
+    && [ -x "$(set -x; command -v tidy)" ] \
+    && [ -x "$(set -x; command -v xsltproc)" ]
 # These should eventually be installed and tested, but since we don't automate on arch, low pri.
 # && [ -x "$(command -v javac)" ] \
 # && [ -x "$(command -v clang)" ] \

--- a/docker/ci/github/Dockerfile
+++ b/docker/ci/github/Dockerfile
@@ -6,49 +6,50 @@ COPY scripts/dev_setup.sh /diem/scripts/dev_setup.sh
 
 #this is the default home on docker images in gha, until it's not?
 ENV HOME "/github/home"
-#Needed for sccache to function
-ENV CARGO_HOME "/opt/cargo/"
+#Needed for sccache to function, and to work around home dir being blatted.
+ENV CARGO_HOME "/opt/cargo"
+ENV RUSTUP_HOME "/opt/rustup"
 
 # Batch mode and all operations tooling
-RUN mkdir -p /github/home \
-    && mkdir -p /opt/cargo/ \
-    && mkdir -p /opt/git/ \
-    && /diem/scripts/dev_setup.sh -t -o -b -p -y -s\
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /github/home && \
+    mkdir -p /opt/cargo/ && \
+    mkdir -p /opt/git/ && \
+    /diem/scripts/dev_setup.sh -t -o -b -p -y -s -n && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-ENV PATH "/opt/cargo/bin:/usr/lib/golang/bin:/github/home/bin:$PATH"
-ENV DOTNET_ROOT "/github/home/.dotnet"
-ENV Z3_EXE "/github/home/bin/z3"
-ENV CVC4_EXE "/github/home/bin/cvc4"
-ENV BOOGIE_EXE "/github/home/.dotnet/tools/boogie"
+ENV DOTNET_ROOT "/opt/dotnet"
+ENV Z3_EXE "/opt/bin/z3"
+ENV CVC4_EXE "/opt/bin/cvc4"
+ENV BOOGIE_EXE "/opt/dotnet/tools/boogie"
+ENV PATH "/opt/cargo/bin:/usr/lib/golang/bin:/opt/bin:${DOTNET_ROOT}:${DOTNET_ROOT}/tools:$PATH"
 
 FROM setup_ci as tested_ci
 
 # Compile a small rust tool?  But we already have in dev_setup (sccache/grcov)...?
 # Test that all commands we need are installed and on the PATH
-RUN [ -x "$(command -v shellcheck)" ] \
-    && [ -x "$(command -v hadolint)" ] \
-    && [ -x "$(command -v vault)" ] \
-    && [ -x "$(command -v terraform)" ] \
-    && [ -x "$(command -v kubectl)" ] \
-    && [ -x "$(command -v rustup)" ] \
-    && [ -x "$(command -v cargo)" ] \
-    && [ -x "$(command -v cargo-guppy)" ] \
-    && [ -x "$(command -v sccache)" ] \
-    && [ -x "$(command -v grcov)" ] \
-    && [ -x "$(command -v helm)" ] \
-    && [ -x "$(command -v aws)" ] \
-    && [ -x "$(command -v z3)" ] \
-    && [ -x "$(command -v "$HOME/.dotnet/tools/boogie")" ] \
-    && [ -x "$(xargs rustup which cargo --toolchain < /diem/rust-toolchain )" ] \
-    && [ -x "$(command -v tidy)" ] \
-    && [ -x "$(command -v xsltproc)" ] \
-    && [ -x "$(command -v javac)" ] \
-    && [ -x "$(command -v clang)" ] \
-    && [ -x "$(command -v python3)" ] \
-    && [ -x "$(command -v go)" ] \
-    && [ -x "$(command -v npm)" ]
+RUN [ -x "$(set -x; command -v shellcheck)" ] \
+    && [ -x "$(set -x; command -v hadolint)" ] \
+    && [ -x "$(set -x; command -v vault)" ] \
+    && [ -x "$(set -x; command -v terraform)" ] \
+    && [ -x "$(set -x; command -v kubectl)" ] \
+    && [ -x "$(set -x; command -v rustup)" ] \
+    && [ -x "$(set -x; command -v cargo)" ] \
+    && [ -x "$(set -x; command -v cargo-guppy)" ] \
+    && [ -x "$(set -x; command -v sccache)" ] \
+    && [ -x "$(set -x; command -v grcov)" ] \
+    && [ -x "$(set -x; command -v helm)" ] \
+    && [ -x "$(set -x; command -v aws)" ] \
+    && [ -x "$(set -x; command -v z3)" ] \
+    && [ -x "$(set -x; command -v "$BOOGIE_EXE")" ] \
+    && [ -x "$(set -x; xargs rustup which cargo --toolchain < /diem/rust-toolchain )" ] \
+    && [ -x "$(set -x; command -v tidy)" ] \
+    && [ -x "$(set -x; command -v xsltproc)" ] \
+    && [ -x "$(set -x; command -v javac)" ] \
+    && [ -x "$(set -x; command -v clang)" ] \
+    && [ -x "$(set -x; command -v python3)" ] \
+    && [ -x "$(set -x; command -v go)" ] \
+    && [ -x "$(set -x; command -v npm)" ]
 
 # should be a no-op
 # sccache builds fine, but is not executable ??? in alpine, ends up being recompiled.  Wierd.

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -458,7 +458,7 @@ function install_dotnet {
 function install_boogie {
   echo "Installing boogie"
   mkdir -p "${DOTNET_INSTALL_DIR}tools/" || true
-  if [[ "$("${DOTNET_INSTALL_DIR}dotnet" tool list -g)" =~ .*boogie.*${BOOGIE_VERSION}.* ]]; then
+  if [[ "$("${DOTNET_INSTALL_DIR}dotnet" tool list --tool-path "${DOTNET_INSTALL_DIR}tools/")" =~ .*boogie.*${BOOGIE_VERSION}.* ]]; then
     echo "Boogie $BOOGIE_VERSION already installed"
   else
     "${DOTNET_INSTALL_DIR}dotnet" tool update --tool-path "${DOTNET_INSTALL_DIR}tools/" Boogie --version $BOOGIE_VERSION

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -61,7 +61,7 @@ function add_to_profile {
 
 
 # It is important to keep all path updates together to allow this script to work well when run in github actions
-# on inside of a docker image created using this script.   GHA wipes the home directory via docker mount options, so
+# inside of a docker image created using this script.   GHA wipes the home directory via docker mount options, so
 # this profile needs built and sourced on every execution of a job using the docker image.   See the .github/actions/build-setup
 # action in this repo, as well as docker/ci/github/Dockerfile.
 function update_path_and_profile {
@@ -160,7 +160,7 @@ function install_hadolint {
 }
 
 function install_vault {
-  VERSION=$(vault --version || true)
+  VERSION=$("${INSTALL_DIR}"/vault --version || true)
   if [[ "$VERSION" != "Vault v${VAULT_VERSION}" ]]; then
     MACHINE=$(uname -m);
     if [[ $MACHINE == "x86_64" ]]; then
@@ -172,7 +172,7 @@ function install_vault {
     rm "$TMPFILE"
     chmod +x "${INSTALL_DIR}"/vault
   fi
-  vault --version
+  "${INSTALL_DIR}"/vault --version
 }
 
 function install_helm {
@@ -253,14 +253,13 @@ function install_awscli {
       unzip -qq -d "$TMPFILE"/work/ "$TMPFILE"/aws.zip
       TARGET_DIR="${HOME}"/.local/
       if [[ "$OPT_DIR" == "true" ]]; then
-         TARGET_DIR="/opt/aws"
+         TARGET_DIR="/opt/aws/"
       fi
-      mkdir -p "${TARGET_DIR}" || true
-      "$TMPFILE"/work/aws/install -i "${TARGET_DIR}"/aws-cli -b "${INSTALL_DIR}"
-      rm -rf "$TMPFILE"
+      mkdir -p "${TARGET_DIR}"
+      "$TMPFILE"/work/aws/install -i "${TARGET_DIR}" -b "${INSTALL_DIR}"
+      "${INSTALL_DIR}"aws --version
     fi
   fi
-  aws --version
 }
 
 function install_pkg {
@@ -671,7 +670,7 @@ INSTALL_PROVER=false;
 INSTALL_CODEGEN=false;
 INSTALL_INDIVIDUAL=false;
 INSTALL_PACKAGES=();
-INSTALL_DIR="$HOME/bin/"
+INSTALL_DIR="${HOME}/bin/"
 OPT_DIR="false"
 
 #parse args


### PR DESCRIPTION
## Motivation

GHA mounts the home dir, so working around it by optionally installing tools from dev_setup.sh in /opt/ dir.   Should save a minute per job, and make CI less fragile.

This saves a minute from every rust job (tooling reinstall time), makes the CI more robust (dotnet downloads tend to fail when azure has a partial outage), and will be a good introduction to Todd, and deim-dev-infra team to what goes in to maintaining this fairly intricate part of CI that exists to make our builds more stable (no download failures), portable (the same dev-setup.sh was used to in circleci, and by some devs in move team), and to work around the limitations of gha (we can't build a docker image and use it in a pr securely - gha can't pull images from gha artifacts) so we have to keep dev-setup.sh idempotent on dev desktops and on CI systems.

### Have you read the [Contributing Guidelines on pull requests]

Y

## Test Plan

CI, branched builds, hacked base image names, and all sorts of other fun.

Tested running in the gha-test-2 branch, by building the full base image, and running a pr against that branch here:
https://github.com/diem/diem/pull/9233/checks?check_run_id=3669290167.   It did show that boogie was always reinstalling so correcting that, first corrected on that test pr, then pushed back to this pr, then pushed directly to gha-test-2.

## Related PRs

None 

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
