### PR TITLE
[State Sync] Add new `TransactionOutputListWithProof` and rename `TransactionListProof` -> `TransactionInfoListWithProof`

### DIFF
--- a/execution/executor/src/executor_test.rs
+++ b/execution/executor/src/executor_test.rs
@@ -616,7 +616,7 @@ proptest! {
             prop_assert_eq!(db.get_latest_version().unwrap(), num_txns as Version);
             let txn_list = db.get_transactions(1 /* start version */, num_txns, num_txns as Version /* ledger version */, false /* fetch events */).unwrap();
             prop_assert_eq!(&block.txns, &txn_list.transactions);
-            let (_, txn_infos) = txn_list.proof.unpack();
+            let txn_infos = txn_list.proof.transaction_infos;
 
             // replay txns in one batch across epoch boundary,
             // and the replayer should deal with `Retry`s automatically

--- a/execution/executor/src/lib.rs
+++ b/execution/executor/src/lib.rs
@@ -216,12 +216,13 @@ where
 
         // If the proof is verified, then the length of txn_infos and txns must be the same.
         let skipped_transaction_infos =
-            &txn_list_with_proof.proof.transaction_infos()[..num_txns_to_skip as usize];
+            &txn_list_with_proof.proof.transaction_infos[..num_txns_to_skip as usize];
 
         // Left side of the proof happens to be the frozen subtree roots of the accumulator
         // right before the list of txns are applied.
         let frozen_subtree_roots_from_proof = txn_list_with_proof
             .proof
+            .ledger_info_to_transaction_infos_proof
             .left_siblings()
             .iter()
             .rev()
@@ -246,7 +247,7 @@ where
         // 3. Return verified transactions to be applied.
         let mut txns: Vec<_> = txn_list_with_proof.transactions;
         txns.drain(0..num_txns_to_skip as usize);
-        let (_, mut txn_infos) = txn_list_with_proof.proof.unpack();
+        let mut txn_infos = txn_list_with_proof.proof.transaction_infos;
         txn_infos.drain(0..num_txns_to_skip as usize);
 
         Ok((txns, txn_infos))

--- a/json-rpc/src/tests/utils.rs
+++ b/json-rpc/src/tests/utils.rs
@@ -25,7 +25,7 @@ use diem_types::{
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     proof::{
         AccumulatorConsistencyProof, AccumulatorRangeProof, SparseMerkleProof,
-        TransactionAccumulatorProof, TransactionInfoWithProof, TransactionListProof,
+        TransactionAccumulatorProof, TransactionInfoListWithProof, TransactionInfoWithProof,
     },
     state_proof::StateProof,
     transaction::{
@@ -238,7 +238,8 @@ impl DbReader for MockDiemDB {
                 ));
             });
         let first_transaction_version = transactions.first().map(|_| start_version);
-        let proof = TransactionListProof::new(AccumulatorRangeProof::new_empty(), txn_infos);
+        let proof =
+            TransactionInfoListWithProof::new(AccumulatorRangeProof::new_empty(), txn_infos);
 
         let events = if fetch_events {
             let events = (start_version..start_version + transactions.len() as u64)

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -19,7 +19,7 @@ use diem_types::{
     event::EventKey,
     proof::{
         AccountStateProof, AccumulatorConsistencyProof, SparseMerkleProof,
-        TransactionAccumulatorProof, TransactionInfoWithProof, TransactionListProof,
+        TransactionAccumulatorProof, TransactionInfoListWithProof, TransactionInfoWithProof,
     },
     state_proof::StateProof,
     transaction::{
@@ -966,7 +966,7 @@ impl TransactionsWithProofsView {
             transactions,
             events,
             first_transaction_version,
-            proof: TransactionListProof::try_from(&self.proofs)?,
+            proof: TransactionInfoListWithProof::try_from(&self.proofs)?,
         })
     }
 }
@@ -1001,10 +1001,10 @@ pub struct TransactionsProofsView {
     pub transaction_infos: BytesView,
 }
 
