### PR TITLE
[State Sync] Return the ledger infos in the DataSummary and fetch the number of accounts

### DIFF
--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -237,13 +237,15 @@ impl StorageReaderInterface for StorageReader {
             .get_latest_ledger_info()
             .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
         let latest_ledger_info = latest_ledger_info_with_sigs.ledger_info();
+        let latest_epoch = latest_ledger_info.epoch();
         let latest_version = latest_ledger_info.version();
 
         // TODO(joshlind): Update the DiemDB to support fetching all of this data!
         // For now we assume everything (since genesis) is held.
         // Return the relevant data summary
         let data_summary = DataSummary {
-            epoch_ending_ledger_infos: CompleteDataRange::new(0, latest_ledger_info.epoch() - 1),
+            synced_ledger_info: latest_ledger_info_with_sigs,
+            epoch_ending_ledger_infos: CompleteDataRange::new(0, latest_epoch - 1),
             transactions: CompleteDataRange::new(0, latest_version),
             transaction_outputs: CompleteDataRange::new(0, latest_version),
             account_states: CompleteDataRange::new(0, latest_version),

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -8,7 +8,10 @@ use diem_infallible::RwLock;
 use diem_types::{
     account_state_blob::AccountStatesChunkWithProof,
     epoch_change::EpochChangeProof,
-    transaction::default_protocol::{TransactionListWithProof, TransactionOutputListWithProof},
+    transaction::{
+        default_protocol::{TransactionListWithProof, TransactionOutputListWithProof},
+        Version,
+    },
 };
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -62,6 +65,9 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
             StorageServiceRequest::GetEpochEndingLedgerInfos(request) => {
                 self.get_epoch_ending_ledger_infos(request)
             }
+            StorageServiceRequest::GetNumberOfAccountsAtVersion(version) => {
+                self.get_number_of_accounts_at_version(version)
+            }
             StorageServiceRequest::GetServerProtocolVersion => self.get_server_protocol_version(),
             StorageServiceRequest::GetStorageServerSummary => self.get_storage_server_summary(),
             StorageServiceRequest::GetTransactionOutputsWithProof(request) => {
@@ -109,6 +115,17 @@ impl<T: StorageReaderInterface> StorageServiceServer<T> {
 
         Ok(StorageServiceResponse::EpochEndingLedgerInfos(
             epoch_change_proof,
+        ))
+    }
+
+    fn get_number_of_accounts_at_version(
+        &self,
+        version: Version,
+    ) -> Result<StorageServiceResponse, Error> {
+        let number_of_accounts = self.storage.get_number_of_accounts(version)?;
+
+        Ok(StorageServiceResponse::NumberOfAccountsAtVersion(
+            number_of_accounts,
         ))
     }
 
@@ -204,6 +221,10 @@ pub trait StorageReaderInterface {
         start_version: u64,
         expected_num_transaction_outputs: u64,
     ) -> Result<TransactionOutputListWithProof, Error>;
+
+    /// Returns the number of accounts in the account state tree at the
+    /// specified version.
+    fn get_number_of_accounts(&self, version: u64) -> Result<u64, Error>;
 
     /// Returns a chunk holding a list of account states starting at the
     /// specified account key with *at most* `expected_num_account_states`.
@@ -307,6 +328,13 @@ impl StorageReaderInterface for StorageReader {
         _start_account_key: HashValue,
         _expected_num_account_states: u64,
     ) -> Result<AccountStatesChunkWithProof, Error> {
+        // TODO(joshlind): implement this once DbReaderWriter supports these calls.
+        Err(Error::UnexpectedErrorEncountered(
+            "Unimplemented! This API call needs to be implemented!".into(),
+        ))
+    }
+
+    fn get_number_of_accounts(&self, _version: u64) -> Result<u64, Error> {
         // TODO(joshlind): implement this once DbReaderWriter supports these calls.
         Err(Error::UnexpectedErrorEncountered(
             "Unimplemented! This API call needs to be implemented!".into(),

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -108,6 +108,7 @@ fn test_get_storage_server_summary() {
             max_account_states_chunk_size: 1000,
         },
         data_summary: DataSummary {
+            synced_ledger_info: create_test_ledger_info_with_sigs(highest_epoch, highest_version),
             epoch_ending_ledger_infos: CompleteDataRange::new(0, highest_epoch - 1),
             transactions: CompleteDataRange::new(0, highest_version),
             transaction_outputs: CompleteDataRange::new(0, highest_version),

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -89,6 +89,26 @@ fn test_get_server_protocol_version() {
 }
 
 #[test]
+fn test_get_number_of_accounts_at_version() {
+    // Create a storage service server
+    let storage_server = create_storage_server();
+
+    // Create a request to fetch the number of accounts at the specified version
+    let number_of_accounts_request = StorageServiceRequest::GetNumberOfAccountsAtVersion(10);
+
+    // Process the request
+    let number_of_accounts_response = storage_server
+        .handle_request(number_of_accounts_request)
+        .unwrap();
+
+    // Verify the response is correct (the API call is currently unsupported)
+    assert_matches!(
+        number_of_accounts_response,
+        StorageServiceResponse::StorageServiceError(StorageServiceError::InternalError)
+    );
+}
+
+#[test]
 fn test_get_storage_server_summary() {
     // Create a storage service server
     let storage_server = create_storage_server();

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -7,6 +7,7 @@ use diem_crypto::HashValue;
 use diem_types::{
     account_state_blob::AccountStatesChunkWithProof,
     epoch_change::EpochChangeProof,
+    ledger_info::LedgerInfoWithSignatures,
     transaction::{
         default_protocol::{TransactionListWithProof, TransactionOutputListWithProof},
         Version,
@@ -110,6 +111,9 @@ pub type Epoch = u64;
 /// A summary of the data actually held by the storage service instance.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DataSummary {
+    /// The ledger info corresponding to the highest synced version in storage.
+    /// This indicates the highest version and epoch that storage can prove.
+    pub synced_ledger_info: LedgerInfoWithSignatures,
     /// The range of epoch ending ledger infos in storage, e.g., if the range
     /// is [(X,Y)], it means all epoch ending ledger infos for epochs X->Y
     /// (inclusive) are held.

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -19,8 +19,9 @@ use diem_types::{
 pub enum StorageServiceRequest {
     GetAccountStatesChunkWithProof(AccountStatesChunkWithProofRequest), // Fetches a list of account states with a proof
     GetEpochEndingLedgerInfos(EpochEndingLedgerInfoRequest), // Fetches a list of epoch ending ledger infos
-    GetServerProtocolVersion, // Fetches the protocol version run by the server
-    GetStorageServerSummary,  // Fetches a summary of the storage server state
+    GetNumberOfAccountsAtVersion(Version), // Fetches the number of accounts at the specified version
+    GetServerProtocolVersion,              // Fetches the protocol version run by the server
+    GetStorageServerSummary,               // Fetches a summary of the storage server state
     GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest), // Fetches a list of transaction outputs with a proof
     GetTransactionsWithProof(TransactionsWithProofRequest), // Fetches a list of transactions with a proof
 }
@@ -30,6 +31,7 @@ pub enum StorageServiceRequest {
 pub enum StorageServiceResponse {
     AccountStatesChunkWithProof(AccountStatesChunkWithProof),
     EpochEndingLedgerInfos(EpochChangeProof),
+    NumberOfAccountsAtVersion(u64),
     ServerProtocolVersion(ServerProtocolVersion),
     StorageServiceError(StorageServiceError),
     StorageServerSummary(StorageServerSummary),


### PR DESCRIPTION
## Motivation

This (small) PR extends the existing storage service template by: (i) returning the ledger info in the storage summary API call (this is required to verify storage summary claims from peers); and (ii) add a new (currently unsupported) API call to fetch the number of account states at a specific version (this is required in the future so that we know how to chunk up the account states at a specific version). Each of these changes happens in its own commit.

Note: none of this is actually plugged in yet. @phlip9 is working on that.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The existing and newly added unit tests cover this functionality.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906