### PR TITLE
[State Sync] Complete the storage service skeleton (server-side).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8044,6 +8044,7 @@ dependencies = [
 name = "storage-service-types"
 version = "0.1.0"
 dependencies = [
+ "diem-crypto",
  "diem-types",
  "diem-workspace-hack",
 ]

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 serde = { version = "1.0.124", default-features = false }
 thiserror = "1.0.24"
 
+diem-crypto = { path = "../../../crypto/crypto" }
 diem-infallible = { path = "../../../common/infallible" }
 diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -35,13 +35,39 @@ use move_core_types::language_storage::TypeTag;
 use std::{collections::BTreeMap, sync::Arc};
 use storage_interface::{DbReader, DbReaderWriter, DbWriter, Order, StartupInfo, TreeState};
 use storage_service_types::{
-    DataSummary, EpochEndingLedgerInfoRequest, ProtocolMetadata, ServerProtocolVersion,
-    StorageServerSummary, StorageServiceError, StorageServiceRequest, StorageServiceResponse,
-    TransactionOutputsWithProofRequest, TransactionsWithProofRequest,
+    AccountStatesChunkWithProofRequest, DataSummary, EpochEndingLedgerInfoRequest,
+    ProtocolMetadata, ServerProtocolVersion, StorageServerSummary, StorageServiceError,
+    StorageServiceRequest, StorageServiceResponse, TransactionOutputsWithProofRequest,
+    TransactionsWithProofRequest,
 };
 
 // TODO(joshlind): Expand these test cases to better test storage interaction
 // and functionality. This will likely require a better mock db abstraction.
+
+#[test]
+fn test_get_account_states_chunk_with_proof() {
+    // Create a storage service server
+    let storage_server = create_storage_server();
+
+    // Create a request to fetch an account states chunk with a proof
+    let account_states_chunk_request =
+        StorageServiceRequest::GetAccountStatesChunkWithProof(AccountStatesChunkWithProofRequest {
+            version: 0,
+            start_account_key: HashValue::random(),
+            expected_num_account_states: 0,
+        });
+
+    // Process the request
+    let account_states_chunk_response = storage_server
+        .handle_request(account_states_chunk_request)
+        .unwrap();
+
+    // Verify the response is correct (the API call is currently unsupported)
+    assert_matches!(
+        account_states_chunk_response,
+        StorageServiceResponse::StorageServiceError(StorageServiceError::InternalError)
+    );
+}
 
 #[test]
 fn test_get_server_protocol_version() {

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -35,10 +35,10 @@ use move_core_types::language_storage::TypeTag;
 use std::{collections::BTreeMap, sync::Arc};
 use storage_interface::{DbReader, DbReaderWriter, DbWriter, Order, StartupInfo, TreeState};
 use storage_service_types::{
-    AccountStatesChunkWithProofRequest, DataSummary, EpochEndingLedgerInfoRequest,
-    ProtocolMetadata, ServerProtocolVersion, StorageServerSummary, StorageServiceError,
-    StorageServiceRequest, StorageServiceResponse, TransactionOutputsWithProofRequest,
-    TransactionsWithProofRequest,
+    AccountStatesChunkWithProofRequest, CompleteDataRange, DataSummary,
+    EpochEndingLedgerInfoRequest, ProtocolMetadata, ServerProtocolVersion, StorageServerSummary,
+    StorageServiceError, StorageServiceRequest, StorageServiceResponse,
+    TransactionOutputsWithProofRequest, TransactionsWithProofRequest,
 };
 
 // TODO(joshlind): Expand these test cases to better test storage interaction
@@ -98,15 +98,20 @@ fn test_get_storage_server_summary() {
     let summary_response = storage_server.handle_request(summary_request).unwrap();
 
     // Verify the response is correct
+    let highest_version = 100;
+    let highest_epoch = 10;
     let expected_server_summary = StorageServerSummary {
         protocol_metadata: ProtocolMetadata {
+            max_epoch_chunk_size: 1000,
             max_transaction_chunk_size: 1000,
+            max_transaction_output_chunk_size: 1000,
+            max_account_states_chunk_size: 1000,
         },
         data_summary: DataSummary {
-            highest_transaction_version: 100,
-            lowest_transaction_version: 0,
-            highest_epoch: 10,
-            lowest_epoch: 0,
+            epoch_ending_ledger_infos: CompleteDataRange::new(0, highest_epoch - 1),
+            transactions: CompleteDataRange::new(0, highest_version),
+            transaction_outputs: CompleteDataRange::new(0, highest_version),
+            account_states: CompleteDataRange::new(0, highest_version),
         },
     };
     assert_eq!(

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -5,7 +5,7 @@
 
 use crate::{StorageReader, StorageServiceServer};
 use anyhow::Result;
-use claim::{assert_none, assert_some};
+use claim::{assert_matches, assert_none, assert_some};
 use diem_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
 use diem_infallible::RwLock;
 use diem_types::{
@@ -36,8 +36,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use storage_interface::{DbReader, DbReaderWriter, DbWriter, Order, StartupInfo, TreeState};
 use storage_service_types::{
     DataSummary, EpochEndingLedgerInfoRequest, ProtocolMetadata, ServerProtocolVersion,
-    StorageServerSummary, StorageServiceRequest, StorageServiceResponse,
-    TransactionsWithProofRequest,
+    StorageServerSummary, StorageServiceError, StorageServiceRequest, StorageServiceResponse,
+    TransactionOutputsWithProofRequest, TransactionsWithProofRequest,
 };
 
 // TODO(joshlind): Expand these test cases to better test storage interaction
@@ -127,6 +127,31 @@ fn test_get_transactions_with_proof_events() {
             panic!("Expected transactions with proof but got: {:?}", result);
         }
     };
+}
+
+#[test]
+fn test_get_transaction_outputs_with_proof() {
+    // Create a storage service server
+    let storage_server = create_storage_server();
+
+    // Create a request to fetch transaction outputs with a proof
+    let transaction_outputs_proof_request =
+        StorageServiceRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
+            proof_version: 1000,
+            start_version: 0,
+            expected_num_outputs: 10,
+        });
+
+    // Process the request
+    let transactions_proof_response = storage_server
+        .handle_request(transaction_outputs_proof_request)
+        .unwrap();
+
+    // Verify the response is correct (the API call is currently unsupported)
+    assert_matches!(
+        transactions_proof_response,
+        StorageServiceResponse::StorageServiceError(StorageServiceError::InternalError)
+    );
 }
 
 #[test]

--- a/state-sync/storage-service/types/Cargo.toml
+++ b/state-sync/storage-service/types/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+diem-crypto = { path = "../../../crypto/crypto" }
 diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -3,7 +3,9 @@
 
 #![forbid(unsafe_code)]
 
+use diem_crypto::HashValue;
 use diem_types::{
+    account_state_blob::AccountStatesChunkWithProof,
     epoch_change::EpochChangeProof,
     transaction::default_protocol::{TransactionListWithProof, TransactionOutputListWithProof},
 };
@@ -11,6 +13,7 @@ use diem_types::{
 /// A storage service request.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StorageServiceRequest {
+    GetAccountStatesChunkWithProof(AccountStatesChunkWithProofRequest), // Fetches a list of account states with a proof
     GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest), // Fetches a list of epoch ending ledger infos
     GetServerProtocolVersion, // Fetches the protocol version run by the server
     GetStorageServerSummary,  // Fetches a summary of the storage server state
@@ -21,12 +24,22 @@ pub enum StorageServiceRequest {
 /// A storage service response.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum StorageServiceResponse {
+    AccountStatesChunkWithProof(AccountStatesChunkWithProof),
     EpochEndingLedgerInfos(EpochChangeProof),
     ServerProtocolVersion(ServerProtocolVersion),
     StorageServiceError(StorageServiceError),
     StorageServerSummary(StorageServerSummary),
     TransactionOutputsWithProof(TransactionOutputListWithProof),
     TransactionsWithProof(TransactionListWithProof),
+}
+
+/// A storage service request for fetching a list of account states at a
+/// specified version.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountStatesChunkWithProofRequest {
+    pub version: u64,                     // The version to fetch the account states at
+    pub start_account_key: HashValue,     // The account key to start fetching account states
+    pub expected_num_account_states: u64, // Expected number of account states to fetch
 }
 
 /// A storage service request for fetching a transaction output list with a

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -4,7 +4,8 @@
 #![forbid(unsafe_code)]
 
 use diem_types::{
-    epoch_change::EpochChangeProof, transaction::default_protocol::TransactionListWithProof,
+    epoch_change::EpochChangeProof,
+    transaction::default_protocol::{TransactionListWithProof, TransactionOutputListWithProof},
 };
 
 /// A storage service request.
