### PR TITLE
[State Sync] Move verify() logic into `SparseMerkleRangeProof`.

### DIFF
--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -530,6 +530,11 @@ where
         &self.value
     }
 
+    /// Gets the associated value hash.
+    pub fn value_hash(&self) -> HashValue {
+        self.value_hash
+    }
+
     pub fn hash(&self) -> HashValue {
         SparseMerkleLeafNode::new(self.account_key, self.value_hash).hash()
     }


### PR DESCRIPTION
## Motivation

This (small) PR refactors some of the `SparseMerkleRangeProof` verification logic, moving it out of the backup and restore code into a `verify()` method on the proof struct itself. This makes the verification structure consistent with other proofs (e.g., `SparseMerkleProof`, `TransactionListWithProof`, `TransactionOutputListWithProof` etc.). Moreover, it allows us to re-use this verification logic in the future (as required by state sync v2).

Note: no logical changes should occur in this PR -- this is purely a refactor.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The storage tests cover this functionality.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906