### PR TITLE
[diem-vm] Replace dyn StateView by impl StateView

### DIFF
--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -70,7 +70,7 @@ pub struct FakeVM;
 impl VMExecutor for FakeVM {
     fn execute_block(
         _transactions: Vec<Transaction>,
-        _state_view: &dyn StateView,
+        _state_view: &impl StateView,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         Ok(Vec::new())
     }

--- a/execution/executor/src/mock_vm/mod.rs
+++ b/execution/executor/src/mock_vm/mod.rs
@@ -54,7 +54,7 @@ pub struct MockVM;
 impl VMExecutor for MockVM {
     fn execute_block(
         transactions: Vec<Transaction>,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         if state_view.is_genesis() {
             assert_eq!(
@@ -169,7 +169,7 @@ impl VMExecutor for MockVM {
 
 fn read_balance(
     output_cache: &HashMap<AccessPath, u64>,
-    state_view: &dyn StateView,
+    state_view: &impl StateView,
     account: AccountAddress,
 ) -> u64 {
     let balance_access_path = balance_ap(account);
@@ -181,7 +181,7 @@ fn read_balance(
 
 fn read_seqnum(
     output_cache: &HashMap<AccessPath, u64>,
-    state_view: &dyn StateView,
+    state_view: &impl StateView,
     account: AccountAddress,
 ) -> u64 {
     let seqnum_access_path = seqnum_ap(account);
@@ -191,15 +191,15 @@ fn read_seqnum(
     }
 }
 
-fn read_balance_from_storage(state_view: &dyn StateView, balance_access_path: &AccessPath) -> u64 {
+fn read_balance_from_storage(state_view: &impl StateView, balance_access_path: &AccessPath) -> u64 {
     read_u64_from_storage(state_view, balance_access_path)
 }
 
-fn read_seqnum_from_storage(state_view: &dyn StateView, seqnum_access_path: &AccessPath) -> u64 {
+fn read_seqnum_from_storage(state_view: &impl StateView, seqnum_access_path: &AccessPath) -> u64 {
     read_u64_from_storage(state_view, seqnum_access_path)
 }
 
-fn read_u64_from_storage(state_view: &dyn StateView, access_path: &AccessPath) -> u64 {
+fn read_u64_from_storage(state_view: &impl StateView, access_path: &AccessPath) -> u64 {
     state_view
         .get(access_path)
         .expect("Failed to query storage.")

--- a/language/diem-vm/src/diem_vm.rs
+++ b/language/diem-vm/src/diem_vm.rs
@@ -459,7 +459,7 @@ impl DiemVM {
 
     fn read_writeset(
         &self,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
         write_set: &WriteSet,
     ) -> Result<(), VMStatus> {
         // All Move executions satisfy the read-before-write property. Thus we need to read each
@@ -688,7 +688,7 @@ impl DiemVM {
     /// `TransactionOutput`
     pub fn execute_block_and_keep_vm_status(
         transactions: Vec<Transaction>,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
     ) -> Result<Vec<(VMStatus, TransactionOutput)>, VMStatus> {
         let mut state_view_cache = StateViewCache::new(state_view);
         let count = transactions.len();
@@ -709,7 +709,7 @@ impl VMExecutor for DiemVM {
     /// transaction output.
     fn execute_block(
         transactions: Vec<Transaction>,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         fail_point!("move_adapter::execute_block", |_| {
             Err(VMStatus::Error(
@@ -741,9 +741,9 @@ impl VMValidator for DiemVM {
     fn validate_transaction(
         &self,
         transaction: SignedTransaction,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
     ) -> VMValidatorResult {
-        validate_signed_transaction::<Self>(self, transaction, state_view)
+        validate_signed_transaction(self, transaction, state_view)
     }
 }
 

--- a/language/diem-vm/src/lib.rs
+++ b/language/diem-vm/src/lib.rs
@@ -145,7 +145,7 @@ pub trait VMValidator {
     fn validate_transaction(
         &self,
         transaction: SignedTransaction,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
     ) -> VMValidatorResult;
 }
 
@@ -159,7 +159,7 @@ pub trait VMExecutor: Send + Sync {
     /// Executes a block of transactions and returns output for each one of them.
     fn execute_block(
         transactions: Vec<Transaction>,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 }
 

--- a/language/tools/vm-genesis/src/lib.rs
+++ b/language/tools/vm-genesis/src/lib.rs
@@ -144,7 +144,7 @@ pub fn encode_genesis_change_set(
 }
 
 fn exec_function(
-    session: &mut Session<StateViewCache>,
+    session: &mut Session<StateViewCache<GenesisStateView>>,
 
     module_name: &str,
     function_name: &str,
@@ -173,7 +173,7 @@ fn exec_function(
 }
 
 fn exec_script_function(
-    session: &mut Session<StateViewCache>,
+    session: &mut Session<StateViewCache<GenesisStateView>>,
 
     sender: AccountAddress,
     script_function: &ScriptFunction,
@@ -192,7 +192,7 @@ fn exec_script_function(
 
 /// Create and initialize Association and Core Code accounts.
 fn create_and_initialize_main_accounts(
-    session: &mut Session<StateViewCache>,
+    session: &mut Session<StateViewCache<GenesisStateView>>,
     diem_root_key: &Ed25519PublicKey,
     treasury_compliance_key: &Ed25519PublicKey,
     publishing_option: VMPublishingOption,
@@ -263,7 +263,7 @@ fn create_and_initialize_main_accounts(
 }
 
 fn create_and_initialize_testnet_minting(
-    session: &mut Session<StateViewCache>,
+    session: &mut Session<StateViewCache<GenesisStateView>>,
 
     public_key: &Ed25519PublicKey,
 ) {
@@ -313,7 +313,7 @@ fn create_and_initialize_testnet_minting(
 /// the required accounts, sets the validator operators for each validator owner, and sets the
 /// validator config on-chain.
 fn create_and_initialize_owners_operators(
-    session: &mut Session<StateViewCache>,
+    session: &mut Session<StateViewCache<GenesisStateView>>,
     validators: &[Validator],
 ) {
     let diem_root_address = account_config::diem_root_address();
@@ -359,7 +359,7 @@ fn create_and_initialize_owners_operators(
 }
 
 /// Publish the standard library.
-fn publish_stdlib(session: &mut Session<StateViewCache>, stdlib: Modules) {
+fn publish_stdlib(session: &mut Session<StateViewCache<GenesisStateView>>, stdlib: Modules) {
     let dep_graph = stdlib.compute_dependency_graph();
     let mut addr_opt: Option<AccountAddress> = None;
     let modules = dep_graph
@@ -390,7 +390,7 @@ fn publish_stdlib(session: &mut Session<StateViewCache>, stdlib: Modules) {
 }
 
 /// Trigger a reconfiguration. This emits an event that will be passed along to the storage layer.
-fn reconfigure(session: &mut Session<StateViewCache>) {
+fn reconfigure(session: &mut Session<StateViewCache<GenesisStateView>>) {
     exec_function(
         session,
         "DiemConfig",

--- a/specifications/move_adapter/README.md
+++ b/specifications/move_adapter/README.md
@@ -53,7 +53,7 @@ pub trait VMValidator {
     fn validate_transaction(
         &self,
         transaction: SignedTransaction,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
     ) -> VMValidatorResult;
 }
 
@@ -494,7 +494,7 @@ pub trait VMExecutor: Send {
     /// Executes a block of transactions and returns the output for each one of them.
     fn execute_block(
         transactions: Vec<Transaction>,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 }
 

--- a/specifications/trusted_computing_base/execution_correctness/README.md
+++ b/specifications/trusted_computing_base/execution_correctness/README.md
@@ -224,7 +224,7 @@ pub trait VMExecutor: Send {
     /// Executes a block of transactions and returns output for each one of them.
     fn execute_block(
         transactions: Vec<Transaction>,
-        state_view: &dyn StateView,
+        state_view: &impl StateView,
     ) -> Result<Vec<TransactionOutput>, VMStatus>;
 }
 ```

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -19,7 +19,7 @@ impl VMValidator for MockVMValidator {
     fn validate_transaction(
         &self,
         _transaction: SignedTransaction,
-        _state_view: &dyn StateView,
+        _state_view: &impl StateView,
     ) -> VMValidatorResult {
         VMValidatorResult::new(None, 0, GovernanceRole::NonGovernanceRole)
     }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Replace the `dyn StateView` with `impl StateView` in the codebase. This is for `VMExecutor` and `VMValidator` we didn't expect the storage to be hetherogeneous and thus limitting it with `impl StateView` will get rid of the extra runtime cost of dynamic traited objects.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo check`