### PR TITLE
[tools][mirai-dataflow] Dataflow analysis examples and configuration

### DIFF
--- a/language/tools/mirai-dataflow-analysis/README.md
+++ b/language/tools/mirai-dataflow-analysis/README.md
@@ -5,6 +5,9 @@ Internally, this tool uses [MIRAI](https://github.com/facebookexperimental/MIRAI
 representation of that call graph. Then, a dataflow analysis is run over the call graph using either
 [Differential Datalog](https://github.com/vmware/differential-datalog) or [Soufflé](https://souffle-lang.github.io/) and decoded results are presented.
 
+## Examples
+Please see the included [examples](examples/examples.md) for notes on analysis construction, execution, and results.
+
 ## Installation
 
 This tool depends on the presence of MIRAI, correctly installed on your system, as well as
@@ -16,6 +19,8 @@ setup, please follow the steps below:
 3. Set the nightly version of Rust for this crate using `rustup override set nightly-YYYY-MM-DD`.
     - See [rust-toolchain](./rust_toolchain)) to determine the current compatible version, which in turn
     must match the version [currently in use by MIRAI](https://github.com/facebookexperimental/MIRAI/blob/main/rust-toolchain).
+
+Please note that the MIRAI's [is_excluded](https://github.com/facebookexperimental/MIRAI/blob/49c8add3706d49f82d96f3ace2c01c738ea04dc2/checker/src/callbacks.rs#L145) function may have to be modified _before_ installing MIRAI to not exclude certain crates.
 
 ### Differential-Datalog-specific step
 

--- a/language/tools/mirai-dataflow-analysis/analyses/ddlog.dl
+++ b/language/tools/mirai-dataflow-analysis/analyses/ddlog.dl
@@ -309,14 +309,15 @@ TerminalNode(node) :- ValidNode(node), not Edge(_, node, _).
 // Typed dataflow not via
 // There exists a dataflow of type t from node1 to node3 that does not pass through node2.
 //
-// a. There is a terminal non-transitive dataflow of type t from node1 to node3.
+// a. There is a terminal non-transitive dataflow of type t from node1 to node3, and node3 is not
+//    dominated by node2 for t.
 // b. There is a dataflow of type t from node1 to node3 that passes through some node4 != node2.
 //    Since there is no dataflow of type t from node2 to node4, node2 cannot be in that same flow.
 //
 // This is not guaranteed if an over-approximation of the call graph is used.
 output relation TypedDataflowNotVia(node1: NodeID, node2: NodeID, node3: NodeID, t: TypeID)
 TypedDataflowNotVia(node1, node2, node3, t) :- NotEqual(node1, node2), NotEqual(node2, node3), TerminalNode(node3),
-                                                TypedDataflowNT(node1, node3, t).
+                                                TypedDataflowNT(node1, node3, t), not TypedDominates(node2, node3, t).
 TypedDataflowNotVia(node1, node2, node3, t) :- NotEqual(node1, node2), NotEqual(node2, node3),
                                                 TypedDataflowVia(node1, node4, node3, t), NotEqual(node2, node4),
                                                 not SafeDataflow(node4, node2, t).

--- a/language/tools/mirai-dataflow-analysis/analyses/souffle.dl
+++ b/language/tools/mirai-dataflow-analysis/analyses/souffle.dl
@@ -189,14 +189,15 @@ TerminalNode(node) :- ValidNode(node), !Edge(_, node, _).
 // Typed dataflow not via
 // There exists a dataflow of type t from node1 to node3 that does not pass through node2.
 //
-// a. There is a terminal non-transitive dataflow of type t from node1 to node3.
+// a. There is a terminal non-transitive dataflow of type t from node1 to node3, and node3 is not
+//    dominated by node2 for t.
 // b. There is a dataflow of type t from node1 to node3 that passes through some node4 != node2.
 //    Since there is no dataflow of type t from node2 to node4, node2 cannot be in that same flow.
 //
 // This is not guaranteed if an over-approximation of the call graph is used.
 .decl TypedDataflowNotVia(node1: NodeID, node2: NodeID, node3: NodeID, t: TypeID)
 TypedDataflowNotVia(node1, node2, node3, t) :- NotEqual(node1, node2), NotEqual(node2, node3), TerminalNode(node3),
-                                                TypedDataflowNT(node1, node3, t).
+                                                TypedDataflowNT(node1, node3, t), !TypedDominates(node2, node3, t).
 TypedDataflowNotVia(node1, node2, node3, t) :- NotEqual(node1, node2), NotEqual(node2, node3),
                                                 TypedDataflowVia(node1, node4, node3, t), NotEqual(node2, node4),
                                                 !SafeDataflow(node4, node2, t).

--- a/language/tools/mirai-dataflow-analysis/config/BoundsChecker_config.json
+++ b/language/tools/mirai-dataflow-analysis/config/BoundsChecker_config.json
@@ -1,0 +1,25 @@
+{
+    "reductions": [
+        {"Slice": "verify_impl"},
+        "Fold",
+        "Clean"
+    ],
+    "included_crates": ["check_bounds"],
+    "node_types": {
+        "entry": [
+            "verify_impl"
+        ],
+        "checker": [
+            "check_bounds_impl",
+            "check_code_unit_bounds_impl",
+            "check_type_parameter"
+        ],
+        "safe": [
+            "get_locals",
+            "offset_out_of_bounds"
+        ],
+        "exit": [
+            "verify_impl_exit"
+        ]
+    }
+}

--- a/language/tools/mirai-dataflow-analysis/config/CompiledModule_type_relations.json
+++ b/language/tools/mirai-dataflow-analysis/config/CompiledModule_type_relations.json
@@ -1,0 +1,314 @@
+{
+    "relations": [
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::Signature]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::Signature",
+            "type2": "file_format::SignatureToken"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::SignatureToken",
+            "type2": "file_format::StructHandleIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::Constant]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::Constant",
+            "type2": "file_format::SignatureToken"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::ModuleHandle]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::ModuleHandle",
+            "type2": "file_format::AddressIdentifierIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::ModuleHandle",
+            "type2": "file_format::IdentifierIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "ModuleHandleIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::StructHandle]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::StructHandle",
+            "type2": "file_format::AddressIdentifierIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::StructHandle",
+            "type2": "file_format::IdentifierIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::FunctionHandle]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionHandle",
+            "type2": "file_format::ModuleHandleIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionHandle",
+            "type2": "file_format::IdentifierIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionHandle",
+            "type2": "file_format::SignatureIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionHandle",
+            "type2": "[file_format::AbilitySet]"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::FieldHandle]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FieldHandle",
+            "type2": "file_format::StructDefinitionIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::StructDefinition",
+            "type2": "file_format::StructFieldInformation"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::StructDefInstantiation]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::StructDefInstantiation",
+            "type2": "file_format::StructDefinitionIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::StructDefInstantiation",
+            "type2": "file_format::SignatureIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::FunctionInstantiation]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionInstantiation",
+            "type2": "file_format::FunctionHandleIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionInstantiation",
+            "type2": "file_format::SignatureIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::FieldInstantiation]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FieldInstantiation",
+            "type2": "file_format::FieldHandleIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FieldInstantiation",
+            "type2": "file_format::SignatureIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::StructDefinition]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::StructDefinition",
+            "type2": "file_format::StructHandleIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::StructDefinition",
+            "type2": "file_format::StructFieldInformation"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::StructFieldInformation",
+            "type2": "[file_format::FieldDefinition]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FieldDefinition",
+            "type2": "file_format::IdentifierIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FieldDefinition",
+            "type2": "file_format::TypeSignature"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::TypeSignature",
+            "type2": "file_format::SignatureToken"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::FunctionDefinition]"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "file_format::FunctionDefinition"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[file_format::FunctionDefinitionIndex]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionDefinition",
+            "type2": "file_format::FunctionHandleIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionDefinition",
+            "type2": "file_format::SignatureIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionDefinition",
+            "type2": "[file_format::StructDefinitionIndex]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionDefinition",
+            "type2": "[file_format::CodeUnit]"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::FunctionDefinition",
+            "type2": "file_format::CodeUnit"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::CodeUnit",
+            "type2": "file_format::ConstantPoolIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::CodeUnit",
+            "type2": "file_format::StructDefInstantiationIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "file_format::CodeUnit",
+            "type2": "file_format::FieldInstantiationIndex"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "file_format::FunctionInstantiationIndex"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "check_bounds::BoundsChecker"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[move_core_types::identifier::Identifier]"
+        },
+        {
+            "kind": "Member",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "[move_core_types::account_address::AccountAddress]"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::Constant",
+            "type2": "file_format::Constant"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::Signature",
+            "type2": "file_format::Signature"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::ModuleHandle",
+            "type2": "file_format::ModuleHandle"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::FunctionHandle",
+            "type2": "file_format::FunctionHandle"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::FunctionInstantiation",
+            "type2": "file_format::FunctionInstantiation"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::FieldHandle",
+            "type2": "file_format::FieldHandle"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::FieldInstantiation",
+            "type2": "file_format::FieldInstantiation"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::FunctionDefinition",
+            "type2": "file_format::FunctionDefinition"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::StructHandle",
+            "type2": "file_format::StructHandle"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::file_format::StructDefinition",
+            "type2": "file_format::StructDefinition"
+        },
+        {
+            "kind": "Eq",
+            "type1": "move_binary_format::CompiledModule",
+            "type2": "check_duplication::DuplicationChecker"
+        }
+    ]
+}

