### PR TITLE
[mempool/state-sync] Make PeerNetworkId copyable

### DIFF
--- a/config/src/config/upstream_config.rs
+++ b/config/src/config/upstream_config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use short_hex_str::AsShortHexStr;
 use std::fmt;
 
-#[derive(Clone, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(Clone, Copy, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 /// Identifier of a node, represented as (network_id, peer_id)
 pub struct PeerNetworkId {
     network_id: NetworkId,

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -205,7 +205,7 @@ async fn handle_event<V>(
         Event::NewPeer(metadata) => {
             counters::shared_mempool_event_inc("new_peer");
             let peer = PeerNetworkId::new(network_id, metadata.remote_peer_id);
-            let is_new_peer = smp.peer_manager.add_peer(peer.clone(), metadata.clone());
+            let is_new_peer = smp.peer_manager.add_peer(peer, metadata.clone());
             let is_upstream_peer = smp.peer_manager.is_upstream_peer(&peer, Some(&metadata));
             debug!(LogSchema::new(LogEntry::NewPeer)
                 .peer(&peer)

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -365,7 +365,7 @@ impl PeerManager {
             peer_states
                 .iter()
                 .filter(|(_, state)| state.is_alive)
-                .map(|(peer, state)| (peer.clone(), state.metadata.role))
+                .map(|(peer, state)| (*peer, state.metadata.role))
                 .collect()
         };
 
@@ -376,7 +376,7 @@ impl PeerManager {
         let peers: Vec<_> = peers
             .iter()
             .sorted_by(|peer_a, peer_b| compare_prioritized_peers(peer_a, peer_b))
-            .map(|(peer, _)| peer.clone())
+            .map(|(peer, _)| *peer)
             .collect();
         let _ = std::mem::replace(&mut *prioritized_peers, peers);
     }

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -52,7 +52,7 @@ pub(crate) fn execute_broadcast<V>(
     V: TransactionValidation,
 {
     let peer_manager = &smp.peer_manager.clone();
-    peer_manager.execute_broadcast(peer.clone(), backoff, smp);
+    peer_manager.execute_broadcast(peer, backoff, smp);
     let schedule_backoff = peer_manager.is_backoff_mode(&peer);
 
     let interval_ms = if schedule_backoff {
@@ -117,7 +117,7 @@ pub(crate) async fn process_transaction_broadcast<V>(
         peer.peer_id().short_str().as_str(),
     );
     let results = process_incoming_transactions(&smp, transactions.clone(), timeline_state).await;
-    log_txn_process_results(&results, Some(peer.clone()));
+    log_txn_process_results(&results, Some(peer));
 
     let ack_response = gen_ack_response(request_id, results, &peer);
     let network_sender = smp

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -104,7 +104,7 @@ impl Future for ScheduledBroadcast {
 
             Poll::Pending
         } else {
-            Poll::Ready((self.peer.clone(), self.backoff))
+            Poll::Ready((self.peer, self.backoff))
         }
     }
 }

--- a/state-sync/state-sync-v1/src/coordinator.rs
+++ b/state-sync/state-sync-v1/src/coordinator.rs
@@ -277,7 +277,7 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
                     .start_timer();
 
                 // Process chunk request
-                let process_result = self.process_chunk_request(peer.clone(), *request.clone());
+                let process_result = self.process_chunk_request(peer, *request.clone());
                 if let Err(ref error) = process_result {
                     error!(
                         LogSchema::event_log(LogEntry::ProcessChunkRequest, LogEvent::Fail)
@@ -1644,7 +1644,7 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
                 return false;
             }
             if request_info.known_version < highest_li_version {
-                ready.push((peer.clone(), request_info.clone()));
+                ready.push((*peer, request_info.clone()));
                 false
             } else {
                 true
@@ -1653,7 +1653,7 @@ impl<T: ExecutorProxyTrait, M: MempoolNotificationSender> StateSyncCoordinator<T
 
         ready.into_iter().for_each(|(peer, request_info)| {
             let result_label = if let Err(err) =
-                self.deliver_subscription(peer.clone(), request_info, highest_li_version)
+                self.deliver_subscription(peer, request_info, highest_li_version)
             {
                 error!(LogSchema::new(LogEntry::SubscriptionDeliveryFail)
                     .peer(&peer)


### PR DESCRIPTION
## Motivation
 
Last of the "make X copyable" PRs, this makes `PeerNetworkId` copyable, as it's the main key for all things multi network.  It was clear this was a bit of an annoyance when working on Mempool updates.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Current tests
