### PR TITLE
[api] post /transactions to submit bcs encoded signed transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,12 +1585,14 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
+ "bytes",
  "diem-api-types",
  "diem-config",
  "diem-crypto",
  "diem-framework-releases",
  "diem-genesis-tool",
  "diem-global-constants",
+ "diem-mempool",
  "diem-sdk",
  "diem-secure-storage",
  "diem-temppath",
@@ -1610,6 +1612,7 @@ dependencies = [
  "serde_json",
  "storage-interface",
  "tokio",
+ "vm-validator",
  "warp",
 ]
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 bcs = "0.1.2"
+bytes = "1.0.1"
 futures = "0.3.12"
 hex = "0.4.3"
 hyper = "0.14.4"
@@ -21,6 +22,7 @@ tokio = { version = "1.8.1", features = ["full"] }
 warp = { version = "0.3.0", features = ["default"] }
 
 diem-config = { path = "../config" }
+diem-mempool = { path = "../mempool"}
 diem-types = { path = "../types" }
 diem-workspace-hack = { path = "../common/workspace-hack" }
 diem-api-types = { path = "./types", package = "diem-api-types" }
@@ -34,11 +36,13 @@ rand = "0.8.3"
 diemdb = { path = "../storage/diemdb", features = ["fuzzing"] }
 diem-crypto = { path = "../crypto/crypto" }
 diem-global-constants = { path = "../config/global-constants" }
+diem-mempool = { path = "../mempool", features = ["fuzzing"] }
 diem-secure-storage = { path = "../secure/storage" }
 diem-temppath = { path = "../common/temppath" }
 diem-genesis-tool = {path = "../config/management/genesis", features = ["testing"] }
 diem-framework-releases = { path = "../language/diem-framework/DPN/releases" }
 diem-sdk = { path = "../sdk" }
+vm-validator = { path = "../vm-validator" }
 diem-vm = { path = "../language/diem-vm" }
 executor = { path = "../execution/executor" }
 executor-types = { path = "../execution/executor-types" }

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -4,6 +4,7 @@
 use crate::{context::Context, index};
 
 use diem_config::config::ApiConfig;
+use diem_mempool::MempoolClientSender;
 use diem_types::{chain_id::ChainId, protocol_spec::DpnProto};
 use storage_interface::MoveDbReader;
 
@@ -16,6 +17,7 @@ pub fn bootstrap(
     chain_id: ChainId,
     db: Arc<dyn MoveDbReader<DpnProto>>,
     config: &ApiConfig,
+    mp_sender: MempoolClientSender,
 ) -> Runtime {
     let runtime = Builder::new_multi_thread()
         .thread_name("api")
@@ -25,7 +27,7 @@ pub fn bootstrap(
 
     let address = config.address;
     runtime.spawn(async move {
-        let service = Context::new(chain_id, db);
+        let service = Context::new(chain_id, db, mp_sender);
         let routes = index::routes(service);
         let server = warp::serve(routes).bind(address);
         server.await

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -436,9 +436,19 @@ pub fn setup_environment(node_config: &NodeConfig, logger: Option<Arc<Logger>>) 
     );
     let (mp_client_sender, mp_client_events) = channel(AC_SMP_CHANNEL_BUFFER_SIZE);
 
-    let rpc_runtime = bootstrap_rpc(node_config, chain_id, diem_db.clone(), mp_client_sender);
+    let rpc_runtime = bootstrap_rpc(
+        node_config,
+        chain_id,
+        diem_db.clone(),
+        mp_client_sender.clone(),
+    );
     let api_runtime = match node_config.api.enabled {
-        true => Some(bootstrap_api(chain_id, diem_db.clone(), &node_config.api)),
+        true => Some(bootstrap_api(
+            chain_id,
+            diem_db.clone(),
+            &node_config.api,
+            mp_client_sender,
+        )),
         false => None,
     };
 

--- a/types/src/mempool_status.rs
+++ b/types/src/mempool_status.rs
@@ -36,6 +36,16 @@ impl MempoolStatus {
     }
 }
 
+impl fmt::Display for MempoolStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", &self.code)?;
+        if !self.message.is_empty() {
+            write!(f, " - {}", &self.message)?;
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[repr(u64)]


### PR DESCRIPTION
#9193

* submit transaction by post bcs encoded SignedTransaction to /transactions.
* response a pending transaction serialized from the SignedTransaction, include transaction hash.
* response 400 for invalid transaction or mempool rejection errors.
* response 202 accepted if mempool accepts the transactions.
* will have a follow up PR to render a Location header for looking up transaction by hash (after we implement GET /transactions/<txn-hash>)