### PR TITLE
[move-lang] Made AddressBytes a wrapper around AccountAddress

### DIFF
--- a/language/diem-framework/src/lib.rs
+++ b/language/diem-framework/src/lib.rs
@@ -8,7 +8,7 @@ use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};
 use move_command_line_common::files::{
     extension_equals, find_filenames, MOVE_COMPILED_EXTENSION, MOVE_EXTENSION,
 };
-use move_lang::{compiled_unit::AnnotatedCompiledUnit, shared::AddressBytes, Compiler};
+use move_lang::{compiled_unit::AnnotatedCompiledUnit, shared::NumericalAddress, Compiler};
 use move_symbol_pool::Symbol;
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
@@ -61,7 +61,7 @@ pub fn diem_stdlib_files() -> Vec<String> {
 }
 
 // TODO: This will be declared in the package once those are in
-pub fn diem_framework_named_addresses() -> BTreeMap<String, AddressBytes> {
+pub fn diem_framework_named_addresses() -> BTreeMap<String, NumericalAddress> {
     let mapping = [
         ("Std", "0x1"),
         ("DiemFramework", "0x1"),
@@ -72,7 +72,7 @@ pub fn diem_framework_named_addresses() -> BTreeMap<String, AddressBytes> {
     ];
     mapping
         .iter()
-        .map(|(name, addr)| (name.to_string(), AddressBytes::parse_str(addr).unwrap()))
+        .map(|(name, addr)| (name.to_string(), NumericalAddress::parse_str(addr).unwrap()))
         .collect()
 }
 

--- a/language/move-core/types/src/account_address.rs
+++ b/language/move-core/types/src/account_address.rs
@@ -41,7 +41,7 @@ impl AccountAddress {
         self.0.to_vec()
     }
 
-    pub fn to_u8(self) -> [u8; Self::LENGTH] {
+    pub fn into_bytes(self) -> [u8; Self::LENGTH] {
         self.0
     }
 

--- a/language/move-lang/src/bin/move-build.rs
+++ b/language/move-lang/src/bin/move-build.rs
@@ -5,7 +5,7 @@
 
 use move_lang::{
     command_line::{self as cli},
-    shared::{self, verify_and_create_named_address_mapping, AddressBytes, Flags},
+    shared::{self, verify_and_create_named_address_mapping, Flags, NumericalAddress},
 };
 use structopt::*;
 
@@ -48,7 +48,7 @@ pub struct Options {
         long = "addresses",
         parse(try_from_str = shared::parse_named_address)
     )]
-    pub named_addresses: Vec<(String, AddressBytes)>,
+    pub named_addresses: Vec<(String, NumericalAddress)>,
 
     #[structopt(flatten)]
     pub flags: Flags,

--- a/language/move-lang/src/bin/move-check.rs
+++ b/language/move-lang/src/bin/move-check.rs
@@ -5,7 +5,7 @@
 
 use move_lang::{
     command_line::{self as cli},
-    shared::{self, verify_and_create_named_address_mapping, AddressBytes, Flags},
+    shared::{self, verify_and_create_named_address_mapping, Flags, NumericalAddress},
 };
 use structopt::*;
 
@@ -43,7 +43,7 @@ pub struct Options {
         long = "addresses",
         parse(try_from_str = shared::parse_named_address)
     )]
-    pub named_addresses: Vec<(String, AddressBytes)>,
+    pub named_addresses: Vec<(String, NumericalAddress)>,
 
     #[structopt(flatten)]
     pub flags: Flags,

--- a/language/move-lang/src/cfgir/constant_fold.rs
+++ b/language/move-lang/src/cfgir/constant_fold.rs
@@ -293,7 +293,7 @@ enum FoldableValue {
     U64(u64),
     U128(u128),
     Bool(bool),
-    Address(AddressBytes),
+    Address(NumericalAddress),
     Bytearray(Vec<u8>),
 }
 

--- a/language/move-lang/src/cfgir/translate.rs
+++ b/language/move-lang/src/cfgir/translate.rs
@@ -11,7 +11,7 @@ use crate::{
     expansion::ast::{AbilitySet, ModuleIdent, Value, Value_},
     hlir::ast::{self as H, Label},
     parser::ast::{ConstantName, FunctionName, StructName, Var},
-    shared::{unique_map::UniqueMap, AddressBytes, CompilationEnv},
+    shared::{unique_map::UniqueMap, CompilationEnv, NumericalAddress},
     FullyCompiledProgram,
 };
 use cfgir::ast::LoopInfo;
@@ -360,14 +360,14 @@ fn move_value_from_exp(context: &mut Context, e: H::Exp) -> Option<MoveValue> {
 }
 
 pub(crate) fn move_value_from_value(
-    address_mapping: &BTreeMap<Symbol, AddressBytes>,
+    address_mapping: &BTreeMap<Symbol, NumericalAddress>,
     sp!(_, v_): Value,
 ) -> MoveValue {
     move_value_from_value_(address_mapping, v_)
 }
 
 pub(crate) fn move_value_from_value_(
-    address_mapping: &BTreeMap<Symbol, AddressBytes>,
+    address_mapping: &BTreeMap<Symbol, NumericalAddress>,
     v_: Value_,
 ) -> MoveValue {
     use MoveValue as MV;

--- a/language/move-lang/src/command_line/compiler.rs
+++ b/language/move-lang/src/command_line/compiler.rs
@@ -9,7 +9,7 @@ use crate::{
     diagnostics::{codes::Severity, *},
     expansion, hlir, interface_generator, naming, parser,
     parser::{comments::*, *},
-    shared::{AddressBytes, CompilationEnv, Flags},
+    shared::{CompilationEnv, Flags, NumericalAddress},
     to_bytecode, typing, unit_test,
 };
 use move_command_line_common::files::{
@@ -36,7 +36,7 @@ pub struct Compiler<'a, 'b> {
     interface_files_dir_opt: Option<String>,
     pre_compiled_lib: Option<&'b FullyCompiledProgram>,
     compiled_module_named_address_mapping: BTreeMap<CompiledModuleId, String>,
-    named_address_mapping: BTreeMap<Symbol, AddressBytes>,
+    named_address_mapping: BTreeMap<Symbol, NumericalAddress>,
     flags: Flags,
 }
 
@@ -141,7 +141,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
     pub fn set_named_address_values(
         mut self,
-        named_address_mapping: BTreeMap<impl Into<Symbol>, AddressBytes>,
+        named_address_mapping: BTreeMap<impl Into<Symbol>, NumericalAddress>,
     ) -> Self {
         assert!(self.named_address_mapping.is_empty());
         self.named_address_mapping = named_address_mapping
@@ -375,7 +375,7 @@ pub fn construct_pre_compiled_lib(
     deps: &[String],
     interface_files_dir_opt: Option<String>,
     flags: Flags,
-    named_address_values: BTreeMap<String, AddressBytes>,
+    named_address_values: BTreeMap<String, NumericalAddress>,
 ) -> anyhow::Result<Result<FullyCompiledProgram, (FilesSourceText, Diagnostics)>> {
     let (files, pprog_and_comments_res) = Compiler::new(&[], deps)
         .set_interface_files_dir_opt(interface_files_dir_opt)

--- a/language/move-lang/src/compiled_unit.rs
+++ b/language/move-lang/src/compiled_unit.rs
@@ -7,7 +7,7 @@ use crate::{
     expansion::ast::{ModuleIdent, ModuleIdent_, SpecId},
     hlir::ast as H,
     parser::ast::{FunctionName, ModuleName, Var},
-    shared::{unique_map::UniqueMap, AddressBytes, Name},
+    shared::{unique_map::UniqueMap, Name, NumericalAddress},
 };
 use bytecode_source_map::source_map::SourceMap;
 use move_binary_format::file_format as F;
@@ -44,7 +44,7 @@ pub struct FunctionInfo {
 
 #[derive(Debug, Clone)]
 pub struct NamedCompiledModule {
-    pub address_bytes: AddressBytes,
+    pub address: NumericalAddress,
     pub name: Symbol,
     pub module: F::CompiledModule,
     pub source_map: SourceMap,
@@ -93,7 +93,7 @@ impl AnnotatedCompiledModule {
     pub fn module_ident(&self) -> ModuleIdent {
         use crate::expansion::ast::Address;
         let address = match self.address_name {
-            None => Address::Anonymous(sp(self.loc, self.named_module.address_bytes)),
+            None => Address::Anonymous(sp(self.loc, self.named_module.address)),
             Some(n) => Address::Named(n),
         };
         sp(
@@ -107,7 +107,7 @@ impl AnnotatedCompiledModule {
 
     pub fn module_id(&self) -> (Option<Name>, ModuleId) {
         let id = ModuleId::new(
-            AccountAddress::new(self.named_module.address_bytes.into_bytes()),
+            AccountAddress::new(self.named_module.address.into_bytes()),
             MoveCoreIdentifier::new(self.named_module.name.to_string()).unwrap(),
         );
         (self.address_name, id)
@@ -125,7 +125,7 @@ impl AnnotatedCompiledUnit {
                 function_infos,
             }) => {
                 let NamedCompiledModule {
-                    address_bytes,
+                    address: address_bytes,
                     name,
                     module,
                     source_map,
@@ -136,7 +136,7 @@ impl AnnotatedCompiledUnit {
                     module_name_loc,
                     address_name,
                     named_module: NamedCompiledModule {
-                        address_bytes,
+                        address: address_bytes,
                         name,
                         module,
                         source_map,

--- a/language/move-lang/src/expansion/ast.rs
+++ b/language/move-lang/src/expansion/ast.rs
@@ -90,7 +90,7 @@ pub struct Script {
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Address {
-    Anonymous(Spanned<AddressBytes>),
+    Anonymous(Spanned<NumericalAddress>),
     Named(Name),
 }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -490,11 +490,14 @@ impl fmt::Debug for Address {
 //**************************************************************************************************
 
 impl Address {
-    pub const fn anonymous(loc: Loc, address: [u8; ADDRESS_LENGTH]) -> Self {
-        Self::Anonymous(sp(loc, AddressBytes::new(address)))
+    pub const fn anonymous(loc: Loc, address: NumericalAddress) -> Self {
+        Self::Anonymous(sp(loc, address))
     }
 
-    pub fn into_addr_bytes(self, addresses: &BTreeMap<Symbol, AddressBytes>) -> AddressBytes {
+    pub fn into_addr_bytes(
+        self,
+        addresses: &BTreeMap<Symbol, NumericalAddress>,
+    ) -> NumericalAddress {
         match self {
             Self::Anonymous(sp!(_, bytes)) => bytes,
             Self::Named(n) => *addresses.get(&n.value).unwrap_or_else(|| {

--- a/language/move-lang/src/expansion/translate.rs
+++ b/language/move-lang/src/expansion/translate.rs
@@ -315,7 +315,7 @@ fn set_sender_address(
             context
                 .env
                 .add_diag(diag!(Declarations::InvalidModule, (loc, msg)));
-            Address::Anonymous(sp(loc, AddressBytes::DEFAULT_ERROR_BYTES))
+            Address::Anonymous(sp(loc, NumericalAddress::DEFAULT_ERROR_ADDRESS))
         }
     })
 }
@@ -612,7 +612,7 @@ fn all_module_members<'a>(
                         address_impl(compilation_env, /* suggest_declaration */ true, *a)
                     }
                     // Error will be handled when the module is compiled
-                    None => Address::Anonymous(sp(m.loc, AddressBytes::DEFAULT_ERROR_BYTES)),
+                    None => Address::Anonymous(sp(m.loc, NumericalAddress::DEFAULT_ERROR_ADDRESS)),
                 };
                 module_members(members, always_add, addr, m)
             }
@@ -1869,34 +1869,34 @@ fn value(context: &mut Context, sp!(loc, pvalue_): P::Value) -> Option<E::Value>
             let mut addr = address(context, /* suggest_declaration */ true, addr);
             if let Address::Named(n) = addr {
                 if context.env.named_address_mapping().get(&n.value).is_none() {
-                    addr = Address::Anonymous(sp(n.loc, AddressBytes::DEFAULT_ERROR_BYTES));
+                    addr = Address::Anonymous(sp(n.loc, NumericalAddress::DEFAULT_ERROR_ADDRESS));
                 }
             }
             EV::Address(addr)
         }
         PV::Num(s) if s.ends_with("u8") => match parse_u8(&s[..s.len() - 2]) {
-            Ok(u) => EV::U8(u),
+            Ok((u, _format)) => EV::U8(u),
             Err(_) => {
                 context.env.add_diag(num_too_big_error(loc, "'u8'"));
                 return None;
             }
         },
         PV::Num(s) if s.ends_with("u64") => match parse_u64(&s[..s.len() - 3]) {
-            Ok(u) => EV::U64(u),
+            Ok((u, _format)) => EV::U64(u),
             Err(_) => {
                 context.env.add_diag(num_too_big_error(loc, "'u64'"));
                 return None;
             }
         },
         PV::Num(s) if s.ends_with("u128") => match parse_u128(&s[..s.len() - 4]) {
-            Ok(u) => EV::U128(u),
+            Ok((u, _format)) => EV::U128(u),
             Err(_) => {
                 context.env.add_diag(num_too_big_error(loc, "'u128'"));
                 return None;
             }
         },
         PV::Num(s) => match parse_u128(&s) {
-            Ok(u) => EV::InferredNum(u),
+            Ok((u, _format)) => EV::InferredNum(u),
             Err(_) => {
                 context.env.add_diag(num_too_big_error(
                     loc,

--- a/language/move-lang/src/expansion/unique_modules_after_mapping.rs
+++ b/language/move-lang/src/expansion/unique_modules_after_mapping.rs
@@ -15,14 +15,14 @@ use std::collections::BTreeMap;
 // Entry
 //**************************************************************************************************
 
-type RefinedModuleIdent = (Loc, Option<Name>, AddressBytes, ModuleName);
+type RefinedModuleIdent = (Loc, Option<Name>, NumericalAddress, ModuleName);
 
 /// Verifies that modules remain unique, even after substituting named addresses for their values
 pub fn verify(
     compilation_env: &mut CompilationEnv,
     modules: &UniqueMap<ModuleIdent, E::ModuleDefinition>,
 ) {
-    let mut decl_locs: BTreeMap<(AddressBytes, Symbol), RefinedModuleIdent> = BTreeMap::new();
+    let mut decl_locs: BTreeMap<(NumericalAddress, Symbol), RefinedModuleIdent> = BTreeMap::new();
     for (sp!(loc, ModuleIdent_ { address, module }), _mdef) in modules.key_cloned_iter() {
         let sp!(nloc, n_) = module.0;
         let addr_name = match &address {

--- a/language/move-lang/src/interface_generator.rs
+++ b/language/move-lang/src/interface_generator.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::AddressBytes;
+use crate::shared::{NumberFormat, NumericalAddress};
 use anyhow::{anyhow, Result};
 use move_binary_format::{
     access::ModuleAccess,
@@ -162,7 +162,10 @@ fn write_module_id(
     match named_address_mapping.get(id) {
         None => format!(
             "{}::{}",
-            format!("{}", AddressBytes::new(id.address().to_u8())),
+            format!(
+                "{}",
+                NumericalAddress::new(id.address().into_bytes(), NumberFormat::Hex)
+            ),
             id.name()
         ),
         Some(n) => format!("{}::{}", n.as_ref(), id.name()),

--- a/language/move-lang/src/parser/ast.rs
+++ b/language/move-lang/src/parser/ast.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{ast_debug::*, AddressBytes, Identifier, Name, TName, ADDRESS_LENGTH};
+use crate::shared::{ast_debug::*, Identifier, Name, NumericalAddress, TName};
 use move_ir_types::location::*;
 use move_symbol_pool::Symbol;
 use std::{fmt, hash::Hash};
@@ -136,7 +136,7 @@ new_name!(ModuleName);
 /// - A named address
 /// - An address numerical value
 pub enum LeadingNameAccess_ {
-    AnonymousAddress(AddressBytes),
+    AnonymousAddress(NumericalAddress),
     Name(Name),
 }
 pub type LeadingNameAccess = Spanned<LeadingNameAccess_>;
@@ -696,8 +696,8 @@ impl fmt::Debug for LeadingNameAccess_ {
 //**************************************************************************************************
 
 impl LeadingNameAccess_ {
-    pub const fn anonymous(address: [u8; ADDRESS_LENGTH]) -> Self {
-        Self::AnonymousAddress(AddressBytes::new(address))
+    pub const fn anonymous(address: NumericalAddress) -> Self {
+        Self::AnonymousAddress(address)
     }
 }
 

--- a/language/move-lang/src/parser/sources_shadow_deps.rs
+++ b/language/move-lang/src/parser/sources_shadow_deps.rs
@@ -32,7 +32,9 @@ pub fn program(compilation_env: &CompilationEnv, prog: Program) -> Program {
             Definition::Module(module) => {
                 modules_defined_in_src.insert((
                     module.address.map(|a| a.value).unwrap_or_else(|| {
-                        LeadingNameAccess_::AnonymousAddress(AddressBytes::DEFAULT_ERROR_BYTES)
+                        LeadingNameAccess_::AnonymousAddress(
+                            NumericalAddress::DEFAULT_ERROR_ADDRESS,
+                        )
                     }),
                     module.name,
                 ));
@@ -63,7 +65,7 @@ pub fn program(compilation_env: &CompilationEnv, prog: Program) -> Program {
             Definition::Address(_) => true,
             Definition::Module(module) => !modules_defined_in_src.contains(&(
                 module.address.map(|a| a.value).unwrap_or_else(|| {
-                    LeadingNameAccess_::AnonymousAddress(AddressBytes::DEFAULT_ERROR_BYTES)
+                    LeadingNameAccess_::AnonymousAddress(NumericalAddress::DEFAULT_ERROR_ADDRESS)
                 }),
                 module.name,
             )),

--- a/language/move-lang/src/parser/syntax.rs
+++ b/language/move-lang/src/parser/syntax.rs
@@ -280,10 +280,10 @@ fn parse_identifier(context: &mut Context) -> Result<Name, Diagnostic> {
 }
 
 // Parse a numerical address value
-//     AddressBytes = <Number>
-fn parse_address_bytes(context: &mut Context) -> Result<Spanned<AddressBytes>, Diagnostic> {
+//     NumericalAddress = <Number>
+fn parse_address_bytes(context: &mut Context) -> Result<Spanned<NumericalAddress>, Diagnostic> {
     let loc = current_token_loc(context.tokens);
-    let addr_res = AddressBytes::parse_str(context.tokens.content());
+    let addr_res = NumericalAddress::parse_str(context.tokens.content());
     consume_token(context.tokens, Tok::NumValue)?;
     let addr_ = match addr_res {
         Ok(addr_) => addr_,
@@ -291,14 +291,14 @@ fn parse_address_bytes(context: &mut Context) -> Result<Spanned<AddressBytes>, D
             context
                 .env
                 .add_diag(diag!(Syntax::InvalidAddress, (loc, msg)));
-            AddressBytes::DEFAULT_ERROR_BYTES
+            NumericalAddress::DEFAULT_ERROR_ADDRESS
         }
     };
     Ok(sp(loc, addr_))
 }
 
 // Parse the beginning of an access, either an address or an identifier:
-//      LeadingNameAccess = <AddressBytes> | <Identifier>
+//      LeadingNameAccess = <NumericalAddress> | <Identifier>
 fn parse_leading_name_access(context: &mut Context) -> Result<LeadingNameAccess, Diagnostic> {
     parse_leading_name_access_(context, || "an address or an identifier")
 }

--- a/language/move-lang/src/to_bytecode/translate.rs
+++ b/language/move-lang/src/to_bytecode/translate.rs
@@ -235,7 +235,7 @@ fn module(
     };
     let function_infos = module_function_infos(&module, &source_map, &collected_function_infos);
     let module = NamedCompiledModule {
-        address_bytes: addr_bytes,
+        address: addr_bytes,
         name: module_name.value(),
         module,
         source_map,

--- a/language/move-lang/src/unit_test/mod.rs
+++ b/language/move-lang/src/unit_test/mod.rs
@@ -4,7 +4,7 @@
 use crate::{
     compiled_unit::{AnnotatedCompiledUnit, NamedCompiledModule},
     diagnostics::FilesSourceText,
-    shared::AddressBytes,
+    shared::NumericalAddress,
 };
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage::ModuleId,
@@ -47,7 +47,7 @@ pub enum ExpectedFailure {
 
 impl ModuleTestPlan {
     pub fn new(
-        addr: &AddressBytes,
+        addr: &NumericalAddress,
         module_name: &str,
         tests: BTreeMap<TestName, TestCase>,
     ) -> Self {

--- a/language/move-lang/src/unit_test/plan_builder.rs
+++ b/language/move-lang/src/unit_test/plan_builder.rs
@@ -7,7 +7,7 @@ use crate::{
     expansion::ast::{self as E, Address, ModuleIdent, ModuleIdent_},
     shared::{
         known_attributes::{KnownAttribute, TestingAttribute},
-        AddressBytes, CompilationEnv, Identifier,
+        CompilationEnv, Identifier, NumericalAddress,
     },
     unit_test::{ExpectedFailure, ModuleTestPlan, TestCase},
 };
@@ -27,7 +27,7 @@ impl<'env> Context<'env> {
         }
     }
 
-    fn resolve_address(&mut self, addr: &Address) -> AddressBytes {
+    fn resolve_address(&mut self, addr: &Address) -> NumericalAddress {
         (*addr).into_addr_bytes(self.env.named_address_mapping())
     }
 }

--- a/language/move-lang/tests/move_check/parser/preserve_address_syntax.exp
+++ b/language/move-lang/tests/move_check/parser/preserve_address_syntax.exp
@@ -1,0 +1,12 @@
+error[E03002]: unbound module
+  ┌─ tests/move_check/parser/preserve_address_syntax.move:5:9
+  │
+5 │         0x00042::M::foo();
+  │         ^^^^^^^^^^ Unbound module '0x42::M'
+
+error[E03002]: unbound module
+  ┌─ tests/move_check/parser/preserve_address_syntax.move:6:9
+  │
+6 │         000112::N::bar();
+  │         ^^^^^^^^^ Unbound module '112::N'
+

--- a/language/move-lang/tests/move_check/parser/preserve_address_syntax.move
+++ b/language/move-lang/tests/move_check/parser/preserve_address_syntax.move
@@ -1,0 +1,8 @@
+// make sure addresses are printed as parsed
+// but zeros are still trimmed
+script {
+    fun ex() {
+        0x00042::M::foo();
+        000112::N::bar();
+    }
+}

--- a/language/move-lang/tests/move_check_testsuite.rs
+++ b/language/move-lang/tests/move_check_testsuite.rs
@@ -8,7 +8,7 @@ use move_command_line_common::{
 use move_lang::{
     compiled_unit::AnnotatedCompiledUnit,
     diagnostics::*,
-    shared::{AddressBytes, Flags},
+    shared::{Flags, NumericalAddress},
     unit_test, CommentMap, Compiler, SteppedCompiler, PASS_CFGIR, PASS_PARSER,
 };
 use std::{collections::BTreeMap, fs, path::Path};
@@ -18,7 +18,7 @@ const KEEP_TMP: &str = "KEEP";
 
 const TEST_EXT: &str = "unit_test";
 
-fn default_testing_addresses() -> BTreeMap<String, AddressBytes> {
+fn default_testing_addresses() -> BTreeMap<String, NumericalAddress> {
     let mapping = [
         ("Std", "0x1"),
         ("M", "0x1"),
@@ -28,7 +28,7 @@ fn default_testing_addresses() -> BTreeMap<String, AddressBytes> {
     ];
     mapping
         .iter()
-        .map(|(name, addr)| (name.to_string(), AddressBytes::parse_str(addr).unwrap()))
+        .map(|(name, addr)| (name.to_string(), NumericalAddress::parse_str(addr).unwrap()))
         .collect()
 }
 

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -1009,7 +1009,7 @@ impl ModuleName {
     }
 
     pub fn from_address_bytes_and_name(
-        addr: move_lang::shared::AddressBytes,
+        addr: move_lang::shared::NumericalAddress,
         name: Symbol,
     ) -> ModuleName {
         ModuleName(BigUint::from_bytes_be(&addr.into_bytes()), name)

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use log::{debug, info, warn};
 use num::BigUint;
 
-use move_lang::{expansion::ast as EA, parser::ast as PA, shared::AddressBytes};
+use move_lang::{expansion::ast as EA, parser::ast as PA, shared::NumericalAddress};
 use move_symbol_pool::Symbol as MoveStringSymbol;
 
 use crate::{
@@ -37,7 +37,7 @@ pub(crate) struct ModelBuilder<'env> {
     /// The global environment we are building.
     pub env: &'env mut GlobalEnv,
     /// Set of known named addresses provided by the compiler
-    pub named_address_mapping: BTreeMap<MoveStringSymbol, AddressBytes>,
+    pub named_address_mapping: BTreeMap<MoveStringSymbol, NumericalAddress>,
     /// A symbol table for specification functions. Because of overloading, and entry can
     /// contain multiple functions.
     pub spec_fun_table: BTreeMap<QualifiedSymbol, Vec<SpecFunEntry>>,
@@ -133,7 +133,7 @@ impl<'env> ModelBuilder<'env> {
     /// Creates a builders.
     pub fn new(
         env: &'env mut GlobalEnv,
-        named_address_mapping: BTreeMap<MoveStringSymbol, AddressBytes>,
+        named_address_mapping: BTreeMap<MoveStringSymbol, NumericalAddress>,
     ) -> Self {
         let mut translator = ModelBuilder {
             env,
@@ -290,7 +290,7 @@ impl<'env> ModelBuilder<'env> {
         assert!(self.const_table.insert(name, entry).is_none());
     }
 
-    pub fn resolve_address(&self, loc: &Loc, addr: &EA::Address) -> AddressBytes {
+    pub fn resolve_address(&self, loc: &Loc, addr: &EA::Address) -> NumericalAddress {
         match addr {
             EA::Address::Anonymous(bytes) => bytes.value,
             EA::Address::Named(n) => self
@@ -299,7 +299,7 @@ impl<'env> ModelBuilder<'env> {
                 .cloned()
                 .unwrap_or_else(|| {
                     self.error(loc, &format!("Undeclared address `{}`", n));
-                    AddressBytes::DEFAULT_ERROR_BYTES
+                    NumericalAddress::DEFAULT_ERROR_ADDRESS
                 }),
         }
     }

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -29,7 +29,7 @@ use move_lang::{
     diagnostics::Diagnostics,
     expansion::ast::{self as E, Address, ModuleDefinition, ModuleIdent, ModuleIdent_},
     parser::ast::{self as P, ModuleName as ParserModuleName},
-    shared::{parse_named_address, unique_map::UniqueMap, AddressBytes},
+    shared::{parse_named_address, unique_map::UniqueMap, NumericalAddress},
     Compiler, Flags, PASS_COMPILATION, PASS_EXPANSION, PASS_PARSER,
 };
 use move_symbol_pool::Symbol as MoveStringSymbol;
@@ -79,7 +79,7 @@ pub fn run_model_builder_with_options(
     move_sources: &[String],
     deps_dir: &[String],
     options: ModelBuilderOptions,
-    named_address_mapping: BTreeMap<String, AddressBytes>,
+    named_address_mapping: BTreeMap<String, NumericalAddress>,
 ) -> anyhow::Result<GlobalEnv> {
     run_model_builder_with_options_and_compilation_flags(
         move_sources,
@@ -97,7 +97,7 @@ pub fn run_model_builder_with_options_and_compilation_flags(
     deps_dir: &[String],
     options: ModelBuilderOptions,
     flags: Flags,
-    named_address_mapping: BTreeMap<String, AddressBytes>,
+    named_address_mapping: BTreeMap<String, NumericalAddress>,
 ) -> anyhow::Result<GlobalEnv> {
     let mut env = GlobalEnv::new();
     env.set_extension(options);
@@ -458,7 +458,7 @@ fn script_into_module(compiled_script: CompiledScript) -> CompiledModule {
 #[allow(deprecated)]
 fn run_spec_checker(
     env: &mut GlobalEnv,
-    named_address_mapping: BTreeMap<MoveStringSymbol, AddressBytes>,
+    named_address_mapping: BTreeMap<MoveStringSymbol, NumericalAddress>,
     units: Vec<AnnotatedCompiledUnit>,
     mut eprog: E::Program,
 ) {
@@ -514,7 +514,8 @@ fn run_spec_checker(
                         }
                     };
                     // Convert the script into a module.
-                    let address = Address::Anonymous(sp(loc, AddressBytes::DEFAULT_ERROR_BYTES));
+                    let address =
+                        Address::Anonymous(sp(loc, NumericalAddress::DEFAULT_ERROR_ADDRESS));
                     let ident = sp(
                         loc,
                         ModuleIdent_::new(address, ParserModuleName(function_name.0)),
@@ -592,7 +593,7 @@ pub fn big_uint_to_addr(i: &BigUint) -> AccountAddress {
 
 pub fn parse_addresses_from_options(
     named_addr_strings: Vec<String>,
-) -> anyhow::Result<BTreeMap<String, AddressBytes>> {
+) -> anyhow::Result<BTreeMap<String, NumericalAddress>> {
     named_addr_strings
         .iter()
         .map(|x| parse_named_address(x))

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -13,7 +13,7 @@ use std::{
 use anyhow::anyhow;
 use clap::{App, Arg};
 use log::LevelFilter;
-use move_lang::shared::AddressBytes;
+use move_lang::shared::NumericalAddress;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use simplelog::{
@@ -794,10 +794,10 @@ impl Options {
 }
 
 pub fn named_addresses_for_options(
-    named_address_values: &BTreeMap<String, AddressBytes>,
+    named_address_values: &BTreeMap<String, NumericalAddress>,
 ) -> Vec<String> {
     named_address_values
         .iter()
-        .map(|(name, addr)| format!("{}=0x{:#X}", name, addr))
+        .map(|(name, addr)| format!("{}={}", name, addr))
         .collect()
 }

--- a/language/move-prover/tools/spec-flatten/src/options.rs
+++ b/language/move-prover/tools/spec-flatten/src/options.rs
@@ -3,7 +3,7 @@
 
 use structopt::StructOpt;
 
-use move_lang::shared::{parse_named_address, AddressBytes};
+use move_lang::shared::{parse_named_address, NumericalAddress};
 
 /// Options passed into the specification flattening tool.
 #[derive(StructOpt, Clone)]
@@ -25,7 +25,7 @@ pub struct FlattenOptions {
 
     /// Extra mappings for named address
     #[structopt(short = "a", long = "address", parse(try_from_str = parse_named_address))]
-    pub named_addresses_extra: Option<Vec<(String, AddressBytes)>>,
+    pub named_addresses_extra: Option<Vec<(String, NumericalAddress)>>,
 
     /// Verbose mode
     #[structopt(short, long)]

--- a/language/move-prover/tools/spec-flatten/src/workflow.rs
+++ b/language/move-prover/tools/spec-flatten/src/workflow.rs
@@ -8,7 +8,7 @@ use bytecode::{
     function_target_pipeline::FunctionTargetsHolder, options::ProverOptions,
     pipeline_factory::default_pipeline_with_options,
 };
-use move_lang::shared::AddressBytes;
+use move_lang::shared::NumericalAddress;
 use move_model::{
     ast::Spec,
     model::{FunId, GlobalEnv, QualifiedId, VerificationScope},
@@ -41,7 +41,7 @@ pub(crate) fn prepare_with_override(
         named_addresses.extend(
             default_mapping
                 .iter()
-                .map(|(name, addr)| (name.to_string(), AddressBytes::parse_str(addr).unwrap())),
+                .map(|(name, addr)| (name.to_string(), NumericalAddress::parse_str(addr).unwrap())),
         );
     }
 

--- a/language/move-stdlib/src/lib.rs
+++ b/language/move-stdlib/src/lib.rs
@@ -3,7 +3,7 @@
 
 use log::LevelFilter;
 use move_command_line_common::files::{extension_equals, find_filenames, MOVE_EXTENSION};
-use move_lang::shared::AddressBytes;
+use move_lang::shared::NumericalAddress;
 use std::{collections::BTreeMap, path::PathBuf};
 
 #[cfg(test)]
@@ -63,11 +63,11 @@ pub fn move_nursery_files() -> Vec<String> {
     find_filenames(&[path], |p| extension_equals(p, MOVE_EXTENSION)).unwrap()
 }
 
-pub fn move_stdlib_named_addresses() -> BTreeMap<String, AddressBytes> {
+pub fn move_stdlib_named_addresses() -> BTreeMap<String, NumericalAddress> {
     let mapping = [("Std", "0x1")];
     mapping
         .iter()
-        .map(|(name, addr)| (name.to_string(), AddressBytes::parse_str(addr).unwrap()))
+        .map(|(name, addr)| (name.to_string(), NumericalAddress::parse_str(addr).unwrap()))
         .collect()
 }
 
@@ -79,7 +79,7 @@ pub fn build_doc(
     sources: &[String],
     dep_paths: Vec<String>,
     with_diagram: bool,
-    named_addresses: BTreeMap<String, AddressBytes>,
+    named_addresses: BTreeMap<String, NumericalAddress>,
 ) {
     let options = move_prover::cli::Options {
         move_sources: sources.to_vec(),

--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -23,7 +23,7 @@ use move_core_types::{
 use move_lang::{
     compiled_unit::AnnotatedCompiledUnit,
     diagnostics::{Diagnostics, FilesSourceText},
-    shared::AddressBytes,
+    shared::NumericalAddress,
     FullyCompiledProgram,
 };
 use move_symbol_pool::Symbol;
@@ -44,7 +44,7 @@ pub struct ProcessedModule {
 pub struct CompiledState<'a> {
     pre_compiled_deps: Option<&'a FullyCompiledProgram>,
     compiled_module_named_address_mapping: BTreeMap<ModuleId, Symbol>,
-    named_address_mapping: BTreeMap<Symbol, AddressBytes>,
+    named_address_mapping: BTreeMap<Symbol, NumericalAddress>,
     modules: BTreeMap<ModuleId, ProcessedModule>,
 }
 
@@ -254,7 +254,7 @@ pub trait MoveTestAdapter<'a> {
 
 impl<'a> CompiledState<'a> {
     pub fn new(
-        named_address_mapping: BTreeMap<impl Into<Symbol>, AddressBytes>,
+        named_address_mapping: BTreeMap<impl Into<Symbol>, NumericalAddress>,
         pre_compiled_deps: Option<&'a FullyCompiledProgram>,
     ) -> Self {
         let named_address_mapping = named_address_mapping
@@ -327,7 +327,7 @@ impl<'a> CompiledState<'a> {
 
 fn compile_source_unit(
     pre_compiled_deps: Option<&FullyCompiledProgram>,
-    named_address_mapping: BTreeMap<Symbol, AddressBytes>,
+    named_address_mapping: BTreeMap<Symbol, NumericalAddress>,
     deps: &[String],
     path: String,
 ) -> Result<(AnnotatedCompiledUnit, Option<String>)> {

--- a/language/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/language/testing-infra/transactional-test-runner/src/tasks.rs
@@ -12,7 +12,7 @@ use move_core_types::{
     parser,
     transaction_argument::TransactionArgument,
 };
-use move_lang::shared::AddressBytes;
+use move_lang::shared::NumericalAddress;
 use std::{fmt::Debug, path::Path, str::FromStr};
 use structopt::*;
 use tempfile::NamedTempFile;
@@ -200,7 +200,7 @@ pub struct InitCommand {
         long = "addresses",
         parse(try_from_str = move_lang::shared::parse_named_address)
     )]
-    pub named_addresses: Vec<(String, AddressBytes)>,
+    pub named_addresses: Vec<(String, NumericalAddress)>,
 }
 
 #[derive(Debug, StructOpt)]
@@ -316,9 +316,9 @@ where
 pub struct EmptyCommand {}
 
 fn parse_account_address(s: &str) -> Result<AccountAddress> {
-    let n = move_lang::shared::parse_u128(s)
+    let a = move_lang::shared::NumericalAddress::parse_str(s)
         .map_err(|e| anyhow!("Failed to parse address. Got error: {}", e))?;
-    Ok(AccountAddress::new(n.to_be_bytes()))
+    Ok(a.into_inner())
 }
 
 fn parse_qualified_module_access(s: &str) -> Result<(ModuleId, Identifier)> {

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -23,7 +23,7 @@ use move_core_types::{
 };
 use move_lang::{
     compiled_unit::AnnotatedCompiledUnit,
-    shared::{verify_and_create_named_address_mapping, AddressBytes},
+    shared::{verify_and_create_named_address_mapping, NumericalAddress},
     FullyCompiledProgram,
 };
 use move_stdlib::move_stdlib_named_addresses;
@@ -128,7 +128,10 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             assert!(prev.is_none());
         }
         for module in &*MOVE_STDLIB_COMPILED {
-            let bytes = AddressBytes::new(module.address().to_u8());
+            let bytes = NumericalAddress::new(
+                module.address().into_bytes(),
+                move_lang::shared::NumberFormat::Hex,
+            );
             let named_addr = *addr_to_name_mapping.get(&bytes).unwrap();
             adapter.compiled_state.add(Some(named_addr), module.clone());
         }

--- a/language/tools/move-cli/src/base/commands/check.rs
+++ b/language/tools/move-cli/src/base/commands/check.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use move_lang::{
     self,
-    shared::{AddressBytes, Flags},
+    shared::{Flags, NumericalAddress},
     Compiler,
 };
 
@@ -15,7 +15,7 @@ pub fn check(
     interface_files: &[String],
     sources_shadow_deps: bool,
     files: &[String],
-    named_addresses: BTreeMap<String, AddressBytes>,
+    named_addresses: BTreeMap<String, NumericalAddress>,
     verbose: bool,
 ) -> Result<()> {
     if verbose {

--- a/language/tools/move-cli/src/base/commands/compile.rs
+++ b/language/tools/move-cli/src/base/commands/compile.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 use anyhow::Result;
 use move_lang::{
     self,
-    shared::{AddressBytes, Flags},
+    shared::{Flags, NumericalAddress},
     Compiler,
 };
 
@@ -17,7 +17,7 @@ pub fn compile(
     output_dir: &str,
     sources_shadow_deps: bool,
     sources: &[String],
-    named_address_mapping: BTreeMap<String, AddressBytes>,
+    named_address_mapping: BTreeMap<String, NumericalAddress>,
     emit_source_map: bool,
     verbose: bool,
 ) -> Result<()> {

--- a/language/tools/move-cli/src/lib.rs
+++ b/language/tools/move-cli/src/lib.rs
@@ -28,7 +28,7 @@ use anyhow::Result;
 use move_core_types::{
     account_address::AccountAddress, errmap::ErrorMapping, identifier::Identifier,
 };
-use move_lang::shared::{self, AddressBytes};
+use move_lang::shared::{self, NumericalAddress};
 use move_vm_runtime::native_functions::NativeFunction;
 use sandbox::utils::mode::{Mode, ModeType};
 use std::path::PathBuf;
@@ -51,7 +51,7 @@ pub struct Move {
         global = true,
         parse(try_from_str = shared::parse_named_address)
     )]
-    named_addresses: Vec<(String, AddressBytes)>,
+    named_addresses: Vec<(String, NumericalAddress)>,
 
     /// Directory storing Move resources, events, and module bytecodes produced by module publishing
     /// and script execution.

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -9,7 +9,7 @@ use crate::{
     NativeFunctionRecord,
 };
 use move_lang::{
-    self, compiled_unit::AnnotatedCompiledUnit, shared::AddressBytes, Compiler, Flags,
+    self, compiled_unit::AnnotatedCompiledUnit, shared::NumericalAddress, Compiler, Flags,
 };
 use move_vm_runtime::move_vm::MoveVM;
 
@@ -23,7 +23,7 @@ pub fn publish(
     republish: bool,
     ignore_breaking_changes: bool,
     override_ordering: Option<&[String]>,
-    named_address_mapping: BTreeMap<String, AddressBytes>,
+    named_address_mapping: BTreeMap<String, NumericalAddress>,
     verbose: bool,
 ) -> Result<()> {
     if verbose {

--- a/language/tools/move-cli/src/sandbox/commands/run.rs
+++ b/language/tools/move-cli/src/sandbox/commands/run.rs
@@ -17,7 +17,7 @@ use move_core_types::{
     transaction_argument::{convert_txn_args, TransactionArgument},
 };
 use move_lang::{
-    self, compiled_unit::AnnotatedCompiledUnit, shared::AddressBytes, Compiler, Flags,
+    self, compiled_unit::AnnotatedCompiledUnit, shared::NumericalAddress, Compiler, Flags,
 };
 use move_vm_runtime::move_vm::MoveVM;
 
@@ -33,7 +33,7 @@ pub fn run(
     signers: &[String],
     txn_args: &[TransactionArgument],
     vm_type_args: Vec<TypeTag>,
-    named_address_mapping: BTreeMap<String, AddressBytes>,
+    named_address_mapping: BTreeMap<String, NumericalAddress>,
     gas_budget: Option<u64>,
     dry_run: bool,
     verbose: bool,
@@ -41,7 +41,7 @@ pub fn run(
     fn compile_script(
         state: &OnDiskStateView,
         script_path: &Path,
-        named_address_mapping: BTreeMap<String, AddressBytes>,
+        named_address_mapping: BTreeMap<String, NumericalAddress>,
         verbose: bool,
     ) -> Result<Option<CompiledScript>> {
         if verbose {

--- a/language/tools/move-cli/src/sandbox/utils/mode.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mode.rs
@@ -11,7 +11,7 @@ use crate::{
 use anyhow::{bail, Result};
 use include_dir::{include_dir, Dir};
 use move_binary_format::file_format::CompiledModule;
-use move_lang::shared::AddressBytes;
+use move_lang::shared::NumericalAddress;
 use move_stdlib::move_stdlib_named_addresses;
 use once_cell::sync::Lazy;
 use std::{
@@ -62,7 +62,7 @@ static PACKAGE_DIEM_FRAMEWORK: Lazy<MovePackage> = Lazy::new(|| {
         ("VMReserved", "0x0"),
     ]
     .iter()
-    .map(|(name, addr)| (name.to_string(), AddressBytes::parse_str(addr).unwrap()))
+    .map(|(name, addr)| (name.to_string(), NumericalAddress::parse_str(addr).unwrap()))
     .collect();
     MovePackage::new(
         "diem".to_string(),
@@ -133,7 +133,7 @@ impl Mode {
         &self,
         out_path: &Path,
         source_only: bool,
-    ) -> Result<BTreeMap<String, AddressBytes>> {
+    ) -> Result<BTreeMap<String, NumericalAddress>> {
         let mut named_address_values = BTreeMap::new();
         for pkg in &self.0 {
             pkg.prepare(out_path, source_only)?;

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -20,7 +20,7 @@ use move_core_types::{
     value::MoveStructLayout,
 };
 use move_ir_types::location::Spanned;
-use move_lang::{shared::AddressBytes, MOVE_COMPILED_INTERFACES_DIR};
+use move_lang::{shared::NumericalAddress, MOVE_COMPILED_INTERFACES_DIR};
 use move_symbol_pool::Symbol;
 use resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue, MoveValueAnnotator};
 use serde::{Deserialize, Serialize};
@@ -107,13 +107,13 @@ impl OnDiskStateView {
 
     pub fn get_named_addresses(
         &self,
-        additional_named_address_values: BTreeMap<String, AddressBytes>,
-    ) -> Result<BTreeMap<String, AddressBytes>> {
+        additional_named_address_values: BTreeMap<String, NumericalAddress>,
+    ) -> Result<BTreeMap<String, NumericalAddress>> {
         let mut save_named_addrs: BTreeMap<_, _> = self
             .read_interface_files_metadata()?
             .named_address_values
             .iter()
-            .map(|(name, addr_str)| (name.clone(), AddressBytes::parse_str(addr_str).unwrap()))
+            .map(|(name, addr_str)| (name.clone(), NumericalAddress::parse_str(addr_str).unwrap()))
             .collect();
         save_named_addrs.extend(additional_named_address_values);
         Ok(save_named_addrs)
@@ -122,7 +122,7 @@ impl OnDiskStateView {
     fn update_interface_files_metadata(
         &self,
         additional_named_address_mapping: BTreeMap<ModuleId, Option<String>>,
-        additional_named_address_values: BTreeMap<String, AddressBytes>,
+        additional_named_address_values: BTreeMap<String, NumericalAddress>,
     ) -> Result<()> {
         let InterfaceFilesMetadata {
             mut named_address_mapping,
@@ -141,7 +141,7 @@ impl OnDiskStateView {
         named_address_values.extend(
             additional_named_address_values
                 .into_iter()
-                .map(|(name, addr)| (name, format!("0x{:#X}", addr))),
+                .map(|(name, addr)| (name, format!("{:#X}", addr))),
         );
         self.write_interface_files_metadata(InterfaceFilesMetadata {
             named_address_mapping,
@@ -436,7 +436,7 @@ impl OnDiskStateView {
     fn sync_interface_files(
         &self,
         named_address_mapping_changes: BTreeMap<ModuleId, Option<String>>,
-        named_address_values: BTreeMap<String, AddressBytes>,
+        named_address_values: BTreeMap<String, NumericalAddress>,
     ) -> Result<()> {
         self.update_interface_files_metadata(named_address_mapping_changes, named_address_values)?;
         move_lang::generate_interface_files(
@@ -463,7 +463,7 @@ impl OnDiskStateView {
     pub fn save_modules<'a>(
         &self,
         modules: impl IntoIterator<Item = &'a (ModuleIdWithNamedAddress, Vec<u8>)>,
-        named_address_values: BTreeMap<String, AddressBytes>,
+        named_address_values: BTreeMap<String, NumericalAddress>,
     ) -> Result<()> {
         let mut named_address_mapping_changes = BTreeMap::new();
         let mut is_empty = true;

--- a/language/tools/move-cli/src/sandbox/utils/package.rs
+++ b/language/tools/move-cli/src/sandbox/utils/package.rs
@@ -10,7 +10,7 @@ use move_command_line_common::files::{
 };
 use move_lang::{
     compiled_unit::{AnnotatedCompiledModule, AnnotatedCompiledUnit},
-    shared::{AddressBytes, Flags},
+    shared::{Flags, NumericalAddress},
     Compiler,
 };
 use move_symbol_pool::Symbol;
@@ -81,7 +81,7 @@ pub struct MovePackage {
     /// Dependencies
     deps: Vec<&'static Lazy<MovePackage>>,
     /// Named address values to be be used in this package.
-    named_addresses: BTreeMap<String, AddressBytes>,
+    named_addresses: BTreeMap<String, NumericalAddress>,
     /// Hack to support named addresses. Works now since our current packages only have one address
     // TODO properly support named addresses, will require migrating to new/planned build system
     named_address_hack: Option<String>,
@@ -92,7 +92,7 @@ impl MovePackage {
         name: String,
         sources: Vec<SourceFilter<'static>>,
         deps: Vec<&'static Lazy<MovePackage>>,
-        named_addresses: BTreeMap<String, AddressBytes>,
+        named_addresses: BTreeMap<String, NumericalAddress>,
         named_address: Option<String>,
     ) -> Self {
         MovePackage {
@@ -186,7 +186,7 @@ impl MovePackage {
         Ok(src_dirs)
     }
 
-    pub(crate) fn named_addresses(&self) -> &BTreeMap<String, AddressBytes> {
+    pub(crate) fn named_addresses(&self) -> &BTreeMap<String, NumericalAddress> {
         &self.named_addresses
     }
 

--- a/language/tools/move-package/src/compilation/model_builder.rs
+++ b/language/tools/move-package/src/compilation/model_builder.rs
@@ -3,7 +3,7 @@
 
 use crate::resolution::resolution_graph::ResolvedGraph;
 use anyhow::Result;
-use move_lang::shared::AddressBytes;
+use move_lang::shared::NumericalAddress;
 use move_model::{model::GlobalEnv, options::ModelBuilderOptions, run_model_builder_with_options};
 
 #[derive(Debug, Clone)]
@@ -64,7 +64,13 @@ impl ModelBuilder {
             root_package
                 .resolution_table
                 .into_iter()
-                .map(|(ident, addr)| (ident.to_string(), AddressBytes::new(addr.to_u8())))
+                .map(|(ident, addr)| {
+                    let addr = NumericalAddress::new(
+                        addr.into_bytes(),
+                        move_lang::shared::NumberFormat::Hex,
+                    );
+                    (ident.to_string(), addr)
+                })
                 .collect(),
         )
     }

--- a/language/tools/move-unit-test/src/lib.rs
+++ b/language/tools/move-unit-test/src/lib.rs
@@ -9,7 +9,7 @@ use move_core_types::language_storage::ModuleId;
 use move_lang::{
     self,
     diagnostics::{self, codes::Severity},
-    shared::{self, AddressBytes},
+    shared::{self, NumericalAddress},
     unit_test::{self, TestPlan},
     Compiler, Flags, PASS_CFGIR,
 };
@@ -70,7 +70,7 @@ pub struct UnitTestingConfig {
         long = "addresses",
         parse(try_from_str = shared::parse_named_address)
     )]
-    pub named_address_values: Vec<(String, AddressBytes)>,
+    pub named_address_values: Vec<(String, NumericalAddress)>,
 
     /// Source files
     #[structopt(name = "sources")]
@@ -114,7 +114,7 @@ impl UnitTestingConfig {
 
     pub fn with_named_addresses(
         mut self,
-        named_address_values: BTreeMap<String, AddressBytes>,
+        named_address_values: BTreeMap<String, NumericalAddress>,
     ) -> Self {
         assert!(self.named_address_values.is_empty());
         self.named_address_values = named_address_values.into_iter().collect();

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -23,7 +23,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_lang::{
-    shared::{AddressBytes, Flags},
+    shared::{Flags, NumericalAddress},
     unit_test::{ExpectedFailure, ModuleTestPlan, TestCase, TestPlan},
 };
 use move_model::{
@@ -45,7 +45,7 @@ pub struct SharedTestingConfig {
     native_function_table: NativeFunctionTable,
     starting_storage_state: InMemoryStorage,
     source_files: Vec<String>,
-    named_address_values: BTreeMap<String, AddressBytes>,
+    named_address_values: BTreeMap<String, NumericalAddress>,
     check_stackless_vm: bool,
     verbose: bool,
 }
@@ -120,7 +120,7 @@ impl TestRunner {
         save_storage_state_on_failure: bool,
         tests: TestPlan,
         native_function_table: Option<NativeFunctionTable>,
-        named_address_values: BTreeMap<String, AddressBytes>,
+        named_address_values: BTreeMap<String, NumericalAddress>,
     ) -> Result<Self> {
         let source_files = tests
             .files

--- a/shuffle/cli/src/deploy.rs
+++ b/shuffle/cli/src/deploy.rs
@@ -116,7 +116,7 @@ pub fn compile_program(file_path: &str, dependency_paths: &[&str]) -> Result<Vec
         command.args(&["-d", dep]);
     }
     for (name, addr) in diem_framework::diem_framework_named_addresses() {
-        command.args(&["-a", &format!("{}=0x{:#X}", name, addr)]);
+        command.args(&["-a", &format!("{}={:#X}", name, addr)]);
     }
 
     let output = command.output()?;

--- a/shuffle/cli/src/new.rs
+++ b/shuffle/cli/src/new.rs
@@ -9,7 +9,7 @@ use move_cli::{
     sandbox,
     sandbox::utils::{on_disk_state_view::OnDiskStateView, Mode, ModeType},
 };
-use move_lang::shared::AddressBytes;
+use move_lang::shared::NumericalAddress;
 use move_package::source_package::layout::SourcePackageLayout;
 use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
@@ -57,21 +57,21 @@ pub struct Config {
 }
 
 // Fetches the named addresses for a particular project or genesis.
-// Uses a BTreeMap over HashMap because upstream AddressBytes does as well,
+// Uses a BTreeMap over HashMap because upstream NumericalAddress does as well,
 // probably because order matters.
 fn fetch_named_addresses(state: &OnDiskStateView) -> Result<BTreeMap<String, AccountAddress>> {
     let address_bytes_map = state.get_named_addresses(BTreeMap::new())?;
     Ok(map_address_bytes_to_account_address(address_bytes_map))
 }
 
-// map_address_bytes_to_account_address converts BTreeMap<String,AddressBytes>
-// to BTreeMap<String, AccountAddress> because AddressBytes is not serializable.
+// map_address_bytes_to_account_address converts BTreeMap<String,NumericalAddress>
+// to BTreeMap<String, AccountAddress> because NumericalAddress is not serializable.
 fn map_address_bytes_to_account_address(
-    original: BTreeMap<String, AddressBytes>,
+    original: BTreeMap<String, NumericalAddress>,
 ) -> BTreeMap<String, AccountAddress> {
     original
-        .iter()
-        .map(|(name, addr)| (name.to_string(), AccountAddress::new(addr.into_bytes())))
+        .into_iter()
+        .map(|(name, addr)| (name, addr.into_inner()))
         .collect()
 }
 

--- a/testsuite/cli/src/client_proxy.rs
+++ b/testsuite/cli/src/client_proxy.rs
@@ -936,7 +936,7 @@ impl ClientProxy {
             args.push_str(&format!(" -d {}", dep));
         }
         for (name, addr) in diem_framework::diem_framework_named_addresses() {
-            args.push_str(&format!(" -a {}=0x{:#X}", name, addr));
+            args.push_str(&format!(" -a {}={:#X}", name, addr));
         }
 
         let status = Command::new("cargo")

--- a/testsuite/smoke-test/src/scripts_and_modules.rs
+++ b/testsuite/smoke-test/src/scripts_and_modules.rs
@@ -270,7 +270,7 @@ pub fn compile_program(file_path: &str, dependency_paths: &[&str]) -> Result<Vec
         command.args(&["-d", dep]);
     }
     for (name, addr) in diem_framework::diem_framework_named_addresses() {
-        command.args(&["-a", &format!("{}=0x{:#X}", name, addr)]);
+        command.args(&["-a", &format!("{}={:#X}", name, addr)]);
     }
 
     let output = command.output()?;


### PR DESCRIPTION
- Renamed AddressBytes to ~~ParsedAddressBytes~~NumericalAddress
- ~~ParsedAddressBytes~~NumericalAddress now just wraps AccountAddress
- ~~ParsedAddressBytes~~NumericalAddress contains formatting information
- Renamed horribly named AccountAddress::to_u8 to ::into_bytes

## Motivation

- Hopefully remove the confusion about these types... maybe
- There is some code duplication still, but it should be more obvious to why it is there and what is doing 

## Test Plan

- new tests
- updated tests