### PR TITLE
[api] better error handlings and response ledger info in header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,7 +933,7 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "strsim",
  "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
@@ -1487,41 +1487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "strsim 0.10.0",
- "syn 1.0.74",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade7bff147130fe5e6d39f089c6bd49ec0250f35d70b2eebf72afdfc919f15cc"
-dependencies = [
- "darling_core",
- "quote 1.0.9",
- "syn 1.0.74",
-]
-
-[[package]]
 name = "dashmap"
 version = "3.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,7 +1621,6 @@ dependencies = [
  "resource-viewer",
  "serde",
  "serde_json",
- "serde_with",
  "warp",
 ]
 
@@ -4181,12 +4145,6 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -7035,12 +6993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
-
-[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7445,29 +7397,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062b87e45d8f26714eacfaef0ed9a583e2bfd50ebd96bdd3c200733bd5758e2c"
-dependencies = [
- "rustversion",
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c1fcca18d55d1763e1c16873c4bde0ac3ef75179a28c7b372917e0494625be"
-dependencies = [
- "darling",
- "proc-macro2 1.0.28",
- "quote 1.0.9",
- "syn 1.0.74",
 ]
 
 [[package]]
@@ -8100,12 +8029,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -3,7 +3,7 @@
 
 use crate::context::Context;
 
-use diem_api_types::{Address, Error, MoveResource};
+use diem_api_types::{Address, Error, MoveResource, Response};
 use diem_types::account_state::AccountState;
 use resource_viewer::MoveValueAnnotator;
 
@@ -34,7 +34,7 @@ async fn handle_get_account_resources(
     let ledger_info = context.get_latest_ledger_info().map_err(Error::internal)?;
 
     let state = context
-        .get_account_state(address.into_inner(), ledger_info.ledger_info().version())
+        .get_account_state(address.into_inner(), ledger_info.version())
         .map_err(Error::internal)?
         .ok_or_else(|| account_not_found(&address_str))?;
 
@@ -48,7 +48,7 @@ async fn handle_get_account_resources(
             .map_err(Error::internal)?;
         resources.push(MoveResource::from(resource));
     }
-    Ok(warp::reply::json(&resources))
+    Ok(Response::new(ledger_info, &resources).map_err(Error::internal)?)
 }
 
 fn account_not_found(address: &str) -> Error {

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -35,7 +35,7 @@ impl Context {
         warp::any().map(move || self.clone())
     }
 
-    pub fn get_latest_ledger_info(&self) -> Result<LedgerInfo> {
+    pub fn get_latest_ledger_info(&self) -> Result<LedgerInfo, Error> {
         Ok(LedgerInfo::new(
             self.chain_id(),
             &self.db.get_latest_ledger_info()?,

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -54,7 +54,7 @@ impl Context {
         ledger_version: u64,
     ) -> Result<AccountState, Error> {
         let state = self
-            .get_account_state_blob(address.into_inner(), ledger_version)?
+            .get_account_state_blob(address.into(), ledger_version)?
             .ok_or_else(|| account_not_found(&address.to_string(), ledger_version))?;
         Ok(AccountState::try_from(&state)?)
     }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1,14 +1,20 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_api_types::LedgerInfo;
+use diem_api_types::{Address, Error, LedgerInfo};
 use diem_types::{
-    account_address::AccountAddress, account_state_blob::AccountStateBlob, chain_id::ChainId,
+    account_address::AccountAddress, account_state::AccountState,
+    account_state_blob::AccountStateBlob, chain_id::ChainId,
 };
 use storage_interface::MoveDbReader;
 
 use anyhow::Result;
-use std::{borrow::Borrow, convert::Infallible, sync::Arc};
+use serde_json::json;
+use std::{
+    borrow::Borrow,
+    convert::{Infallible, TryFrom},
+    sync::Arc,
+};
 use warp::Filter;
 
 // Context holds application scope context
@@ -44,6 +50,17 @@ impl Context {
 
     pub fn get_account_state(
         &self,
+        address: &Address,
+        ledger_version: u64,
+    ) -> Result<AccountState, Error> {
+        let state = self
+            .get_account_state_blob(address.into_inner(), ledger_version)?
+            .ok_or_else(|| account_not_found(&address.to_string(), ledger_version))?;
+        Ok(AccountState::try_from(&state)?)
+    }
+
+    pub fn get_account_state_blob(
+        &self,
         account: AccountAddress,
         version: u64,
     ) -> Result<Option<AccountStateBlob>> {
@@ -52,4 +69,11 @@ impl Context {
             .get_account_state_with_proof_by_version(account, version)?;
         Ok(account_state_blob)
     }
+}
+
+fn account_not_found(address: &str, ledger_version: u64) -> Error {
+    Error::not_found(
+        format!("could not find account by address: {}", address),
+        json!({ "ledger_version": ledger_version.to_string() }),
+    )
 }

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -1,9 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use diem_api_types::LedgerInfo;
 use diem_types::{
     account_address::AccountAddress, account_state_blob::AccountStateBlob, chain_id::ChainId,
-    ledger_info::LedgerInfoWithSignatures,
 };
 use storage_interface::MoveDbReader;
 
@@ -35,8 +35,11 @@ impl Context {
         warp::any().map(move || self.clone())
     }
 
-    pub fn get_latest_ledger_info(&self) -> Result<LedgerInfoWithSignatures> {
-        self.db.get_latest_ledger_info()
+    pub fn get_latest_ledger_info(&self) -> Result<LedgerInfo> {
+        Ok(LedgerInfo::new(
+            self.chain_id(),
+            &self.db.get_latest_ledger_info()?,
+        ))
     }
 
     pub fn get_account_state(

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{accounts, context::Context};
-use diem_api_types::{Error, LedgerInfo};
+use diem_api_types::{Error, Response};
 
 use std::convert::Infallible;
 use warp::{http::StatusCode, reply, Filter, Rejection, Reply};
@@ -22,17 +22,8 @@ pub fn index(context: Context) -> impl Filter<Extract = impl Reply, Error = Reje
 }
 
 pub async fn handle_index(context: Context) -> Result<impl Reply, Rejection> {
-    let ledger_info = context.get_latest_ledger_info().map_err(Error::internal)?;
-    let chain_id = context.chain_id().id();
-    let ledger_version = ledger_info.ledger_info().version().into();
-    let ledger_timestamp = ledger_info.ledger_info().timestamp_usecs().into();
-
-    let info = LedgerInfo {
-        chain_id,
-        ledger_version,
-        ledger_timestamp,
-    };
-    Ok(warp::reply::json(&info))
+    let info = context.get_latest_ledger_info().map_err(Error::internal)?;
+    Ok(Response::new(info.clone(), &info).map_err(Error::internal)?)
 }
 
 async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
@@ -64,8 +55,8 @@ mod test {
         let ledger_info = context.get_latest_ledger_info().unwrap();
         let expected = json!({
             "chain_id": 4,
-            "ledger_version": ledger_info.ledger_info().version().to_string(),
-            "ledger_timestamp": ledger_info.ledger_info().timestamp_usecs().to_string(),
+            "ledger_version": ledger_info.version().to_string(),
+            "ledger_timestamp": ledger_info.timestamp().to_string(),
         });
 
         assert_eq!(expected, resp);

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -22,8 +22,8 @@ pub fn index(context: Context) -> impl Filter<Extract = impl Reply, Error = Reje
 }
 
 pub async fn handle_index(context: Context) -> Result<impl Reply, Rejection> {
-    let info = context.get_latest_ledger_info().map_err(Error::internal)?;
-    Ok(Response::new(info.clone(), &info).map_err(Error::internal)?)
+    let info = context.get_latest_ledger_info()?;
+    Ok(Response::new(info.clone(), &info)?)
 }
 
 async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -24,8 +24,8 @@ pub fn index(context: Context) -> impl Filter<Extract = impl Reply, Error = Reje
 pub async fn handle_index(context: Context) -> Result<impl Reply, Rejection> {
     let ledger_info = context.get_latest_ledger_info().map_err(Error::internal)?;
     let chain_id = context.chain_id().id();
-    let ledger_version = ledger_info.ledger_info().version();
-    let ledger_timestamp = ledger_info.ledger_info().timestamp_usecs();
+    let ledger_version = ledger_info.ledger_info().version().into();
+    let ledger_timestamp = ledger_info.ledger_info().timestamp_usecs().into();
 
     let info = LedgerInfo {
         chain_id,

--- a/api/types/Cargo.toml
+++ b/api/types/Cargo.toml
@@ -14,7 +14,6 @@ anyhow = "1.0.38"
 hex = "0.4.3"
 serde = { version = "1.0.124", default-features = false }
 serde_json = "1.0.64"
-serde_with = "1.10.0"
 warp = { version = "0.3.0", features = ["default"] }
 
 diem-types = { path = "../../types" }

--- a/api/types/src/ledger_info.rs
+++ b/api/types/src/ledger_info.rs
@@ -4,6 +4,7 @@
 use crate::U64;
 
 use diem_types::{chain_id::ChainId, ledger_info::LedgerInfoWithSignatures};
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -24,10 +25,10 @@ impl LedgerInfo {
     }
 
     pub fn version(&self) -> u64 {
-        self.ledger_version.into_inner()
+        self.ledger_version.into()
     }
 
     pub fn timestamp(&self) -> u64 {
-        self.ledger_timestamp.into_inner()
+        self.ledger_timestamp.into()
     }
 }

--- a/api/types/src/ledger_info.rs
+++ b/api/types/src/ledger_info.rs
@@ -1,15 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::U64;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr};
 
-#[serde_as]
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct LedgerInfo {
     pub chain_id: u8,
-    #[serde_as(as = "DisplayFromStr")]
-    pub ledger_version: u64,
-    #[serde_as(as = "DisplayFromStr")]
-    pub ledger_timestamp: u64,
+    pub ledger_version: U64,
+    pub ledger_timestamp: U64,
 }

--- a/api/types/src/ledger_info.rs
+++ b/api/types/src/ledger_info.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::U64;
+
+use diem_types::{chain_id::ChainId, ledger_info::LedgerInfoWithSignatures};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
@@ -9,4 +11,23 @@ pub struct LedgerInfo {
     pub chain_id: u8,
     pub ledger_version: U64,
     pub ledger_timestamp: U64,
+}
+
+impl LedgerInfo {
+    pub fn new(chain_id: &ChainId, info: &LedgerInfoWithSignatures) -> Self {
+        let ledger_info = info.ledger_info();
+        Self {
+            chain_id: chain_id.id(),
+            ledger_version: ledger_info.version().into(),
+            ledger_timestamp: ledger_info.timestamp_usecs().into(),
+        }
+    }
+
+    pub fn version(&self) -> u64 {
+        self.ledger_version.into_inner()
+    }
+
+    pub fn timestamp(&self) -> u64 {
+        self.ledger_timestamp.into_inner()
+    }
 }

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -5,6 +5,7 @@ mod address;
 mod error;
 mod ledger_info;
 mod move_types;
+mod response;
 
 pub use address::Address;
 pub use error::Error;
@@ -13,3 +14,4 @@ pub use move_types::{
     HexEncodedBytes, MoveResource, MoveResourceType, MoveStructTag, MoveStructValue, MoveTypeTag,
     MoveValue, U128, U64,
 };
+pub use response::{Response, X_DIEM_CHAIN_ID, X_DIEM_LEDGER_TIMESTAMP, X_DIEM_LEDGER_VERSION};

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -35,18 +35,24 @@ impl From<AnnotatedMoveStruct> for MoveResource {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Copy)]
 pub struct U64(u64);
-
-impl U64 {
-    pub fn into_inner(&self) -> u64 {
-        self.0
-    }
-}
 
 impl From<u64> for U64 {
     fn from(d: u64) -> Self {
         Self(d)
+    }
+}
+
+impl From<U64> for warp::http::header::HeaderValue {
+    fn from(d: U64) -> Self {
+        d.0.into()
+    }
+}
+
+impl From<U64> for u64 {
+    fn from(d: U64) -> Self {
+        d.0
     }
 }
 
@@ -74,18 +80,18 @@ impl<'de> Deserialize<'de> for U64 {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Copy)]
 pub struct U128(u128);
-
-impl U128 {
-    pub fn into_inner(&self) -> u128 {
-        self.0
-    }
-}
 
 impl From<u128> for U128 {
     fn from(d: u128) -> Self {
         Self(d)
+    }
+}
+
+impl From<U128> for u128 {
+    fn from(d: U128) -> Self {
+        d.0
     }
 }
 
@@ -154,7 +160,7 @@ impl From<AnnotatedMoveValue> for MoveValue {
             AnnotatedMoveValue::U64(v) => MoveValue::U64(U64(v)),
             AnnotatedMoveValue::U128(v) => MoveValue::U128(U128(v)),
             AnnotatedMoveValue::Bool(v) => MoveValue::Bool(v),
-            AnnotatedMoveValue::Address(v) => MoveValue::Address(Address::new(v)),
+            AnnotatedMoveValue::Address(v) => MoveValue::Address(v.into()),
             AnnotatedMoveValue::Vector(_, vals) => {
                 MoveValue::Vector(vals.into_iter().map(MoveValue::from).collect())
             }
@@ -190,7 +196,7 @@ pub struct MoveStructTag {
 impl From<StructTag> for MoveStructTag {
     fn from(tag: StructTag) -> Self {
         Self {
-            address: Address::new(tag.address),
+            address: tag.address.into(),
             module: tag.module,
             name: tag.name,
             type_params: tag.type_params.into_iter().map(MoveTypeTag::from).collect(),
@@ -414,7 +420,7 @@ mod tests {
         assert_eq!(val, json!(u64::MAX.to_string()));
 
         let data: U64 = serde_json::from_value(json!(u64::MAX.to_string())).unwrap();
-        assert_eq!(data.into_inner(), u64::MAX);
+        assert_eq!(u64::from(data), u64::MAX);
     }
 
     #[test]
@@ -423,7 +429,7 @@ mod tests {
         assert_eq!(val, json!(u128::MAX.to_string()));
 
         let data: U128 = serde_json::from_value(json!(u128::MAX.to_string())).unwrap();
-        assert_eq!(data.into_inner(), u128::MAX);
+        assert_eq!(u128::from(data), u128::MAX);
     }
 
     fn create_nested_struct() -> StructTag {

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -9,7 +9,7 @@ use move_core_types::{
 use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
 
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize, Serializer};
-use std::{collections::BTreeMap, convert::From, result::Result};
+use std::{collections::BTreeMap, convert::From, fmt, result::Result};
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct MoveResource {
@@ -47,6 +47,12 @@ impl U64 {
 impl From<u64> for U64 {
     fn from(d: u64) -> Self {
         Self(d)
+    }
+}
+
+impl fmt::Display for U64 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", &self.0)
     }
 }
 

--- a/api/types/src/response.rs
+++ b/api/types/src/response.rs
@@ -1,11 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::LedgerInfo;
+use crate::{Error, LedgerInfo};
 
 use anyhow::Result;
 use serde::Serialize;
-use std::convert::From;
 use warp::http::header::{HeaderValue, CONTENT_TYPE};
 
 pub const X_DIEM_CHAIN_ID: &str = "X-Diem-Chain-Id";
@@ -18,10 +17,10 @@ pub struct Response {
 }
 
 impl Response {
-    pub fn new<T: Serialize>(ledger_info: LedgerInfo, body: &T) -> Result<Self> {
+    pub fn new<T: Serialize>(ledger_info: LedgerInfo, body: &T) -> Result<Self, Error> {
         Ok(Self {
             ledger_info,
-            body: serde_json::to_vec(body).map_err(anyhow::Error::from)?,
+            body: serde_json::to_vec(body)?,
         })
     }
 }

--- a/api/types/src/response.rs
+++ b/api/types/src/response.rs
@@ -1,0 +1,47 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::LedgerInfo;
+
+use anyhow::Result;
+use serde::Serialize;
+use std::convert::From;
+use warp::http::header::{HeaderValue, CONTENT_TYPE};
+
+pub const X_DIEM_CHAIN_ID: &str = "X-Diem-Chain-Id";
+pub const X_DIEM_LEDGER_VERSION: &str = "X-Diem-Ledger-Version";
+pub const X_DIEM_LEDGER_TIMESTAMP: &str = "X-Diem-Ledger-Timestamp";
+
+pub struct Response {
+    pub ledger_info: LedgerInfo,
+    pub body: Vec<u8>,
+}
+
+impl Response {
+    pub fn new<T: Serialize>(ledger_info: LedgerInfo, body: &T) -> Result<Self> {
+        Ok(Self {
+            ledger_info,
+            body: serde_json::to_vec(body).map_err(anyhow::Error::from)?,
+        })
+    }
+}
+
+impl warp::Reply for Response {
+    fn into_response(self) -> warp::reply::Response {
+        let mut res = warp::reply::Response::new(self.body.into());
+        let headers = res.headers_mut();
+
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        headers.insert(X_DIEM_CHAIN_ID, (self.ledger_info.chain_id as u16).into());
+        headers.insert(
+            X_DIEM_LEDGER_VERSION,
+            self.ledger_info.ledger_version.into_inner().into(),
+        );
+        headers.insert(
+            X_DIEM_LEDGER_TIMESTAMP,
+            self.ledger_info.ledger_timestamp.into_inner().into(),
+        );
+
+        res
+    }
+}

--- a/api/types/src/response.rs
+++ b/api/types/src/response.rs
@@ -34,11 +34,11 @@ impl warp::Reply for Response {
         headers.insert(X_DIEM_CHAIN_ID, (self.ledger_info.chain_id as u16).into());
         headers.insert(
             X_DIEM_LEDGER_VERSION,
-            self.ledger_info.ledger_version.into_inner().into(),
+            self.ledger_info.ledger_version.into(),
         );
         headers.insert(
             X_DIEM_LEDGER_TIMESTAMP,
-            self.ledger_info.ledger_timestamp.into_inner().into(),
+            self.ledger_info.ledger_timestamp.into(),
         );
 
         res


### PR DESCRIPTION
1. implement U64 and U128 deserializer and use U64 for LedgerInfo fields
2. handle invalid URL path properly, response 404 error
3. response the latest diem ledger chain id, version and timestamp in the success response header.
4. remove unused From trait impl for Error
5. get account resources not found error includes ledger_version used for looking up the account
6. split get account resources handler logic into 2 steps: param parsing and processing

related issue #9193 

## Test Plan

Unit tests