@@ -13,6 +14,7 @@ pub enum StorageServiceRequest {
     GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest), // Fetches a list of epoch ending ledger infos
     GetServerProtocolVersion, // Fetches the protocol version run by the server
     GetStorageServerSummary,  // Fetches a summary of the storage server state
+    GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest), // Fetches a list of transaction outputs with a proof
     GetTransactionsWithProof(TransactionsWithProofRequest), // Fetches a list of transactions with a proof
 }
 
@@ -23,7 +25,17 @@ pub enum StorageServiceResponse {
     ServerProtocolVersion(ServerProtocolVersion),
     StorageServiceError(StorageServiceError),
     StorageServerSummary(StorageServerSummary),
+    TransactionOutputsWithProof(TransactionOutputListWithProof),
     TransactionsWithProof(TransactionListWithProof),
+}
+
+/// A storage service request for fetching a transaction output list with a
+/// corresponding proof.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TransactionOutputsWithProofRequest {
+    pub proof_version: u64,        // The version the proof should be relative to
+    pub start_version: u64,        // The starting version of the transaction output list
+    pub expected_num_outputs: u64, // Expected number of transaction outputs in the list
 }
 
 /// A storage service request for fetching a transaction list with a

--- a/types/src/account_state_blob.rs
+++ b/types/src/account_state_blob.rs
@@ -6,7 +6,7 @@ use crate::{
     account_config::{AccountResource, BalanceResource},
     account_state::AccountState,
     ledger_info::LedgerInfo,
-    proof::AccountStateProof,
+    proof::{AccountStateProof, SparseMerkleRangeProof},
     transaction::{TransactionInfoTrait, Version},
 };
 use anyhow::{anyhow, ensure, Error, Result};
