### PR TITLE
[shuffle] Add Message module example

### DIFF
--- a/shuffle/move/examples/Message/Move.toml
+++ b/shuffle/move/examples/Message/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "Message"
+version = "0.0.0"
+
+[addresses]
+MessageAddress = "0x2"
+
+[dependencies]
+MoveStdlib = { local = "../../../../language/move-stdlib", addr_subst = { "Std" = "0x1" }}

--- a/shuffle/move/examples/Message/sources/Message.move
+++ b/shuffle/move/examples/Message/sources/Message.move
@@ -1,0 +1,35 @@
+module MessageAddress::Message {
+    use Std::Signer;
+    use Std::Event;
+
+    struct MessageHolder has key {
+        message: vector<u8>,
+        message_change_events: Event::EventHandle<MessageChangeEvent>,
+    }
+    struct MessageChangeEvent has drop, store {
+        from_message: vector<u8>,
+        to_message: vector<u8>,
+    }
+
+    /// There is no message present
+    const ENO_MESSAGE: u64 = 0;
+
+    public fun set_message(account: signer, message: vector<u8>)
+    acquires MessageHolder {
+        let account_addr = Signer::address_of(&account);
+        if (!exists<MessageHolder>(account_addr)) {
+            move_to(&account, MessageHolder {
+                message,
+                message_change_events: Event::new_event_handle<MessageChangeEvent>(&account),
+            })
+        } else {
+            let old_message_holder = borrow_global_mut<MessageHolder>(account_addr);
+            let from_message = *&old_message_holder.message;
+            Event::emit_event(&mut old_message_holder.message_change_events, MessageChangeEvent {
+                from_message,
+                to_message: copy message,
+            });
+            old_message_holder.message = message;
+        }
+    }
+}

--- a/shuffle/move/examples/Message/sources/set_message.move
+++ b/shuffle/move/examples/Message/sources/set_message.move
@@ -1,0 +1,7 @@
+script {
+    use MessageAddress::Message;
+
+    fun set_message(account: signer, message: vector<u8>) {
+        Message::set_message(account, message);
+    }
+}

--- a/shuffle/move/src/lib.rs
+++ b/shuffle/move/src/lib.rs
@@ -1,0 +1,2 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This adds a `Message` module demo for Shuffle. This allows you to:
* Set a message on-chain; and
* If the set updates the message an event will be emitted saying what the message was changed from and what it was changed to.


You can compile this and generate transaction builders as follows (assuming you are in `shuffle/move/examples/Message`:
```
cargo run -p move-cli -- package --abi build
```

You can then build the transaction builders for this in typescript/javascript (again, assuming you are in `shuffle/move/examples/Message`):

```
cargo run -p transaction-builder-generator --  --language typescript \
    --module-name diemStdlib \
    --with-diem-types "../../../../testsuite/generate-format/tests/staged/diem.yaml" \
    --target-source-dir txn_builders .
```

This will place the generated typescript builders in `shuffle/move/examples/Message/txn_builders`