-impl TryFrom<&TransactionListProof> for TransactionsProofsView {
+impl TryFrom<&TransactionInfoListWithProof> for TransactionsProofsView {
     type Error = Error;
 
-    fn try_from(proof: &TransactionListProof) -> Result<Self, Self::Error> {
+    fn try_from(proof: &TransactionInfoListWithProof) -> Result<Self, Self::Error> {
         Ok(TransactionsProofsView {
             ledger_info_to_transaction_infos_proof: BytesView::new(bcs::to_bytes(
                 &proof.ledger_info_to_transaction_infos_proof,
@@ -1014,11 +1014,11 @@ impl TryFrom<&TransactionListProof> for TransactionsProofsView {
     }
 }
 
-impl TryFrom<&TransactionsProofsView> for TransactionListProof {
+impl TryFrom<&TransactionsProofsView> for TransactionInfoListWithProof {
     type Error = Error;
 
     fn try_from(view: &TransactionsProofsView) -> Result<Self, Self::Error> {
-        Ok(TransactionListProof {
+        Ok(TransactionInfoListWithProof {
             ledger_info_to_transaction_infos_proof: bcs::from_bytes(
                 &view.ledger_info_to_transaction_infos_proof,
             )?,

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -863,7 +863,7 @@ impl TryFrom<TransactionListWithProof> for TransactionListView {
     type Error = Error;
 
     fn try_from(txs: TransactionListWithProof) -> Result<Self, Self::Error> {
-        if txs.is_empty() {
+        if txs.transactions.is_empty() {
             return Ok(Self::empty());
         }
         let start_version = txs

--- a/state-sync/state-sync-v1/src/chunk_response.rs
+++ b/state-sync/state-sync-v1/src/chunk_response.rs
@@ -87,7 +87,7 @@ impl fmt::Display for GetChunkResponse {
             None => "empty".to_string(),
             Some(first_version) => {
                 let last_version = first_version
-                    .checked_add(self.txn_list_with_proof.len() as u64)
+                    .checked_add(self.txn_list_with_proof.transactions.len() as u64)
                     .and_then(|v| v.checked_sub(1)) // last_version = first_version + txns.len() - 1
                     .map(|v| v.to_string())
                     .unwrap_or_else(|| "Last version has overflown!".into());

--- a/state-sync/state-sync-v1/src/coordinator.rs
+++ b/state-sync/state-sync-v1/src/coordinator.rs
@@ -948,7 +948,7 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
 
         // Process the chunk based on the response type
         let txn_list_with_proof = response.txn_list_with_proof.clone();
-        let chunk_size = response.txn_list_with_proof.len() as u64;
+        let chunk_size = response.txn_list_with_proof.transactions.len() as u64;
         let known_version = self.local_state.synced_version();
         match response.response_li {
             ResponseLedgerInfo::VerifiableLedgerInfo(li) => {
@@ -1241,7 +1241,7 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
         let new_version = self
             .local_state
             .synced_version()
-            .checked_add(txn_list_with_proof.len() as u64)
+            .checked_add(txn_list_with_proof.transactions.len() as u64)
             .ok_or_else(|| {
                 Error::IntegerOverflow("Potential state sync version has overflown".into())
             })?;

--- a/state-sync/state-sync-v1/src/coordinator.rs
+++ b/state-sync/state-sync-v1/src/coordinator.rs
@@ -1741,7 +1741,7 @@ mod tests {
         chain_id::ChainId,
         contract_event::ContractEvent,
         ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-        proof::TransactionListProof,
+        proof::TransactionInfoListWithProof,
         transaction::{
             RawTransaction, Script, SignedTransaction, Transaction, TransactionListWithProof,
             TransactionPayload, Version,
@@ -2365,7 +2365,7 @@ mod tests {
             vec![create_test_transaction()],
             None,
             Some(version),
-            TransactionListProof::new_empty(),
+            TransactionInfoListWithProof::new_empty(),
         )
     }
 

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -28,7 +28,7 @@ use diem_types::{
         parse_memory, NetworkAddress, Protocol,
     },
     on_chain_config::ValidatorSet,
-    proof::TransactionListProof,
+    proof::TransactionInfoListWithProof,
     test_helpers::transaction_test_helpers::get_test_signed_txn,
     transaction::{
         authenticator::AuthenticationKey, SignedTransaction, Transaction, TransactionListWithProof,
@@ -859,7 +859,7 @@ impl ExecutorProxyTrait for MockExecutorProxy {
             txns,
             None,
             first_txn_version,
-            TransactionListProof::new_empty(),
+            TransactionInfoListWithProof::new_empty(),
         );
         (self.handler)(txns_with_proof)
     }

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -17,7 +17,7 @@ use diem_types::{
     epoch_change::EpochChangeProof,
     event::EventKey,
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
-    proof::{SparseMerkleProof, TransactionListProof},
+    proof::{SparseMerkleProof, TransactionInfoListWithProof},
     state_proof::StateProof,
     transaction::{
         AccountTransactionsWithProof, RawTransaction, Script, SignedTransaction, Transaction,
@@ -309,7 +309,7 @@ impl DbReader for MockDbReaderWriter {
             transactions,
             events,
             first_transaction_version: Some(start_version),
-            proof: TransactionListProof::new_empty(),
+            proof: TransactionInfoListWithProof::new_empty(),
         })
     }
 

--- a/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/restore.rs
@@ -21,7 +21,7 @@ use diem_logger::prelude::*;
 use diem_types::{
     contract_event::ContractEvent,
     ledger_info::LedgerInfoWithSignatures,
-    proof::{TransactionAccumulatorRangeProof, TransactionListProof},
+    proof::{TransactionAccumulatorRangeProof, TransactionInfoListWithProof},
     transaction::{Transaction, TransactionInfo, TransactionListWithProof, Version},
 };
 use diem_vm::DiemVM;
@@ -115,12 +115,15 @@ impl LoadedChunk {
             txns,
             Some(event_vecs),
             Some(manifest.first_version),
-            TransactionListProof::new(range_proof, txn_infos),
+            TransactionInfoListWithProof::new(range_proof, txn_infos),
         );
         txn_list_with_proof.verify(ledger_info.ledger_info(), Some(manifest.first_version))?;
         // and disassemble it to get things back.
         let txns = txn_list_with_proof.transactions;
-        let (range_proof, txn_infos) = txn_list_with_proof.proof.unpack();
+        let range_proof = txn_list_with_proof
+            .proof
+            .ledger_info_to_transaction_infos_proof;
+        let txn_infos = txn_list_with_proof.proof.transaction_infos;
         let event_vecs = txn_list_with_proof.events.expect("unknown to be Some.");
 
         Ok(Self {

--- a/storage/diemdb/src/diemdb_test.rs
+++ b/storage/diemdb/src/diemdb_test.rs
@@ -517,7 +517,7 @@ fn verify_committed_transactions(
         txn_list_with_proof
             .verify(ledger_info, Some(cur_ver))
             .unwrap();
-        assert_eq!(txn_list_with_proof.len(), 1);
+        assert_eq!(txn_list_with_proof.transactions.len(), 1);
 
         // Fetch and verify account states.
         for (addr, expected_blob) in txn_to_commit.account_states() {

--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -69,7 +69,7 @@ use diem_types::{
     ledger_info::LedgerInfoWithSignatures,
     proof::{
         AccountStateProof, AccumulatorConsistencyProof, EventProof, SparseMerkleProof,
-        TransactionListProof,
+        TransactionInfoListWithProof,
     },
     state_proof::StateProof,
     transaction::{
@@ -725,7 +725,7 @@ impl DbReader for DiemDB {
             } else {
                 None
             };
-            let proof = TransactionListProof::new(
+            let proof = TransactionInfoListWithProof::new(
                 self.ledger_store.get_transaction_range_proof(
                     Some(start_version),
                     limit,

--- a/testsuite/diem-fuzzer/src/fuzz_targets.rs
+++ b/testsuite/diem-fuzzer/src/fuzz_targets.rs
@@ -52,7 +52,7 @@ static ALL_TARGETS: Lazy<BTreeMap<&'static str, Box<dyn FuzzTargetImpl>>> = Lazy
         Box::new(proof::TransactionInfoWithProofFuzzer::default()),
         Box::new(proof::AccountStateProofFuzzer::default()),
         Box::new(proof::EventProofFuzzer::default()),
-        Box::new(proof::TransactionListProofFuzzer::default()),
+        Box::new(proof::TransactionInfoListWithProofFuzzer::default()),
         // Network
         Box::new(network::NetworkNoiseInitiator::default()),
         Box::new(network::NetworkNoiseResponder::default()),

--- a/testsuite/diem-fuzzer/src/fuzz_targets/proof.rs
+++ b/testsuite/diem-fuzzer/src/fuzz_targets/proof.rs
@@ -9,7 +9,7 @@ use diem_types::{
     ledger_info::LedgerInfo,
     proof::{
         AccountStateProof, EventProof, SparseMerkleProof, TestAccumulatorProof,
-        TestAccumulatorRangeProof, TransactionInfoWithProof, TransactionListProof,
+        TestAccumulatorRangeProof, TransactionInfoListWithProof, TransactionInfoWithProof,
     },
     transaction::Version,
 };
@@ -204,33 +204,30 @@ impl FuzzTargetImpl for EventProofFuzzer {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct TransactionListProofFuzzer;
+pub struct TransactionInfoListWithProofFuzzer;
 
 #[derive(Debug, Arbitrary)]
-struct TransactionListProofFuzzerInput {
-    proof: TransactionListProof,
+struct TransactionInfoListWithProofFuzzerInput {
+    proof: TransactionInfoListWithProof,
     ledger_info: LedgerInfo,
     first_transaction_version: Option<Version>,
-    transaction_hashes: Vec<HashValue>,
 }
 
-impl FuzzTargetImpl for TransactionListProofFuzzer {
+impl FuzzTargetImpl for TransactionInfoListWithProofFuzzer {
     fn description(&self) -> &'static str {
-        "Proof: TransactionListProof"
+        "Proof: TransactionInfoListWithProof"
     }
 
     fn generate(&self, _idx: usize, _gen: &mut ValueGenerator) -> Option<Vec<u8>> {
-        Some(corpus_from_strategy(
-            any::<TransactionListProofFuzzerInput>(),
-        ))
+        Some(corpus_from_strategy(any::<
+            TransactionInfoListWithProofFuzzerInput,
+        >()))
     }
 
     fn fuzz(&self, data: &[u8]) {
-        let input = fuzz_data_to_value(data, any::<TransactionListProofFuzzerInput>());
-        let _res = input.proof.verify(
-            &input.ledger_info,
-            input.first_transaction_version,
-            &input.transaction_hashes[..],
-        );
+        let input = fuzz_data_to_value(data, any::<TransactionInfoListWithProofFuzzerInput>());
+        let _res = input
+            .proof
+            .verify(&input.ledger_info, input.first_transaction_version);
     }
 }

--- a/types/src/proof/mod.rs
+++ b/types/src/proof/mod.rs
@@ -32,7 +32,7 @@ pub use self::definition::{
     AccountStateProof, AccumulatorConsistencyProof, AccumulatorExtensionProof, AccumulatorProof,
     AccumulatorRangeProof, EventAccumulatorProof, EventProof, SparseMerkleProof,
     SparseMerkleRangeProof, TransactionAccumulatorProof, TransactionAccumulatorRangeProof,
-    TransactionAccumulatorSummary, TransactionInfoWithProof, TransactionListProof,
+    TransactionAccumulatorSummary, TransactionInfoListWithProof, TransactionInfoWithProof,
 };
 
 #[cfg(any(test, feature = "fuzzing"))]

--- a/types/src/proof/unit_tests/proof_conversion_test.rs
+++ b/types/src/proof/unit_tests/proof_conversion_test.rs
@@ -5,8 +5,8 @@ use crate::{
     account_state_blob::AccountStateBlob,
     proof::{
         AccountStateProof, AccumulatorConsistencyProof, EventProof, SparseMerkleRangeProof,
-        TestAccumulatorProof, TestAccumulatorRangeProof, TransactionInfoWithProof,
-        TransactionListProof,
+        TestAccumulatorProof, TestAccumulatorRangeProof, TransactionInfoListWithProof,
+        TransactionInfoWithProof,
     },
 };
 use bcs::test_helpers::assert_canonical_encode_decode;
@@ -72,7 +72,7 @@ proptest! {
 
 
     #[test]
-    fn test_transaction_list_proof_bcs_roundtrip(proof in any::<TransactionListProof>()) {
+    fn test_transaction_list_proof_bcs_roundtrip(proof in any::<TransactionInfoListWithProof>()) {
         assert_canonical_encode_decode(proof);
     }
 }

--- a/types/src/proptest_types.rs
+++ b/types/src/proptest_types.rs
@@ -16,7 +16,7 @@ use crate::{
     event::{EventHandle, EventKey},
     ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
     on_chain_config::ValidatorSet,
-    proof::TransactionListProof,
+    proof::TransactionInfoListWithProof,
     transaction::{
         ChangeSet, Module, RawTransaction, Script, SignatureCheckedTransaction, SignedTransaction,
         Transaction, TransactionArgument, TransactionListWithProof, TransactionPayload,
@@ -892,7 +892,7 @@ fn arb_transaction_list_with_proof() -> impl Strategy<Value = TransactionListWit
             ),
             0..10,
         ),
-        any::<TransactionListProof>(),
+        any::<TransactionInfoListWithProof>(),
     )
         .prop_flat_map(|(transaction_and_events, proof)| {
             let transactions: Vec<_> = transaction_and_events


### PR DESCRIPTION
## Motivation

This PR adds a new proof struct required by state sync for `TransactionOutput` processing: `TransactionOutputListWithProof`. To achieve this, the PR also does the following:
- Renames `TransactionListProof` to `TransactionInfoListWithProof` and modifies the `verify()` function of `TransactionInfoListWithProof` to only verify that the list of transaction infos are attested by the ledger info. This is required so that `TransactionInfoListWithProof` can be shared by `TransactionListWithProof` and the new `TransactionOutputListWithProof`.
- Moves the old verification logic from `verify()` in `TransactionListProof` (that checks each transaction maps to the transaction info) to the `verify()` function of `TransactionListWithProof` as this logic is about transactions (!) not transaction infos.
- Cleans up some of the code around the proofs and adds unit tests for all 3 structs.

This PR offers the following commits:
1. Clean up some methods around `TransactionListWithProof`, specifically old comments, unused methods and various accessor methods (these are unnecessary as the fields are all public anyway...).
2. Add `TransactionOutputListWithProof` and rename `TransactionListProof` to `TransactionInfoListWithProof`. Here, we change the verification logic (as described above) and do various clean ups.
4. Add simple unit tests for `TransactionListWithProof`, `TransactionInfoListWithProof` and `TransactionOutputListWithProof`.

Notes:
- This change should *not* be a breaking change. The [BCS](https://github.com/diem/bcs) spec notes that the names of structs should not be used when serialized across the wire. As a result, two nodes should be able to serialize/deserialize messages successfully, even if the messages have different local names 😄. Moreover, restructuring the `verify()` methods is not expected to affect any external dependencies.
- Unit tests were previously missing for `TransactionListWithProof` and `TransactionListProof`, however, much (not all) of this functionality is tested in end-to-end tests (e.g., in the executor). The unit tests should help close the gap a little.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

A set of simple unit tests have been added for this functionality. Likewise, end-to-end tests will also ensure correctness in the future.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906