### PR TITLE
[parallel_executor] Handle unestimated read in the executor

### DIFF
--- a/language/diem-vm/mvhashmap/src/lib.rs
+++ b/language/diem-vm/mvhashmap/src/lib.rs
@@ -176,10 +176,6 @@ impl<K: Hash + Clone + Eq, V> MVHashMap<K, V> {
 
         Err(None)
     }
-
-    pub fn view(&self, version: Version) -> MVHashMapView<K, V> {
-        MVHashMapView { map: self, version }
-    }
 }
 
 const PARALLEL_THRESHOLD: usize = 1000;
@@ -223,20 +219,5 @@ where
 
         let (max_dependency_len, data) = Self::split_merge(num_cpus, 0, possible_writes);
         (MVHashMap { data }, max_dependency_len)
-    }
-}
-
-pub struct MVHashMapView<'a, K, V> {
-    map: &'a MVHashMap<K, V>,
-    version: Version,
-}
-
-impl<'a, K: Hash + Clone + Eq, V> MVHashMapView<'a, K, V> {
-    pub fn read(&self, key: &K) -> Result<&V, Option<Version>> {
-        self.map.read(key, self.version)
-    }
-
-    pub fn version(&self) -> Version {
-        self.version
     }
 }

--- a/language/diem-vm/parallel-executor/src/outcome_array.rs
+++ b/language/diem-vm/parallel-executor/src/outcome_array.rs
@@ -37,7 +37,6 @@ impl<T: TransactionOutput, E: Send> OutcomeArray<T, E> {
                 Some(ExecutionStatus::SkipRest(t)) if idx == stop_at - 1 => t,
                 Some(ExecutionStatus::SkipRest(_)) => return Err(Error::InvariantViolation),
                 Some(ExecutionStatus::Abort(err)) => return Err(err),
-                Some(ExecutionStatus::Retry(_)) => return Err(Error::InvariantViolation),
                 None => return Err(Error::InvariantViolation),
             };
             final_results.push(t)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Handle the unestimated read case of parallel executor on the executor side instead of the client with a dirty bit. With this the task thread won't need to propagate the read estimation error back to the executor.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Modified the test and make sure unestimated reads can still be handled correctly.