--- a/language/tools/mirai-dataflow-analysis/config/DuplicationChecker_config.json
+++ b/language/tools/mirai-dataflow-analysis/config/DuplicationChecker_config.json
@@ -1,0 +1,25 @@
+{
+    "reductions": [
+        {"Slice": "bytecode_verifier::check_duplication::{impl#0}::verify_module"},
+        "Fold",
+        "Clean"
+    ],
+    "included_crates": ["check_duplication"],
+    "node_types": {
+        "entry": ["verify_module"],
+        "checker": ["first_duplicate_element"],
+        "safe": [
+            "check_struct_handles::{closure#0}",
+            "check_function_handles::{closure#0}",
+            "check_function_defintions::{closure#0}",
+            "check_function_defintions::{closure#1}",
+            "check_function_defintions::{closure#2}",
+            "check_struct_definitions::{closure#0}",
+            "check_struct_definitions::{closure#1}",
+            "check_struct_definitions::{closure#2}",
+            "check_struct_definitions::{closure#3}",
+            "verify_script::{closure#0}"
+        ],
+        "exit": ["verify_module_impl_exit"]
+    }
+}

--- a/language/tools/mirai-dataflow-analysis/examples/BoundsChecker.md
+++ b/language/tools/mirai-dataflow-analysis/examples/BoundsChecker.md
@@ -1,0 +1,135 @@
+# Bounds Checker Analysis
+
+## Property
+
+All module indexes fall within bounds of a corresponding pool.
+
+## Background
+
+The `CompiledModuleMut` has a set of pools, e.g. `module.field_handles` which contain structs that individually need to be checked. These structs are identified via indexes into their respective pools.
+
+## Analysis goal
+
+Check that every dataflow of `Index` type passes through one of the these three checking functions:
+
+1. `check_bounds_impl`
+2. `check_code_unit_bounds_impl`
+3. `check_type_parameter`
+
+Data types to Check: Data of `Index` type:
+```
+ModuleHandleIndex,
+StructHandleIndex,
+FunctionHandleIndex,
+FieldHandleIndex,
+StructDefInstantiationIndex,
+FunctionInstantiationIndex,
+FieldInstantiationIndex,
+IdentifierIndex,
+AddressIdentifierIndex,
+ConstantPoolIndex,
+SignatureIndex,
+StructDefinitionIndex,
+FunctionDefinitionIndex
+```
+
+## Analysis definition
+
+1. Entry: `verify_impl`
+    - Justification: Both public entry points of the bounds checker, `verify_script` and `verify_module` subsequently call `verify_impl`.
+2. Checkers:
+    1. `check_bounds_impl`
+    2. `check_code_unit_bounds_impl`
+    3. `check_type_parameter`
+3. Exit: Dummy function called at the end of `verify_impl`:
+    ```Rust
+    fn verify_impl_exit(&self) -> PartialVMResult<()> {
+        Ok(())
+    }
+    ```
+    - Justification: For the BoundsChecker, the entry point is the same as the exit (`verify_impl`), thus we need to distinguish the end of the function via a call to this dummy function.
+4. Safe functions:
+    ```
+    get_locals,
+    offset_out_of_bounds
+    ```
+    - Justification: These functions are false positives of the analysis if not explicitly marked as safe. They are safe because they are utility functions that have dataflow within the context of the BoundsChecker.
+
+## Type relations
+
+The analysis uses input type relations that describe the structure of a compiled module with regards to the data-types-to-check, e.g., `ConstantPoolIndex, IdentifierIndex`, etc. For example, we provide a relation showing that the `CompiledModule` has a collection of `ModuleHandle`s that each have `IdentifierIndex`s:
+```
+{
+    "kind": "Member",
+    "type1": "move_binary_format::CompiledModule",
+    "type2": "[file_format::ModuleHandle]"
+},
+{
+    "kind": "Member",
+    "type1": "file_format::ModuleHandle",
+    "type2": "file_format::IdentifierIndex"
+},
+```
+
+## Verification conditions for checkers
+
+1. For `check_bounds_impl(pool: &[T], idx: I)`
+    - Invariant: `idx >= pool.len() ==> Err`
+2. For `check_code_unit_bounds_impl(pool: &[T], idx: I)`
+    - Invariant: `idx >= pool.len() ==> Err`
+5. For `check_type_parameter(ty: &SignatureToken, type_param_count: usize)`
+    - Invariant: `exists ty == TypeParameter(idx) in ty . idx >= type_param_count ==> Err`
+
+## Required code modifications
+
+1. Add the exit dummy function.
+2. Separate `verify_impl` loops into individual functions. This is already done as of Diem commit `5122a1d9994350d0c2de7acfe4b44c59e157d2fa`. Example:
+    - Before:
+        ```Rust
+        fn verify_impl(...) {
+            ...
+            for signature in self.view.signatures() {
+                self.check_signature(signature)?
+            }
+            ...
+        }
+        ```
+    - After
+        ```Rust
+        fn verify_impl(...) {
+            ...
+            self.check_signatures(signature)?;
+            ...
+        }
+
+        fn check_signatures(&self) -> PartialVMResult<()> {
+            for signature in self.view.signatures() {
+                self.check_signature(signature)?
+            }
+            Ok(())
+        }
+        ```
+
+    - Justification: False positive occurs if this is not done (
+    `NotCheckedType` with zero loop iterations):
+        - We cannot establish a dominance relationship between one of the functions in loops (e.g., `self.check_signature` and the exit. This is because the loop may execute zero times, in which case `self.check_signature` will not be called.
+        - Technically a true positive in the sense that there is a path to the exit where the dataflow is not checked, but actually a false positive because the loop only does not execute if there are no members of that dataflow to check in the first place.
+
+## Results
+
+All `Index` types are checked:
+```
+ModuleHandleIndex,
+StructHandleIndex,
+FunctionHandleIndex,
+FieldHandleIndex,
+StructDefInstantiationIndex,
+FunctionInstantiationIndex,
+FieldInstantiationIndex,
+IdentifierIndex,
+AddressIdentifierIndex,
+ConstantPoolIndex,
+SignatureIndex,
+StructDefinitionIndex,
+FunctionDefinitionIndex
+```

--- a/language/tools/mirai-dataflow-analysis/examples/DuplicationChecker.md
+++ b/language/tools/mirai-dataflow-analysis/examples/DuplicationChecker.md
@@ -1,0 +1,110 @@
+# Duplication Checker Analysis
+
+## Property
+
+No duplication of entries in any pool of a `CompiledModule` or `CompiledScript`.
+
+## Background
+
+The `CompiledModule` (and `CompiledScript`) have a set of pools, e.g. `module.field_handles` which contain structs. These pools need to be checked for duplicated elements.
+
+## Analysis goal
+
+Check that every dataflow of Pool type passes through the checking function: `first_duplicate_element`. Data types to Check: All of the module or script pools:
+```
+module_handles: Vec<ModuleHandle>
+struct_handles: Vec<StructHandle>
+function_handles: Vec<FunctionHandle>
+field_handles: Vec<FieldHandle>
+friend_decls: Vec<ModuleHandle>
+struct_def_instantiations: Vec<StructDefInstantiation>
+function_instantiations: Vec<FunctionInstantiation>
+field_instantiations: Vec<FieldInstantiation>
+signatures: Vec<Signature>
+identifiers: Vec<Identifier>
+address_identifiers: Vec<AccountAddress>
+constant_pool: Vec<Constant>
+struct_defs: Vec<StructDefinition>
+function_defs: Vec<FunctionDefinition>
+```
+- Note that the `module_handles` and `friend_decls` share the same type so it is not possible to distinguish them in this analysis.
+
+## Analysis definition
+
+1. Entry points:
+    1. `verify_module`
+    2. `verify_script`
+2. Checker: `first_duplicate_element`
+3. Exit: Dummy function called at the end of `verify_module` and `verify_script`:
+    1. `verify_module_impl_exit`
+        ```Rust
+        fn verify_module_impl_exit(_module: &'a CompiledModule) -> PartialVMResult<()> {
+            Ok(())
+        }
+        ```
+    2. `verify_script_impl_exit`
+        ```Rust
+        fn verify_script_impl_exit(_module: &'a CompiledScript) -> PartialVMResult<()> {
+            Ok(())
+        }
+        ```
+    - Justification: For the DuplicationChecker, the entry points are the same as the exits, thus we need to distinguish the end of the function via a call to this dummy function.
+4. Safe functions:
+    ```
+    check_struct_handles::{closure#0}
+    check_function_handles::{closure#0}
+    check_function_defintions::{closure#0}
+    check_function_defintions::{closure#1}
+    check_function_defintions::{closure#2}
+    check_struct_definitions::{closure#0}
+    check_struct_definitions::{closure#1}
+    check_struct_definitions::{closure#2}
+    check_struct_definitions::{closure#3}
+    verify_script::{closure#0}
+    ```
+    - Justification: As used in the DuplicationChecker, the above closures lead to two false positives for the analysis (causing both the `struct_defs` and `function_defs` to be identified as `NotCheckedType`). However, these checkers have no unsafe dataflows outside of the DuplicationChecker; they primarily show up in function application on iterators.
+
+## Type relations
+
+The analysis uses input type relations that describe the structure of a compiled module with regards to the data-types-to-check, e.g., `Vec<Signature>, Vec<ModuleHandle>` etc. For example, we provide a relation showing that the `CompiledModule` has a collection of signatures:
+```
+{
+    "kind": "Member",
+    "type1": "move_binary_format::CompiledModule",
+    "type2": "[file_format::Signature]"
+}
+```
+
+## Verification conditions for checkers
+
+1. For `first_duplicate_element(iter) -> res: Option<idx>`:
+    ```
+    res is None =>
+        forall idx1 in iter .
+            forall idx2 in iter .
+                idx1 != idx2 => iter[idx1] != iter[idx2]
+    ```
+
+## Required code modifications
+
+1. Add the dummy exit functions.
+
+## Results
+
+All pools are checked:
+```
+module_handles: Vec<ModuleHandle>
+struct_handles: Vec<StructHandle>
+function_handles: Vec<FunctionHandle>
+field_handles: Vec<FieldHandle>
+friend_decls: Vec<ModuleHandle>
+struct_def_instantiations: Vec<StructDefInstantiation>
+function_instantiations: Vec<FunctionInstantiation>
+field_instantiations: Vec<FieldInstantiation>
+signatures: Vec<Signature>
+identifiers: Vec<Identifier>
+address_identifiers: Vec<AccountAddress>
+constant_pool: Vec<Constant>
+struct_defs: Vec<StructDefinition>
+function_defs: Vec<FunctionDefinition>
+```

--- a/language/tools/mirai-dataflow-analysis/examples/examples.md
+++ b/language/tools/mirai-dataflow-analysis/examples/examples.md
@@ -1,0 +1,62 @@
+# Overview
+
+We present two example analyses using `mirai-dataflow`:
+1. An analysis on the move-binary-format crate's [BoundsChecker](./BoundsChecker.md).
+2. An analysis on the bytecode-verifier crate's [DuplicationChecker](./DuplicationChecker.md).
+
+## Environment
+
+All analysis results were captured using the following software versions:
+- The Diem commit that this file was published with (after `92a19a426bae04199f2ca0845dfb19fdee4740a6`).
+- The commit of MIRAI in use is `49c8add3706d49f82d96f3ace2c01c738ea04dc2`.
+- The version of Soufflé in use is `2.1-123-g1f664173b`.
+- The version of Differential Datalog in use is `v0.42.0 (f2824fec7b86c84486ec34b8880bd590678c0765)`.
+
+Please note that MIRAI's [is_excluded](https://github.com/facebookexperimental/MIRAI/blob/49c8add3706d49f82d96f3ace2c01c738ea04dc2/checker/src/callbacks.rs#L145) function will have to be modified _before_ installing MIRAI to not exclude the `move-binary-format` and `bytecode-verifier` crates:
+1. For `move-binary-format` comment out [this line](https://github.com/facebookexperimental/MIRAI/blob/49c8add3706d49f82d96f3ace2c01c738ea04dc2/checker/src/callbacks.rs#L215).
+2. For the `bytecode-verifier` comment out [this line](https://github.com/facebookexperimental/MIRAI/blob/49c8add3706d49f82d96f3ace2c01c738ea04dc2/checker/src/callbacks.rs#L149).
+
+## Example Structure
+
+The example analyses have the following structure:
+1. Property
+2. Background
+3. Analysis goal
+4. Analysis definition
+5. Type relations
+6. Verification conditions for checkers
+7. Required code modifications
+8. Results
+
+The **Property** section describes the property we want the analysis to check for.
+
+The **Background** section explains relevant background for the property.
+
+The **Analysis goal** section translates the property into a checked / unchecked dataflow problem statement, and states the data types that should be checked.
+
+The **Analysis definition** section identifies the entry point(s), checking function(s), and exit point(s). These correspond exactly to the `"node_type"` configuration of the analysis.
+
+The **Type relations** section describes the necessary input type relations needed to describe the data types that will be checked.
+
+The **Verification conditions for checkers** section states invariants that the checking function(s) must uphold in order for the analysis to imply satisfaction of the property.
+
+The **Required code modifications** section describes modifications that have (or had) to be performed to get the analysis to function correctly.
+
+Finally, the **Results** section describes the results of the analysis; e.g., which of the data-types-to-check are identified as being checked.
+
+## Running an example analysis
+
+The results presented in one of the analysis documents can be replicated by following these steps:
+1. Ensure that installed versions of software match those listed under the "Environment" heading of _this_ document.
+2. Ensure that a configuration file is present for the analysis and matches what is listed in the "Analysis definition" section of that analysis document. For the above examples, three configuration files should be present in the `config` folder:
+    ```
+    BoundsChecker_config.json
+    DuplicationChecker_config.json
+    CompiledModule_type_relations.json
+    ```
+3. Make code modifications as described in the "Required code modifications" section of the analysis document.
+4. Run the analysis using the provided configuration. For example, to run the BoundsChecker analysis:
+    ```
+    cargo run -- ../../move-binary-format config/BoundsChecker_config.json --type-relations-path config/CompiledModule_type_relations.json
+    ```
+5. Review the results in `output/decoded.json` to ensure that they match those presented in the analysis document.


### PR DESCRIPTION
## Motivation

This PR adds `mirai-dataflow` configuration files for analysis of the `BoundsChecker` and the `DuplicationChecker`. It also adds type relations to describe the structure of a `CompiledModule`.

Additionally, documentation has been added that explains both the `BoundsChecker` and `DuplicationChecker` analyses' configuration, justification, how to run, and results.

Finally, this PR makes a minor modification to the terminal non-transitive dataflow case of `TypedDataflowNotVia`. This change refines that case to exclude non-transitive dataflows to terminal nodes if those terminal nodes are dominated by the checker (`node2`).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The existing Datalog tests pass.

## Related PRs

N/A

## If targeting a release branch, please fill the below out as well

N/A
