### PR TITLE
[forge] Add extra k8s node as buffer

### DIFF
--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -416,15 +416,16 @@ pub fn set_eks_nodegroup_size(
 
     // nodegroup scaling factors
     let max_surge = 2; // multiplier for max size
+    let buffer = 1; // extra node as buffer
     let num_validators: i64 = num_validators as i64;
     let idle_utilities_size = 5; // keep extra utilities nodes around for forge pods and monitoring
     let validator_scaling = NodegroupScalingConfig {
-        desired_size: Some(cmp::max(num_validators * 3, 1)),
+        desired_size: Some(cmp::max(num_validators * 3 + buffer, 1)),
         max_size: Some(cmp::max((num_validators * 3 + 1) * max_surge, 1)),
         min_size: Some(cmp::max(num_validators * 3, 1)),
     };
     let utilities_scaling = NodegroupScalingConfig {
-        desired_size: Some(cmp::max(num_validators * 3, idle_utilities_size)),
+        desired_size: Some(cmp::max(num_validators * 3 + buffer, idle_utilities_size)),
         max_size: Some(cmp::max(
             num_validators * 3 * max_surge,
             idle_utilities_size,


### PR DESCRIPTION
Since scheduling error rarely happen as below
```
FailedScheduling  13s (x11 over 2m41s)  default-scheduler  0/210 nodes are available
```
Added extra node as buffer to prevent this case

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