@@ -194,6 +194,26 @@ pub mod default_protocol {
     pub type AccountStateWithProof = super::AccountStateWithProof<TransactionInfo>;
 }
 
+/// TODO(joshlind): add a proof implementation (e.g., verify()) and unit tests
+/// for these once we start supporting them.
+///
+/// A single chunk of all account states at a specific version.
+/// Note: this is similar to `StateSnapshotChunk` but all data is included
+/// in the struct itself and not behind pointers/handles to file locations.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountStatesChunkWithProof {
+    pub first_index: u64,
+    // The first account index in chunk
+    pub last_index: u64,
+    // The last account index in chunk
+    pub first_key: HashValue,
+    // The first account key in chunk
+    pub last_key: HashValue,
+    // The last account key in chunk
+    pub account_blobs: Vec<(HashValue, AccountStateBlob)>,
+    // The account blobs in the chunk
+    pub proof: SparseMerkleRangeProof, // The proof to ensure the chunk is in the account states
+}
 #[cfg(test)]
 mod tests {
     use super::{default_protocol::AccountStateWithProof, *};

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1397,5 +1397,7 @@ pub mod default_protocol {
     pub type AccountTransactionsWithProof = super::AccountTransactionsWithProof<TransactionInfo>;
     pub type TransactionInfoWithProof = super::TransactionInfoWithProof<TransactionInfo>;
     pub type TransactionListWithProof = super::TransactionListWithProof<TransactionInfo>;
+    pub type TransactionOutputListWithProof =
+        super::TransactionOutputListWithProof<TransactionInfo>;
     pub type TransactionWithProof = super::TransactionWithProof<TransactionInfo>;
 }


### PR DESCRIPTION
## Motivation

This PR completes the skeleton for the server-side of the storage service. Specifically, it stubs out the logic required for the remaining API calls (`get_transaction_outputs_with_proof()` and `get_account_states_chunk_with_proof()`) and adds support for fetching relevant metadata regarding these calls. With this PR, we now have a skeleton for the server side of the storage service that can be filled in to provide all the data we need for state sync v2.

The PR offers the following commits:
1. Add a skeleton for the `get_transaction_outputs_with_proof()` API call. For now, the API call will return an error as we're waiting for `TransactionOutputs` to be supported by the DB.
2. Add a skeleton for the `get_account_states_chunk_with_proof()` API call. This requires introducing a new type `AccountStatesChunkWithProof` that will be implemented/completed in a follow up PR. For now, the API call will return an error.
3. Expand the storage server summary to include information about the transactions, epochs, transaction outputs and account states chunks held by the server. For now, we *naively* assume all nodes hold all of this data up to the version they are currently synced to, however, we'll need change this in the future once the DB supports relevant calls to fetch this information.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Several simple unit tests cover the storage service implementation.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906