### PR TITLE
[forge] change compatibility test suite start with older version

### DIFF
--- a/testsuite/forge-cli/src/lib.rs
+++ b/testsuite/forge-cli/src/lib.rs
@@ -1,0 +1,2 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -262,6 +262,7 @@ fn land_blocking_test_compat_suite() -> ForgeConfig<'static> {
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(30).unwrap())
         .with_network_tests(&[&SimpleValidatorUpgrade, &PerformanceBenchmark])
+        .with_initial_version(InitialVersion::Oldest)
 }
 
 //TODO Make public test later

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -93,7 +93,7 @@ impl Factory for K8sFactory {
         &self,
         _rng: &mut StdRng,
         node_num: NonZeroUsize,
-        version: &Version,
+        init_version: &Version,
     ) -> Result<Box<dyn Swarm>> {
         uninstall_from_k8s_cluster()?;
         set_eks_nodegroup_size(self.cluster_name.clone(), 0, true)?;
@@ -101,8 +101,8 @@ impl Factory for K8sFactory {
         clean_k8s_cluster(
             self.helm_repo.clone(),
             node_num.get(),
-            format!("{}", version),
-            format!("{}", version),
+            format!("{}", init_version),
+            format!("{}", init_version),
             true,
         )?;
         let rt = Runtime::new().unwrap();
@@ -114,6 +114,7 @@ impl Factory for K8sFactory {
                 &self.helm_repo,
                 &self.image_tag,
                 &self.base_image_tag,
+                format!("{}", init_version).as_str(),
             ))
             .unwrap();
         Ok(Box::new(swarm))

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -49,10 +49,11 @@ impl K8sSwarm {
         helm_repo: &str,
         image_tag: &str,
         base_image_tag: &str,
+        init_image_tag: &str,
     ) -> Result<Self> {
         let kube_client = create_k8s_client().await;
         let fullnodes = HashMap::new();
-        let validators = get_validators(kube_client.clone(), image_tag).await?;
+        let validators = get_validators(kube_client.clone(), init_image_tag).await?;
 
         let client = validators.values().next().unwrap().json_rpc_client();
         let key = load_root_key(root_key);


### PR DESCRIPTION
change compatibility test suite start with older version can save one time downgrading procedure at the start

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
