### PR TITLE
[docker] add experimental move bytecode

### DIFF
--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -32,9 +32,12 @@ RUN mkdir -p /opt/diem/bin
 COPY --from=builder /diem/target/release/diem-genesis-tool /usr/local/bin
 COPY --from=builder /diem/target/release/diem-operational-tool /usr/local/bin
 
-### Get Move modules bytecodes for genesis ceremony
+### Get DPN Move modules bytecodes for genesis ceremony
 RUN mkdir -p /diem/move
 COPY --from=builder /diem/language/diem-framework/DPN/releases/artifacts/current /diem/move
+### Get experimental Move modules bytecodes for genesis ceremony
+RUN mkdir -p /experimental/move
+COPY --from=builder /diem/language/diem-framework/experimental/releases/artifacts/current /experimental/move
 
 FROM pre-prod as testing
 

--- a/docker/tools/Dockerfile
+++ b/docker/tools/Dockerfile
@@ -47,9 +47,12 @@ COPY --from=builder /diem/target/release/db-restore /usr/local/bin
 COPY --from=builder /diem/target/release/diem-transaction-replay /usr/local/bin
 COPY --from=builder /diem/target/release/diem-writeset-generator /usr/local/bin
 
-### Get Move modules bytecodes for genesis ceremony
+### Get DPN Move modules bytecodes for genesis ceremony
 RUN mkdir -p /diem/move
 COPY --from=builder /diem/language/diem-framework/DPN/releases/artifacts/current /diem/move
+### Get experimental Move modules bytecodes for genesis ceremony
+RUN mkdir -p /experimental/move
+COPY --from=builder /diem/language/diem-framework/experimental/releases/artifacts/current /experimental/move
 
 ARG BUILD_DATE
 ARG GIT_REV


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add experimental move modules bytecode to docker image, so that we can use them to bootstrap experimental testnet.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Build docker image and check if the new folder is there.
testing image: 853397791086.dkr.ecr.us-west-2.amazonaws.com/diem/tools:dev_sherryxiao_pull_9234

