### PR TITLE
[network] clean up SupportedProtocols. support iterating with unknown ProtocolIds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,7 +1645,6 @@ name = "diem-bitvec"
 version = "0.1.0"
 dependencies = [
  "bcs",
- "diem-proptest-helpers",
  "diem-workspace-hack",
  "proptest",
  "proptest-derive",

--- a/common/bitvec/Cargo.toml
+++ b/common/bitvec/Cargo.toml
@@ -18,7 +18,6 @@ serde_bytes = "0.11.5"
 
 [dev-dependencies]
 bcs = "0.1.2"
-diem-proptest-helpers = { path = "../proptest-helpers"}
 proptest = { version = "1.0.0", default-features = true }
 proptest-derive = { version = "0.3.0" }
 

--- a/config/management/operational/src/network_checker.rs
+++ b/config/management/operational/src/network_checker.rs
@@ -29,7 +29,6 @@ use network::{
     noise::{HandshakeAuthMode, NoiseUpgrader},
     protocols::wire::handshake::v1::SupportedProtocols,
     transport::{upgrade_outbound, UpgradeContext, SUPPORTED_MESSAGING_PROTOCOL},
-    ProtocolId,
 };
 use std::{collections::BTreeMap, sync::Arc};
 use structopt::StructOpt;
@@ -219,7 +218,7 @@ fn build_upgrade_context(
     let mut supported_protocols = BTreeMap::new();
     supported_protocols.insert(
         SUPPORTED_MESSAGING_PROTOCOL,
-        SupportedProtocols::from(ProtocolId::all().iter()),
+        SupportedProtocols::all_known(),
     );
 
     // Build the noise and network handshake, without running a full Noise server with listener

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -33,6 +33,7 @@ use network::{
 };
 use std::{
     collections::{HashMap, HashSet},
+    iter::FromIterator,
     sync::Arc,
     time::Duration,
 };
@@ -550,13 +551,11 @@ mod tests {
             let (_, conn_status_rx) = conn_notifs_channel::new();
             shared_connections.write().insert(
                 *peer,
-                vec![
+                SupportedProtocols::from_iter([
                     ProtocolId::ConsensusDirectSendJSON,
                     ProtocolId::ConsensusDirectSend,
                     ProtocolId::ConsensusRpc,
-                ]
-                .iter()
-                .into(),
+                ]),
             );
             let mut network_sender = ConsensusNetworkSender::new(
                 PeerManagerRequestSender::new(network_reqs_tx),
@@ -653,13 +652,11 @@ mod tests {
             );
             shared_connections.write().insert(
                 *peer,
-                vec![
+                SupportedProtocols::from_iter([
                     ProtocolId::ConsensusDirectSendJSON,
                     ProtocolId::ConsensusDirectSend,
                     ProtocolId::ConsensusRpc,
-                ]
-                .iter()
-                .into(),
+                ]),
             );
             network_sender.initialize(shared_connections.clone());
             let network_events = ConsensusNetworkEvents::new(consensus_rx, conn_status_rx);

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -54,11 +54,14 @@ use futures::{
 };
 use network::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
-    protocols::network::{Event, NewNetworkEvents, NewNetworkSender},
+    protocols::{
+        network::{Event, NewNetworkEvents, NewNetworkSender},
+        wire::handshake::v1::SupportedProtocols,
+    },
     ProtocolId,
 };
 use safety_rules::{PersistentSafetyStorage, SafetyRulesManager};
-use std::{sync::Arc, time::Duration};
+use std::{iter::FromIterator, sync::Arc, time::Duration};
 use tokio::runtime::Handle;
 
 /// Auxiliary struct that is setting up node environment for the test.
@@ -104,13 +107,11 @@ impl NodeSetup {
         for signer in signers.iter().take(num_nodes) {
             shared_connections.write().insert(
                 signer.author(),
-                vec![
+                SupportedProtocols::from_iter([
                     ProtocolId::ConsensusDirectSendJSON,
                     ProtocolId::ConsensusDirectSend,
                     ProtocolId::ConsensusRpc,
-                ]
-                .iter()
-                .into(),
+                ]),
             );
         }
         for (id, signer) in signers.iter().take(num_nodes).enumerate() {

--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -30,10 +30,13 @@ use event_notifications::{ReconfigNotification, ReconfigNotificationListener};
 use futures::channel::mpsc;
 use network::{
     peer_manager::{conn_notifs_channel, ConnectionRequestSender, PeerManagerRequestSender},
-    protocols::network::{NewNetworkEvents, NewNetworkSender},
+    protocols::{
+        network::{NewNetworkEvents, NewNetworkSender},
+        wire::handshake::v1::SupportedProtocols,
+    },
     ProtocolId,
 };
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, iter::FromIterator, sync::Arc};
 use tokio::runtime::{Builder, Runtime};
 
 /// Auxiliary struct that is preparing SMR for the test
@@ -161,13 +164,11 @@ impl SMRNode {
         node_configs.iter().for_each(|config| {
             shared_connections.write().insert(
                 author_from_config(config),
-                vec![
+                SupportedProtocols::from_iter([
                     ProtocolId::ConsensusDirectSendJSON,
                     ProtocolId::ConsensusDirectSend,
                     ProtocolId::ConsensusRpc,
-                ]
-                .iter()
-                .into(),
+                ]),
             );
         });
 

--- a/network/src/peer/fuzzing.rs
+++ b/network/src/peer/fuzzing.rs
@@ -10,7 +10,6 @@ use crate::{
     },
     testutils::fake_socket::ReadOnlyTestSocketVec,
     transport::{Connection, ConnectionId, ConnectionMetadata},
-    ProtocolId,
 };
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_config::{config::PeerRole, network_id::NetworkContext};
@@ -83,7 +82,7 @@ pub fn fuzz(data: &[u8]) {
         NetworkAddress::mock(),
         ConnectionOrigin::Inbound,
         MessagingProtocolVersion::V1,
-        SupportedProtocols::from(ProtocolId::all().iter()),
+        SupportedProtocols::all_known(),
         PeerRole::Unknown,
     );
     let connection = Connection { socket, metadata };

--- a/network/src/peer/test.rs
+++ b/network/src/peer/test.rs
@@ -12,7 +12,7 @@ use crate::{
         direct_send::Message,
         rpc::{error::RpcError, InboundRpcRequest, OutboundRpcRequest},
         wire::{
-            handshake::v1::MessagingProtocolVersion,
+            handshake::v1::{MessagingProtocolVersion, SupportedProtocols},
             messaging::v1::{
                 DirectSendMsg, NetworkMessage, NetworkMessageSink, NetworkMessageStream,
                 RpcRequest, RpcResponse,
@@ -64,7 +64,7 @@ fn build_test_peer(
             NetworkAddress::from_str("/ip4/127.0.0.1/tcp/8081").unwrap(),
             origin,
             MessagingProtocolVersion::V1,
-            [].iter().into(),
+            SupportedProtocols::empty(),
             PeerRole::Unknown,
         ),
         socket: a,

--- a/network/src/peer_manager/builder.rs
+++ b/network/src/peer_manager/builder.rs
@@ -81,7 +81,7 @@ impl TransportContext {
         self.direct_send_protocols
             .iter()
             .chain(&self.rpc_protocols)
-            .into()
+            .collect()
     }
 
     fn augment_direct_send_protocols(

--- a/network/src/peer_manager/tests.rs
+++ b/network/src/peer_manager/tests.rs
@@ -10,7 +10,7 @@ use crate::{
         PeerManager, PeerManagerNotification, PeerManagerRequest, TransportNotification,
     },
     protocols::wire::{
-        handshake::v1::MessagingProtocolVersion,
+        handshake::v1::{MessagingProtocolVersion, SupportedProtocols},
         messaging::v1::{ErrorCode, NetworkMessage, NetworkMessageSink, NetworkMessageStream},
     },
     transport,
@@ -39,8 +39,6 @@ use tokio_util::compat::{
     FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt,
 };
 
-const TEST_PROTOCOL: ProtocolId = ProtocolId::ConsensusRpc;
-
 // Builds a concrete typed transport (instead of using impl Trait) for testing PeerManager.
 // Specifically this transport is compatible with the `build_test_connection` test helper making
 // it easy to build connections without going through the whole transport pipeline.
@@ -58,7 +56,7 @@ pub fn build_test_transport(
                     addr,
                     origin,
                     MessagingProtocolVersion::V1,
-                    [TEST_PROTOCOL].iter().into(),
+                    SupportedProtocols::mock(),
                     PeerRole::Unknown,
                 ),
             })
@@ -108,7 +106,7 @@ fn build_test_peer_manager(
         Arc::new(RwLock::new(HashMap::new())),
         peer_manager_request_rx,
         connection_reqs_rx,
-        [(TEST_PROTOCOL, hello_tx)].iter().cloned().collect(),
+        [(ProtocolId::mock(), hello_tx)].iter().cloned().collect(),
         vec![conn_status_tx],
         constants::NETWORK_CHANNEL_SIZE,
         constants::MAX_CONCURRENT_NETWORK_REQS,
@@ -240,7 +238,7 @@ fn create_connection<TSocket: transport::TSocket>(
             addr,
             origin,
             MessagingProtocolVersion::V1,
-            [TEST_PROTOCOL].iter().into(),
+            SupportedProtocols::mock(),
             PeerRole::Unknown,
         ),
     }
@@ -565,7 +563,7 @@ fn peer_manager_simultaneous_dial_disconnect_event() {
                 NetworkAddress::mock(),
                 ConnectionOrigin::Inbound,
                 MessagingProtocolVersion::V1,
-                [TEST_PROTOCOL].iter().into(),
+                SupportedProtocols::mock(),
                 PeerRole::Unknown,
             ),
             DisconnectReason::ConnectionLost,
@@ -620,7 +618,7 @@ fn test_dial_disconnect() {
                 NetworkAddress::mock(),
                 ConnectionOrigin::Outbound,
                 MessagingProtocolVersion::V1,
-                [TEST_PROTOCOL].iter().into(),
+                SupportedProtocols::mock(),
                 PeerRole::Unknown,
             ),
             DisconnectReason::Requested,

--- a/network/src/protocols/identity.rs
+++ b/network/src/protocols/identity.rs
@@ -44,7 +44,7 @@ mod tests {
     use crate::{
         protocols::{
             identity::exchange_handshake,
-            wire::handshake::v1::{HandshakeMsg, MessagingProtocolVersion},
+            wire::handshake::v1::{HandshakeMsg, MessagingProtocolVersion, SupportedProtocols},
         },
         ProtocolId,
     };
@@ -52,7 +52,7 @@ mod tests {
     use diem_types::chain_id::ChainId;
     use futures::{executor::block_on, future::join};
     use memsocket::MemorySocket;
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, iter::FromIterator};
 
     fn build_test_connection() -> (MemorySocket, MemorySocket) {
         MemorySocket::new_pair()
@@ -68,12 +68,10 @@ mod tests {
         let mut supported_protocols = BTreeMap::new();
         supported_protocols.insert(
             MessagingProtocolVersion::V1,
-            [
+            SupportedProtocols::from_iter([
                 ProtocolId::ConsensusDirectSend,
                 ProtocolId::MempoolDirectSend,
-            ]
-            .iter()
-            .into(),
+            ]),
         );
         let server_handshake = HandshakeMsg {
             chain_id,
@@ -83,9 +81,10 @@ mod tests {
         let mut supported_protocols = BTreeMap::new();
         supported_protocols.insert(
             MessagingProtocolVersion::V1,
-            [ProtocolId::ConsensusRpc, ProtocolId::ConsensusDirectSend]
-                .iter()
-                .into(),
+            SupportedProtocols::from_iter([
+                ProtocolId::ConsensusRpc,
+                ProtocolId::ConsensusDirectSend,
+            ]),
         );
         let client_handshake = HandshakeMsg {
             supported_protocols,

--- a/network/src/transport/mod.rs
+++ b/network/src/transport/mod.rs
@@ -150,7 +150,7 @@ impl ConnectionMetadata {
             connection_id: CONNECTION_ID_GENERATOR.next(),
             addr: NetworkAddress::mock(),
             messaging_protocol: MessagingProtocolVersion::V1,
-            application_protocols: [].iter().into(),
+            application_protocols: SupportedProtocols::empty(),
         }
     }
 }

--- a/network/src/transport/test.rs
+++ b/network/src/transport/test.rs
@@ -24,7 +24,7 @@ use netcore::{
     transport::{memory, ConnectionOrigin, Transport},
 };
 use rand::{rngs::StdRng, SeedableRng};
-use std::{collections::HashMap, io, sync::Arc};
+use std::{collections::HashMap, io, iter::FromIterator, sync::Arc};
 use tokio::runtime::Runtime;
 
 /// helper to build trusted peer map
@@ -143,9 +143,8 @@ where
             }
         };
 
-    let supported_protocols = SupportedProtocols::from(
-        [ProtocolId::ConsensusRpc, ProtocolId::DiscoveryDirectSend].iter(),
-    );
+    let supported_protocols =
+        SupportedProtocols::from_iter([ProtocolId::ConsensusRpc, ProtocolId::DiscoveryDirectSend]);
     let chain_id = ChainId::default();
     let listener_transport = DiemNetTransport::new(
         base_transport.clone(),


### PR DESCRIPTION
Previously, when iterating over a SupportedProtocols that contains an
unknown ProtocolId (that we can't decode yet) we would Err out of the
whole iteration.

With this change, we can safely iterate over a SupportedProtocols; it
will just ignore any ProtocolId's we can't decode.