### PR TITLE
[State Sync] Add the (skeleton) Diem Data Client API and crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,6 +1752,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "diem-data-client"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "diem-crypto",
+ "diem-types",
+ "diem-workspace-hack",
+ "futures",
+ "serde",
+ "storage-service-types",
+ "thiserror",
+]
+
+[[package]]
 name = "diem-documentation-tool"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,7 @@ members = [
     "shuffle/genesis",
     "shuffle/move",
     "shuffle/transaction-builder",
+    "state-sync/diem-data-client",
     "state-sync/inter-component/consensus-notifications",
     "state-sync/inter-component/event-notifications",
     "state-sync/inter-component/mempool-notifications",

--- a/state-sync/diem-data-client/Cargo.toml
+++ b/state-sync/diem-data-client/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "diem-data-client"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+description = "The Diem data client"
+repository = "https://github.com/diem/diem"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+async-trait = "0.1.42"
+futures = "0.3.12"
+serde = { version = "1.0.124", default-features = false }
+thiserror = "1.0.24"
+
+diem-crypto = { path = "../../crypto/crypto" }
+diem-types = { path = "../../types" }
+diem-workspace-hack = { path = "../../common/workspace-hack" }
+storage-service-types = { path = "../storage-service/types" }

--- a/state-sync/diem-data-client/README.md
+++ b/state-sync/diem-data-client/README.md
@@ -1,0 +1,11 @@
+---
+id: diem data client
+title: Diem Data Client
+custom_edit_url: https://github.com/diem/diem/edit/main/state-sync/diem-data-client/README.md
+---
+
+# Diem Data Client
+
+This crate contains the Diem Data Client.
+
+// TODO(phlip9): complete me!

--- a/state-sync/diem-data-client/src/lib.rs
+++ b/state-sync/diem-data-client/src/lib.rs
@@ -1,0 +1,171 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+use async_trait::async_trait;
+use diem_crypto::hash::HashValue;
+use diem_types::{
+    account_state_blob::AccountStatesChunkWithProof,
+    ledger_info::LedgerInfoWithSignatures,
+    transaction::{
+        default_protocol::{TransactionListWithProof, TransactionOutputListWithProof},
+        Version,
+    },
+};
+use serde::{Deserialize, Serialize};
+use storage_service_types::{CompleteDataRange, Epoch};
+use thiserror::Error;
+
+/// An error returned by the Diem Data Client for failed API calls.
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Serialize)]
+pub enum Error {
+    #[error("The requested data is unavailable and cannot be found! Error: {0}")]
+    DataIsUnavailable(String),
+    #[error("The requested data is too large: {0}")]
+    DataIsTooLarge(String),
+    #[error("Timed out waiting for a response: {0}")]
+    TimeoutWaitingForResponse(String),
+    #[error("Unexpected error encountered: {0}")]
+    UnexpectedErrorEncountered(String),
+}
+
+/// A response error that users of the Diem Data Client can use to notify
+/// the Data Client about invalid or malformed responses.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub enum ResponseError {
+    InvalidData,
+    MissingData,
+    ProofVerificationError,
+}
+
+/// The API offered by the Diem Data Client.
+#[async_trait]
+pub trait DiemDataClient {
+    /// Returns a single account states chunk with proof, containing the accounts
+    /// from start to end index (inclusive) at the specified version. The proof
+    /// version is the same as the specified version.
+    async fn get_account_states_with_proof(
+        &self,
+        version: u64,
+        start_index: HashValue,
+        end_index: HashValue,
+    ) -> Result<DataClientResponse, Error>;
+
+    /// Returns all epoch ending ledger infos between start and end (inclusive).
+    /// If the data cannot be fetched (e.g., the number of epochs is too large),
+    /// an error is returned.
+    async fn get_epoch_ending_ledger_infos(
+        &self,
+        start_epoch: u64,
+        end_epoch: u64,
+    ) -> Result<DataClientResponse, Error>;
+
+    /// Returns a global summary of the data currently available in the network.
+    fn get_global_data_summary(&self) -> Result<DataClientResponse, Error>;
+
+    /// Returns the number of account states at the specified version.
+    async fn get_number_of_account_states(&self, version: u64)
+        -> Result<DataClientResponse, Error>;
+
+    /// Returns a transaction output list with proof object, with transaction
+    /// outputs from start to end versions (inclusive). The proof is relative to
+    /// the specified `proof_version`. If the data cannot be fetched (e.g., the
+    /// number of transaction outputs is too large), an error is returned.
+    async fn get_transaction_outputs_with_proof(
+        &self,
+        proof_version: u64,
+        start_version: u64,
+        end_version: u64,
+    ) -> Result<DataClientResponse, Error>;
+
+    /// Returns a transaction list with proof object, with transactions from
+    /// start to end versions (inclusive). The proof is relative to the specified
+    /// `proof_version`. If the data cannot be fetched (e.g., the number of
+    /// transactions is too large), an error is returned.
+    async fn get_transactions_with_proof(
+        &self,
+        proof_version: u64,
+        start_version: u64,
+        end_version: u64,
+    ) -> Result<DataClientResponse, Error>;
+
+    /// Notifies the Diem Data Client about a previously received response that
+    /// was bad (e.g., invalid or malformed).
+    ///
+    /// Note: this is required because the Diem Data Client can only fetch
+    /// data from peers in the network, but it is not able to fully verify that
+    /// the given data responses are valid (e.g., it is unable to verify proofs).
+    /// This API call provides a simple feedback mechanism for users of the Diem
+    /// Data Client to alert it to bad responses so that the peers responsible
+    /// for providing this data can be penalized. The `response_id` is the handle
+    /// used by clients to notify the Diem Data Client of invalid responses.
+    async fn notify_bad_response(
+        &self,
+        response_id: u64,
+        response_error: ResponseError,
+    ) -> Result<(), Error>;
+}
+
+/// A response from the Data Client for a single API call.
+///
+/// Note: the `response_id` is a simple handle returned by the Diem Data Client
+/// that allows API callers to notify the Diem Data Client that the given
+/// response payload is bad (e.g., it contains invalid or malformed data, or
+/// the proof failed verification). This can be done using the
+/// `notify_bad_response()` API call above.
+pub struct DataClientResponse {
+    pub response_id: u64,
+    pub response_payload: DataClientPayload,
+}
+
+/// The payload returned in a Data Client response.
+pub enum DataClientPayload {
+    AccountStatesWithProof(AccountStatesChunkWithProof),
+    EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
+    GlobalDataSummary(GlobalDataSummary),
+    NumberOfAccountStates(u64),
+    TransactionOutputsWithProof(TransactionOutputListWithProof),
+    TransactionsWithProof(TransactionListWithProof),
+}
+
+/// A snapshot of the global state of data available in the Diem network.
+pub struct GlobalDataSummary {
+    pub advertised_data: AdvertisedData,
+    pub optimal_chunk_sizes: OptimalChunkSizes,
+}
+
+/// Holds the optimal chunk sizes that clients should use when
+/// requesting data. This makes the request *more likely* to succeed.
+pub struct OptimalChunkSizes {
+    pub account_states_chunk_size: u64,
+    pub epoch_chunk_size: u64,
+    pub transaction_chunk_size: u64,
+    pub transaction_output_chunk_size: u64,
+}
+
+/// A summary of all data that is currently advertised in the network.
+pub struct AdvertisedData {
+    /// The ranges of account states advertised, e.g., if a range is
+    /// (X,Y), it means all account states are held for every version X->Y
+    /// (inclusive).
+    pub account_states: Vec<CompleteDataRange<Version>>,
+
+    /// The ranges of epoch ending ledger infos advertised, e.g., if a range
+    /// is (X,Y), it means all epoch ending ledger infos for epochs X->Y
+    /// (inclusive) are available.
+    pub epoch_ending_ledger_infos: Vec<CompleteDataRange<Epoch>>,
+
+    /// The ledger infos corresponding to the highest synced versions
+    /// currently advertised.
+    pub synced_ledger_infos: Vec<LedgerInfoWithSignatures>,
+
+    /// The ranges of transactions advertised, e.g., if a range is
+    /// (X,Y), it means all transactions for versions X->Y (inclusive)
+    /// are available.
+    pub transactions: Vec<CompleteDataRange<Version>>,
+
+    /// The ranges of transaction outputs advertised, e.g., if a range
+    /// is (X,Y), it means all transaction outputs for versions X->Y
+    /// (inclusive) are available.
+    pub transaction_outputs: Vec<CompleteDataRange<Version>>,
+}

--- a/x.toml
+++ b/x.toml
@@ -183,6 +183,7 @@ members = [
     "cli",
     "cluster-test",
     "testcases",
+    "diem-data-client", # Will be removed once the Diem data client is plugged into diem-node.
     "diem-documentation-tool",
     "diem-e2e-tests-replay",
     "diem-fuzz",


### PR DESCRIPTION
## Motivation

This PR adds an (empty) skeleton "Diem Data Client" crate and a corresponding client API to the code. This decouples State Sync v2 and the Diem Data Client, allowing the workstreams to progress in parallel.

Notes:
- This crate is owned by @phlip9. For now, I've put the crate in the `state-sync` subfolder (to match the `storage-service`). But, we may wish to move it in the future. I don't feel super strongly here.
- The API is not final or complete. What is offered here is a simple starting point to decouple the workstreams. Moreover, many of the implementation details (e.g., errors) are subject to change 😄

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

This is only the interface. No tests required.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906