### PR TITLE
[shuffle] use move package system instead of manual files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7557,6 +7557,7 @@ dependencies = [
  "anyhow",
  "diem-config",
  "diem-framework",
+ "diem-framework-releases",
  "diem-genesis-tool",
  "diem-node",
  "diem-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7563,6 +7563,7 @@ dependencies = [
  "diem-workspace-hack",
  "move-cli",
  "move-lang",
+ "move-package",
  "move-stdlib",
  "once_cell",
  "serde",

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -3,6 +3,7 @@
 
 use std::{
     collections::HashMap,
+    fmt::Display,
     fs::{create_dir_all, read_to_string},
     io::Write,
     path::{Path, PathBuf},
@@ -122,15 +123,7 @@ pub fn handle_package_commands(
         }
         PackageCommand::New { name } => {
             let creation_path = Path::new(&path).join(name);
-            create_dir_all(&creation_path)?;
-            create_dir_all(creation_path.join(SourcePackageLayout::Sources.path()))?;
-            let mut w =
-                std::fs::File::create(creation_path.join(SourcePackageLayout::Manifest.path()))?;
-            writeln!(
-                &mut w,
-                "[package]\nname = \"{}\"\nversion = \"0.0.0\"",
-                name
-            )?;
+            create_move_package(name, &creation_path)?;
         }
         PackageCommand::Prove { cmd } => {
             let options = match cmd {
@@ -260,5 +253,16 @@ pub fn handle_package_commands(
             }
         }
     };
+    Ok(())
+}
+
+pub fn create_move_package<S: AsRef<str> + Display>(name: S, creation_path: &Path) -> Result<()> {
+    create_dir_all(creation_path.join(SourcePackageLayout::Sources.path()))?;
+    let mut w = std::fs::File::create(creation_path.join(SourcePackageLayout::Manifest.path()))?;
+    writeln!(
+        &mut w,
+        "[package]\nname = \"{}\"\nversion = \"0.0.0\"",
+        name
+    )?;
     Ok(())
 }

--- a/shuffle/cli/Cargo.toml
+++ b/shuffle/cli/Cargo.toml
@@ -19,6 +19,7 @@ toml = "0.5.8"
 
 diem-config = { path = "../../config" }
 diem-framework = { path = "../../language/diem-framework" }
+diem-framework-releases = { path = "../../language/diem-framework/DPN/releases" }
 diem-genesis-tool = { path = "../../config/management/genesis" }
 diem-node = { path = "../../diem-node" }
 diem-types = { path = "../../types" }

--- a/shuffle/cli/Cargo.toml
+++ b/shuffle/cli/Cargo.toml
@@ -25,6 +25,7 @@ diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-cli = { path = "../../language/tools/move-cli" }
 move-lang = { path = "../../language/move-lang" }
+move-package = { path = "../../language/tools/move-package" }
 move-stdlib = { path = "../../language/move-stdlib" }
 shuffle-custom-node = { path = "../genesis" }
 

--- a/shuffle/cli/src/new.rs
+++ b/shuffle/cli/src/new.rs
@@ -137,14 +137,12 @@ fn build_move_starter_modules(project_path: &Path, state: &OnDiskStateView) -> R
 
 fn generate_validator_config(project_path: &Path) -> Result<ValidatorConfig> {
     let publishing_option = VMPublishingOption::open();
+    // TODO (dimroc): place genesis module deployment/generate validator config
+    // in shuffle node command
     shuffle_custom_node::generate_validator_config(
         project_path.join("nodeconfig").as_path(),
-        project_path
-            .join(HELLOBLOCKCHAIN)
-            .join("storage/0x00000000000000000000000000000001/modules")
-            .as_path(),
+        diem_framework_releases::current_module_blobs().to_vec(),
         publishing_option,
-        Vec::new(),
     )
 }
 

--- a/shuffle/genesis/src/lib.rs
+++ b/shuffle/genesis/src/lib.rs
@@ -32,6 +32,7 @@ pub fn generate_validator_config(
     node_config_dir: &Path,
     move_bytecode_dir: &Path,
     publishing_option: VMPublishingOption,
+    additional_modules: Vec<Vec<u8>>,
 ) -> Result<ValidatorConfig> {
     assert!(
         !node_config_dir.exists(),
@@ -42,7 +43,7 @@ pub fn generate_validator_config(
     let mut genesis_modules: Vec<Vec<u8>> = fs::read_dir(move_bytecode_dir)?
         .map(|f| fs::read(f.unwrap().path()).unwrap())
         .collect();
-    genesis_modules.extend(diem_framework_releases::current_module_blobs().to_vec());
+    genesis_modules.extend(additional_modules);
     println!("Creating genesis with {} modules", genesis_modules.len());
     let template = NodeConfig::default_for_validator();
     std::fs::DirBuilder::new()

--- a/shuffle/genesis/src/lib.rs
+++ b/shuffle/genesis/src/lib.rs
@@ -30,9 +30,8 @@ const TRANSACTION_BUILDERS_GENERATED_SOURCE_PATH: &str = "../transaction-builder
 
 pub fn generate_validator_config(
     node_config_dir: &Path,
-    move_bytecode_dir: &Path,
+    genesis_modules: Vec<Vec<u8>>,
     publishing_option: VMPublishingOption,
-    additional_modules: Vec<Vec<u8>>,
 ) -> Result<ValidatorConfig> {
     assert!(
         !node_config_dir.exists(),
@@ -40,10 +39,6 @@ pub fn generate_validator_config(
         node_config_dir
     );
     fs::create_dir(node_config_dir)?;
-    let mut genesis_modules: Vec<Vec<u8>> = fs::read_dir(move_bytecode_dir)?
-        .map(|f| fs::read(f.unwrap().path()).unwrap())
-        .collect();
-    genesis_modules.extend(additional_modules);
     println!("Creating genesis with {} modules", genesis_modules.len());
     let template = NodeConfig::default_for_validator();
     std::fs::DirBuilder::new()

--- a/shuffle/genesis/src/main.rs
+++ b/shuffle/genesis/src/main.rs
@@ -38,6 +38,7 @@ fn main() -> Result<()> {
         Path::new(&args.node_config_dir),
         Path::new(MOVE_BYTECODE_DIR),
         publishing_option,
+        diem_framework_releases::current_module_blobs().to_vec(),
     )?;
     let node_config = NodeConfig::load(validator_config.config_path())?;
     println!("Running a Diem node with custom modules ...");

--- a/shuffle/genesis/src/main.rs
+++ b/shuffle/genesis/src/main.rs
@@ -9,8 +9,6 @@ use structopt::StructOpt;
 
 /// Directory where Move source code lives
 const MOVE_CODE_DIR: &str = "../move/";
-/// Directory where Move module bytecodes live
-const MOVE_BYTECODE_DIR: &str = "../move/storage/0x00000000000000000000000000000001/modules";
 
 #[derive(StructOpt)]
 #[structopt(
@@ -36,9 +34,8 @@ fn main() -> Result<()> {
     };
     let validator_config = shuffle_custom_node::generate_validator_config(
         Path::new(&args.node_config_dir),
-        Path::new(MOVE_BYTECODE_DIR),
-        publishing_option,
         diem_framework_releases::current_module_blobs().to_vec(),
+        publishing_option,
     )?;
     let node_config = NodeConfig::load(validator_config.config_path())?;
     println!("Running a Diem node with custom modules ...");

--- a/shuffle/genesis/tests/e2e.rs
+++ b/shuffle/genesis/tests/e2e.rs
@@ -24,6 +24,7 @@ fn node_e2e() -> Result<()> {
         node_config_dir.path(),
         Path::new("../move/storage/0x00000000000000000000000000000001/modules"),
         VMPublishingOption::open(),
+        diem_framework_releases::current_module_blobs().to_vec(),
     )?;
     let node_config = NodeConfig::load(validator_config.config_path())?;
     let root_key = generate_key::load_key(node_config_dir.path().join("mint.key"));

--- a/shuffle/genesis/tests/e2e.rs
+++ b/shuffle/genesis/tests/e2e.rs
@@ -15,16 +15,14 @@ use diem_types::{
     account_config, chain_id::ChainId, on_chain_config::VMPublishingOption,
     transaction::authenticator::AuthenticationKey,
 };
-use std::path::Path;
 
 #[test]
 fn node_e2e() -> Result<()> {
     let node_config_dir = diem_temppath::TempPath::new();
     let validator_config = shuffle_custom_node::generate_validator_config(
         node_config_dir.path(),
-        Path::new("../move/storage/0x00000000000000000000000000000001/modules"),
-        VMPublishingOption::open(),
         diem_framework_releases::current_module_blobs().to_vec(),
+        VMPublishingOption::open(),
     )?;
     let node_config = NodeConfig::load(validator_config.config_path())?;
     let root_key = generate_key::load_key(node_config_dir.path().join("mint.key"));

--- a/shuffle/move/src/modules/SampleModule.move
+++ b/shuffle/move/src/modules/SampleModule.move
@@ -1,4 +1,6 @@
 module 0x1::SampleModule {
+    use Std::Signer;
+
     struct Coin has key, store {
         value: u64,
     }
@@ -8,6 +10,7 @@ module 0x1::SampleModule {
     const COIN_HAS_WRONG_VALUE: u64 = 2;
 
     public(script) fun mint_coin(owner: signer, amount: u64) {
+        let _x = Signer::address_of(&owner); // Prove Stdlib is available
         move_to(&owner, Coin { value: amount } );
     }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Previously, we manually embedded move stdlib files. Now we use the [move package system](https://github.com/diem/diem/blob/main/language/tools/move-cli/src/package/cli.rs) to generate the new helloblockchain project.

1. `shuffle new` generates a new folder structure including helloblockchain/

<img width="271" alt="CleanShot 2021-09-22 at 20 19 56@2x" src="https://user-images.githubusercontent.com/635121/134450137-08308fc5-a6ef-4324-80e9-60356a567ec2.png">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test` in shuffle/cli runs unit tests and e2e tests.