### PR TITLE
[network] Integrate NetworkInterface for Network Senders into mempool, and fix some abstractions for networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,6 +2224,7 @@ name = "diem-mempool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bcs",
  "bounded-executor",
  "channel",
@@ -5495,6 +5496,7 @@ dependencies = [
 name = "network-builder"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bcs",
  "channel",
  "diem-config",
@@ -7879,6 +7881,7 @@ dependencies = [
 name = "state-sync-v1"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bcs",
  "bytes",
  "channel",

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -46,7 +46,7 @@ use diem_types::{
 };
 use event_notifications::ReconfigNotificationListener;
 use futures::{channel::mpsc::unbounded, select, StreamExt};
-use network::protocols::network::Event;
+use network::protocols::network::{ApplicationNetworkSender, Event};
 use safety_rules::SafetyRulesManager;
 use std::{
     cmp::Ordering,

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -25,7 +25,9 @@ use diem_types::{
 };
 use futures::{channel::oneshot, stream::select, SinkExt, Stream, StreamExt};
 use network::protocols::{
-    network::Event, rpc::error::RpcError, wire::handshake::v1::ProtocolIdSet,
+    network::{ApplicationNetworkSender, Event},
+    rpc::error::RpcError,
+    wire::handshake::v1::ProtocolIdSet,
 };
 use std::{
     collections::HashMap,

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
+async-trait = "0.1.42"
 fail = "0.4.0"
 futures = "0.3.12"
 itertools = "0.10.0"

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -6,7 +6,7 @@
 use crate::{counters, shared_mempool::peer_manager::PeerSyncState};
 use async_trait::async_trait;
 use channel::{diem_channel, message_queues::QueueStyle};
-use diem_config::network_id::PeerNetworkId;
+use diem_config::network_id::{NetworkId, PeerNetworkId};
 use diem_types::{transaction::SignedTransaction, PeerId};
 use fail::fail_point;
 use network::{
@@ -24,7 +24,11 @@ use network::{
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
-use std::{collections::hash_map::Entry, sync::Arc, time::Duration};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    sync::Arc,
+    time::Duration,
+};
 
 /// Container for exchanging transactions with other Mempools.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -65,7 +69,7 @@ pub type MempoolNetworkEvents = NetworkEvents<MempoolSyncMsg>;
 /// remote, to finally receiving the response and deserializing. It therefore
 /// makes the most sense to make the rpc call on a separate async task, which
 /// requires the `MempoolNetworkSender` to be `Clone` and `Send`.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MempoolNetworkSender {
     inner: NetworkSender<MempoolSyncMsg>,
 }
@@ -114,10 +118,24 @@ impl ApplicationNetworkSender<MempoolSyncMsg> for MempoolNetworkSender {
 
 type MempoolMultiNetworkSender = MultiNetworkSender<MempoolSyncMsg, MempoolNetworkSender>;
 
+#[derive(Clone, Debug)]
 pub(crate) struct MempoolNetworkInterface {
     peer_metadata_storage: Arc<PeerMetadataStorage>,
     sender: MempoolMultiNetworkSender,
-    sync_states: LockingHashMap<PeerNetworkId, PeerSyncState>,
+    sync_states: Arc<LockingHashMap<PeerNetworkId, PeerSyncState>>,
+}
+
+impl MempoolNetworkInterface {
+    pub(crate) fn new(
+        peer_metadata_storage: Arc<PeerMetadataStorage>,
+        network_senders: HashMap<NetworkId, MempoolNetworkSender>,
+    ) -> MempoolNetworkInterface {
+        MempoolNetworkInterface {
+            peer_metadata_storage,
+            sender: MultiNetworkSender::new(network_senders),
+            sync_states: Arc::new(LockingHashMap::new()),
+        }
+    }
 }
 
 impl NetworkInterface<MempoolSyncMsg, MempoolMultiNetworkSender> for MempoolNetworkInterface {

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -4,16 +4,21 @@
 //! Interface between Mempool and Network layers.
 
 use crate::counters;
+use async_trait::async_trait;
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_types::{transaction::SignedTransaction, PeerId};
 use fail::fail_point;
 use network::{
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
-    protocols::network::{AppConfig, NetworkEvents, NetworkSender, NewNetworkSender},
+    protocols::network::{
+        AppConfig, ApplicationNetworkSender, NetworkEvents, NetworkSender, NewNetworkSender,
+        RpcError,
+    },
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 /// Container for exchanging transactions with other Mempools.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -81,16 +86,22 @@ impl NewNetworkSender for MempoolNetworkSender {
     }
 }
 
-impl MempoolNetworkSender {
-    pub fn send_to(
-        &mut self,
-        recipient: PeerId,
-        message: MempoolSyncMsg,
-    ) -> Result<(), NetworkError> {
+#[async_trait]
+impl ApplicationNetworkSender<MempoolSyncMsg> for MempoolNetworkSender {
+    fn send_to(&mut self, recipient: PeerId, message: MempoolSyncMsg) -> Result<(), NetworkError> {
         fail_point!("mempool::send_to", |_| {
             Err(anyhow::anyhow!("Injected error in mempool::send_to").into())
         });
         let protocol = ProtocolId::MempoolDirectSend;
         self.inner.send_to(recipient, protocol, message)
+    }
+
+    async fn send_rpc(
+        &mut self,
+        _recipient: PeerId,
+        _req_msg: MempoolSyncMsg,
+        _timeout: Duration,
+    ) -> Result<MempoolSyncMsg, RpcError> {
+        unimplemented!()
     }
 }

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -3,12 +3,18 @@
 
 //! Interface between Mempool and Network layers.
 
-use crate::counters;
+use crate::{counters, shared_mempool::peer_manager::PeerSyncState};
 use async_trait::async_trait;
 use channel::{diem_channel, message_queues::QueueStyle};
+use diem_config::network_id::PeerNetworkId;
 use diem_types::{transaction::SignedTransaction, PeerId};
 use fail::fail_point;
 use network::{
+    application::{
+        interface::{MultiNetworkSender, NetworkInterface},
+        storage::{LockingHashMap, PeerMetadataStorage},
+        types::PeerError,
+    },
     error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
     protocols::network::{
@@ -18,7 +24,7 @@ use network::{
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
+use std::{collections::hash_map::Entry, sync::Arc, time::Duration};
 
 /// Container for exchanging transactions with other Mempools.
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -103,5 +109,48 @@ impl ApplicationNetworkSender<MempoolSyncMsg> for MempoolNetworkSender {
         _timeout: Duration,
     ) -> Result<MempoolSyncMsg, RpcError> {
         unimplemented!()
+    }
+}
+
+type MempoolMultiNetworkSender = MultiNetworkSender<MempoolSyncMsg, MempoolNetworkSender>;
+
+pub(crate) struct MempoolNetworkInterface {
+    peer_metadata_storage: Arc<PeerMetadataStorage>,
+    sender: MempoolMultiNetworkSender,
+    sync_states: LockingHashMap<PeerNetworkId, PeerSyncState>,
+}
+
+impl NetworkInterface<MempoolSyncMsg, MempoolMultiNetworkSender> for MempoolNetworkInterface {
+    type AppDataKey = PeerNetworkId;
+    type AppData = PeerSyncState;
+
+    fn peer_metadata_storage(&self) -> &PeerMetadataStorage {
+        &self.peer_metadata_storage
+    }
+
+    fn sender(&self) -> MempoolMultiNetworkSender {
+        self.sender.clone()
+    }
+
+    fn insert_app_data(&self, app_data_key: Self::AppDataKey, data: Self::AppData) {
+        self.sync_states.insert(app_data_key, data)
+    }
+
+    fn remove_app_data(&self, app_data_key: &Self::AppDataKey) {
+        self.sync_states.remove(app_data_key)
+    }
+
+    fn read_app_data(&self, app_data_key: &Self::AppDataKey) -> Option<Self::AppData> {
+        self.sync_states.read(app_data_key)
+    }
+
+    fn write_app_data<
+        F: FnOnce(&mut Entry<Self::AppDataKey, Self::AppData>) -> Result<(), PeerError>,
+    >(
+        &self,
+        app_data_key: Self::AppDataKey,
+        modifier: F,
+    ) -> Result<(), PeerError> {
+        self.sync_states.write(app_data_key, modifier)
     }
 }

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -19,7 +19,7 @@ use diem_logger::prelude::*;
 use diem_types::transaction::SignedTransaction;
 use itertools::Itertools;
 use netcore::transport::ConnectionOrigin;
-use network::transport::ConnectionMetadata;
+use network::{protocols::network::ApplicationNetworkSender, transport::ConnectionMetadata};
 use serde::{Deserialize, Serialize};
 use short_hex_str::AsShortHexStr;
 use std::{

--- a/mempool/src/shared_mempool/peer_manager.rs
+++ b/mempool/src/shared_mempool/peer_manager.rs
@@ -38,7 +38,7 @@ pub(crate) type PeerSyncStates = HashMap<PeerNetworkId, PeerSyncState>;
 /// State of last sync with peer:
 /// `timeline_id` is position in log of ready transactions
 /// `is_alive` - is connection healthy
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct PeerSyncState {
     pub timeline_id: u64,
     pub is_alive: bool,
@@ -83,7 +83,7 @@ impl Ord for BatchId {
 }
 
 /// Txn broadcast-related info for a given remote peer.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct BroadcastInfo {
     // Sent broadcasts that have not yet received an ack.
     pub sent_batches: BTreeMap<BatchId, SystemTime>,

--- a/mempool/src/shared_mempool/runtime.rs
+++ b/mempool/src/shared_mempool/runtime.rs
@@ -53,15 +53,15 @@ pub(crate) fn start_shared_mempool<V>(
         network_senders.insert(network_id, network_sender);
     }
 
-    let smp = SharedMempool {
-        mempool: mempool.clone(),
-        config: config.mempool.clone(),
+    let smp = SharedMempool::new(
+        mempool.clone(),
+        config.mempool.clone(),
         network_senders,
         db,
         validator,
         peer_manager,
         subscribers,
-    };
+    );
 
     executor.spawn(coordinator(
         smp,

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -25,6 +25,7 @@ use diem_types::{
     vm_status::DiscardedVMStatus,
 };
 use futures::{channel::oneshot, stream::FuturesUnordered};
+use network::protocols::network::ApplicationNetworkSender;
 use rayon::prelude::*;
 use short_hex_str::AsShortHexStr;
 use std::{

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -41,6 +41,28 @@ where
     pub subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
 }
 
+impl<V: TransactionValidation + 'static> SharedMempool<V> {
+    pub fn new(
+        mempool: Arc<Mutex<CoreMempool>>,
+        config: MempoolConfig,
+        network_senders: HashMap<NetworkId, MempoolNetworkSender>,
+        db: Arc<dyn DbReader<DpnProto>>,
+        validator: Arc<RwLock<V>>,
+        peer_manager: Arc<PeerManager>,
+        subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
+    ) -> Self {
+        SharedMempool {
+            mempool,
+            config,
+            network_senders,
+            db,
+            validator,
+            peer_manager,
+            subscribers,
+        }
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub enum SharedMempoolNotification {
     PeerStateChange,

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -4,6 +4,7 @@
 //! Objects used by/related to shared mempool
 use crate::{
     core_mempool::CoreMempool,
+    network::MempoolNetworkInterface,
     shared_mempool::{network::MempoolNetworkSender, peer_manager::PeerManager},
 };
 use anyhow::Result;
@@ -21,6 +22,7 @@ use futures::{
     future::Future,
     task::{Context, Poll},
 };
+use network::application::storage::PeerMetadataStorage;
 use std::{collections::HashMap, fmt, pin::Pin, sync::Arc, task::Waker, time::Instant};
 use storage_interface::DbReader;
 use tokio::runtime::Handle;
@@ -34,7 +36,7 @@ where
 {
     pub mempool: Arc<Mutex<CoreMempool>>,
     pub config: MempoolConfig,
-    pub network_senders: HashMap<NetworkId, MempoolNetworkSender>,
+    pub(crate) network_interface: MempoolNetworkInterface,
     pub db: Arc<dyn DbReader<DpnProto>>,
     pub validator: Arc<RwLock<V>>,
     pub peer_manager: Arc<PeerManager>,
@@ -51,15 +53,23 @@ impl<V: TransactionValidation + 'static> SharedMempool<V> {
         peer_manager: Arc<PeerManager>,
         subscribers: Vec<UnboundedSender<SharedMempoolNotification>>,
     ) -> Self {
+        let network_interface = MempoolNetworkInterface::new(
+            PeerMetadataStorage::new(&[NetworkId::Public, NetworkId::Validator, NetworkId::Vfn]),
+            network_senders,
+        );
         SharedMempool {
             mempool,
             config,
-            network_senders,
+            network_interface,
             db,
             validator,
             peer_manager,
             subscribers,
         }
+    }
+
+    pub fn network_interface(&self) -> &MempoolNetworkInterface {
+        &self.network_interface
     }
 }
 

--- a/mempool/src/tests/fuzzing.rs
+++ b/mempool/src/tests/fuzzing.rs
@@ -35,15 +35,15 @@ pub fn test_mempool_process_incoming_transactions_impl(
     let config = NodeConfig::default();
     let mock_db = MockDbReaderWriter;
     let vm_validator = Arc::new(RwLock::new(MockVMValidator));
-    let smp = SharedMempool {
-        mempool: Arc::new(Mutex::new(CoreMempool::new(&config))),
-        config: config.mempool.clone(),
-        network_senders: HashMap::new(),
-        db: Arc::new(mock_db),
-        validator: vm_validator,
-        peer_manager: Arc::new(PeerManager::new(config.base.role, config.mempool)),
-        subscribers: vec![],
-    };
+    let smp = SharedMempool::new(
+        Arc::new(Mutex::new(CoreMempool::new(&config))),
+        config.mempool.clone(),
+        HashMap::new(),
+        Arc::new(mock_db),
+        vm_validator,
+        Arc::new(PeerManager::new(config.base.role, config.mempool)),
+        vec![],
+    );
 
     let _ = tasks::process_incoming_transactions(&smp, txns, timeline_state);
 }

--- a/network/benches/network_bench.rs
+++ b/network/benches/network_bench.rs
@@ -22,7 +22,10 @@ use futures::{
     sink::SinkExt,
     stream::{FuturesUnordered, StreamExt},
 };
-use network::protocols::{network::Event, rpc::error::RpcError};
+use network::protocols::{
+    network::{ApplicationNetworkSender, Event},
+    rpc::error::RpcError,
+};
 use network_builder::dummy::{setup_network, DummyMsg, DummyNetworkSender};
 use std::time::Duration;
 

--- a/network/builder/Cargo.toml
+++ b/network/builder/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1.42"
 futures = "0.3.12"
 rand = "0.8.3"
 serde = { version = "1.0.124", default-features = false }

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -4,6 +4,7 @@
 //! Integration tests for validator_network.
 
 use crate::builder::NetworkBuilder;
+use async_trait::async_trait;
 use channel::diem_channel;
 use diem_config::{
     config::{Peer, PeerRole, PeerSet, RoleType, NETWORK_CHANNEL_SIZE},
@@ -22,7 +23,10 @@ use network::{
         builder::AuthenticationMode, ConnectionRequestSender, PeerManagerRequestSender,
     },
     protocols::{
-        network::{AppConfig, Event, NetworkEvents, NetworkSender, NewNetworkSender},
+        network::{
+            AppConfig, ApplicationNetworkSender, Event, NetworkEvents, NetworkSender,
+            NewNetworkSender,
+        },
         rpc::error::RpcError,
     },
     ProtocolId,
@@ -69,13 +73,14 @@ impl NewNetworkSender for DummyNetworkSender {
     }
 }
 
-impl DummyNetworkSender {
-    pub fn send_to(&mut self, recipient: PeerId, message: DummyMsg) -> Result<(), NetworkError> {
+#[async_trait]
+impl ApplicationNetworkSender<DummyMsg> for DummyNetworkSender {
+    fn send_to(&mut self, recipient: PeerId, message: DummyMsg) -> Result<(), NetworkError> {
         let protocol = TEST_DIRECT_SEND_PROTOCOL;
         self.inner.send_to(recipient, protocol, message)
     }
 
-    pub async fn send_rpc(
+    async fn send_rpc(
         &mut self,
         recipient: PeerId,
         message: DummyMsg,

--- a/network/builder/src/test.rs
+++ b/network/builder/src/test.rs
@@ -4,7 +4,7 @@
 //! Integration tests for validator_network.
 use crate::dummy::{setup_network, DummyMsg};
 use futures::{future::join, StreamExt};
-use network::protocols::network::Event;
+use network::protocols::network::{ApplicationNetworkSender, Event};
 use std::time::Duration;
 
 #[test]

--- a/network/src/application/interface.rs
+++ b/network/src/application/interface.rs
@@ -7,8 +7,7 @@ use crate::{
         types::{PeerError, PeerInfo, PeerState},
     },
     error::NetworkError,
-    protocols::network::{Message, NetworkSender, RpcError},
-    ProtocolId,
+    protocols::network::{ApplicationNetworkSender, Message, RpcError},
 };
 use async_trait::async_trait;
 use diem_config::network_id::{NetworkId, PeerNetworkId};
@@ -16,6 +15,7 @@ use diem_types::PeerId;
 use itertools::Itertools;
 use std::{
     collections::{hash_map::Entry, HashMap},
+    marker::PhantomData,
     time::Duration,
 };
 
@@ -79,59 +79,39 @@ pub trait NetworkInterface {
     ) -> Result<(), PeerError>;
 }
 
-#[async_trait]
-trait PeerNetworkIdSender<TMessage: Message> {
-    fn send_to(
-        &mut self,
-        recipient: PeerNetworkId,
-        protocol: ProtocolId,
-        message: TMessage,
-    ) -> Result<(), NetworkError>;
-
-    fn send_to_many(
-        &mut self,
-        recipients: impl Iterator<Item = PeerNetworkId>,
-        protocol: ProtocolId,
-        message: TMessage,
-    ) -> Result<(), NetworkError>;
-
-    async fn send_rpc(
-        &mut self,
-        recipient: PeerNetworkId,
-        protocol: ProtocolId,
-        req_msg: TMessage,
-        timeout: Duration,
-    ) -> Result<TMessage, RpcError>;
+/// A sender that combines multiple `ApplicationNetworkSender` to send across multiple networks
+/// Therefore, sending messages to multiple networks can be routed by just `PeerNetworkId` without
+/// having to do lookups for `NetworkId` related senders.  Additionally, will give some checking
+/// around attempting to send messages to networks that don't exist.
+#[derive(Clone)]
+struct MultiNetworkSender<
+    TMessage: Message + Send,
+    Sender: ApplicationNetworkSender<TMessage> + Send,
+> {
+    senders: HashMap<NetworkId, Sender>,
+    _phantom: PhantomData<TMessage>,
 }
 
-struct MultiNetworkSender<TMessage: Message> {
-    senders: HashMap<NetworkId, NetworkSender<TMessage>>,
-}
-
-impl<TMessage: Message> MultiNetworkSender<TMessage> {
-    fn sender(&mut self, network_id: &NetworkId) -> &mut NetworkSender<TMessage> {
+impl<TMessage: Message + Send, Sender: ApplicationNetworkSender<TMessage> + Send>
+    MultiNetworkSender<TMessage, Sender>
+{
+    fn sender(&mut self, network_id: &NetworkId) -> &mut Sender {
         self.senders.get_mut(network_id).expect("Unknown NetworkId")
     }
 }
 
 #[async_trait]
-impl<TMessage: Clone + Message + Send> PeerNetworkIdSender<TMessage>
-    for MultiNetworkSender<TMessage>
+impl<TMessage: Clone + Message + Send, Sender: ApplicationNetworkSender<TMessage> + Send>
+    ApplicationPeerNetworkIdSender<TMessage> for MultiNetworkSender<TMessage, Sender>
 {
-    fn send_to(
-        &mut self,
-        recipient: PeerNetworkId,
-        protocol: ProtocolId,
-        message: TMessage,
-    ) -> Result<(), NetworkError> {
+    fn send_to(&mut self, recipient: PeerNetworkId, message: TMessage) -> Result<(), NetworkError> {
         self.sender(&recipient.network_id())
-            .send_to(recipient.peer_id(), protocol, message)
+            .send_to(recipient.peer_id(), message)
     }
 
     fn send_to_many(
         &mut self,
         recipients: impl Iterator<Item = PeerNetworkId>,
-        protocol: ProtocolId,
         message: TMessage,
     ) -> Result<(), NetworkError> {
         for (network_id, recipients) in
@@ -139,7 +119,7 @@ impl<TMessage: Clone + Message + Send> PeerNetworkIdSender<TMessage>
         {
             let sender = self.sender(&network_id);
             let peer_ids = recipients.map(|peer_network_id| peer_network_id.peer_id());
-            sender.send_to_many(peer_ids, protocol, message.clone())?;
+            sender.send_to_many(peer_ids, message.clone())?;
         }
         Ok(())
     }
@@ -147,12 +127,33 @@ impl<TMessage: Clone + Message + Send> PeerNetworkIdSender<TMessage>
     async fn send_rpc(
         &mut self,
         recipient: PeerNetworkId,
-        protocol: ProtocolId,
         req_msg: TMessage,
         timeout: Duration,
     ) -> Result<TMessage, RpcError> {
         self.sender(&recipient.network_id())
-            .send_rpc(recipient.peer_id(), protocol, req_msg, timeout)
+            .send_rpc(recipient.peer_id(), req_msg, timeout)
             .await
     }
+}
+
+/// A trait for sending messages using `PeerNetworkId` rather than `NetworkId`.  At the networking
+/// level, it only knows about a single `NetworkId`.  But, the applications know about multiple
+/// networks, and communicate with `PeerNetworkId` as the uniqueness constraint.  This lets them
+/// use that uniqueness constraint and we can hide the details from the applications.
+#[async_trait]
+trait ApplicationPeerNetworkIdSender<TMessage: Send>: Clone {
+    fn send_to(&mut self, recipient: PeerNetworkId, message: TMessage) -> Result<(), NetworkError>;
+
+    fn send_to_many(
+        &mut self,
+        recipients: impl Iterator<Item = PeerNetworkId>,
+        message: TMessage,
+    ) -> Result<(), NetworkError>;
+
+    async fn send_rpc(
+        &mut self,
+        recipient: PeerNetworkId,
+        req_msg: TMessage,
+        timeout: Duration,
+    ) -> Result<TMessage, RpcError>;
 }

--- a/network/src/application/interface.rs
+++ b/network/src/application/interface.rs
@@ -85,13 +85,24 @@ pub trait NetworkInterface<
 /// Therefore, sending messages to multiple networks can be routed by just `PeerNetworkId` without
 /// having to do lookups for `NetworkId` related senders.  Additionally, will give some checking
 /// around attempting to send messages to networks that don't exist.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MultiNetworkSender<
     TMessage: Message + Send,
     Sender: ApplicationNetworkSender<TMessage> + Send,
 > {
     senders: HashMap<NetworkId, Sender>,
     _phantom: PhantomData<TMessage>,
+}
+
+impl<TMessage: Message + Send, Sender: ApplicationNetworkSender<TMessage> + Send>
+    MultiNetworkSender<TMessage, Sender>
+{
+    pub fn new(senders: HashMap<NetworkId, Sender>) -> Self {
+        MultiNetworkSender {
+            senders,
+            _phantom: Default::default(),
+        }
+    }
 }
 
 impl<TMessage: Clone + Message + Send, Sender: ApplicationNetworkSender<TMessage> + Send>

--- a/network/src/application/storage.rs
+++ b/network/src/application/storage.rs
@@ -17,6 +17,7 @@ use std::{
 
 /// Metadata storage for peers across all of networking.  Splits storage of information across
 /// networks to prevent different networks from affecting each other
+#[derive(Debug)]
 pub struct PeerMetadataStorage {
     storage: HashMap<NetworkId, LockingHashMap<PeerId, PeerInfo>>,
 }
@@ -146,6 +147,7 @@ fn to_peer_network_ids(
 }
 
 /// A generic locking hash map with ability to read before write consistency
+#[derive(Debug)]
 pub struct LockingHashMap<Key: Clone + Debug + Eq + Hash, Value: Clone + Debug> {
     map: RwLock<HashMap<Key, Value>>,
 }

--- a/network/src/peer_manager/senders.rs
+++ b/network/src/peer_manager/senders.rs
@@ -18,14 +18,14 @@ use crate::peer_manager::{types::PeerManagerRequest, ConnectionRequest, PeerMana
 
 /// Convenience wrapper which makes it easy to issue communication requests and await the responses
 /// from PeerManager.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PeerManagerRequestSender {
     inner: diem_channel::Sender<(PeerId, ProtocolId), PeerManagerRequest>,
 }
 
 /// Convenience wrapper which makes it easy to issue connection requests and await the responses
 /// from PeerManager.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ConnectionRequestSender {
     inner: diem_channel::Sender<PeerId, ConnectionRequest>,
 }

--- a/network/src/protocols/health_checker/interface.rs
+++ b/network/src/protocols/health_checker/interface.rs
@@ -98,8 +98,9 @@ impl HealthCheckNetworkInterface {
 }
 
 #[async_trait]
-impl NetworkInterface for HealthCheckNetworkInterface {
-    type Sender = HealthCheckerNetworkSender;
+impl NetworkInterface<HealthCheckerMsg, HealthCheckerNetworkSender>
+    for HealthCheckNetworkInterface
+{
     type AppDataKey = PeerId;
     type AppData = HealthCheckData;
 
@@ -107,7 +108,7 @@ impl NetworkInterface for HealthCheckNetworkInterface {
         &self.peer_metadata_storage
     }
 
-    fn sender(&self) -> Self::Sender {
+    fn sender(&self) -> HealthCheckerNetworkSender {
         self.sender.clone()
     }
 

--- a/network/src/protocols/health_checker/mod.rs
+++ b/network/src/protocols/health_checker/mod.rs
@@ -76,6 +76,37 @@ pub struct HealthCheckerNetworkSender {
     inner: NetworkSender<HealthCheckerMsg>,
 }
 
+#[async_trait]
+impl crate::application::interface::ApplicationPeerNetworkIdSender<HealthCheckerMsg>
+    for HealthCheckerNetworkSender
+{
+    fn send_to(
+        &mut self,
+        recipient: PeerNetworkId,
+        message: HealthCheckerMsg,
+    ) -> Result<(), NetworkError> {
+        ApplicationNetworkSender::send_to(self, recipient.peer_id(), message)
+    }
+
+    fn send_to_many(
+        &mut self,
+        recipients: impl Iterator<Item = PeerNetworkId>,
+        message: HealthCheckerMsg,
+    ) -> Result<(), NetworkError> {
+        let recipients = recipients.map(|peer_network_id| peer_network_id.peer_id());
+        ApplicationNetworkSender::send_to_many(self, recipients, message)
+    }
+
+    async fn send_rpc(
+        &mut self,
+        recipient: PeerNetworkId,
+        req_msg: HealthCheckerMsg,
+        timeout: Duration,
+    ) -> Result<HealthCheckerMsg, RpcError> {
+        ApplicationNetworkSender::send_rpc(self, recipient.peer_id(), req_msg, timeout).await
+    }
+}
+
 /// Configuration for the network endpoints to support HealthChecker.
 pub fn network_endpoint_config() -> AppConfig {
     AppConfig::p2p(
@@ -122,7 +153,6 @@ impl ApplicationNetworkSender<HealthCheckerMsg> for HealthCheckerNetworkSender {
             .await
     }
 }
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum HealthCheckerMsg {
     Ping(Ping),

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     transport::ConnectionMetadata,
     ProtocolId,
 };
+use async_trait::async_trait;
 use bytes::Bytes;
 use channel::diem_channel;
 use diem_logger::prelude::*;
@@ -348,4 +349,24 @@ impl<TMessage: Message> NetworkSender<TMessage> {
         let res_msg: TMessage = protocol.from_bytes(&res_data)?;
         Ok(res_msg)
     }
+}
+
+/// A simplified version of `NetworkSender` that doesn't use `ProtocolId` in the input
+/// It was already being implemented for every application, but is now standardized
+#[async_trait]
+pub trait ApplicationNetworkSender<TMessage: Send>: Clone {
+    fn send_to(&mut self, recipient: PeerId, message: TMessage) -> Result<(), NetworkError>;
+
+    fn send_to_many(
+        &mut self,
+        recipients: impl Iterator<Item = PeerId>,
+        message: TMessage,
+    ) -> Result<(), NetworkError>;
+
+    async fn send_rpc(
+        &mut self,
+        recipient: PeerId,
+        req_msg: TMessage,
+        timeout: Duration,
+    ) -> Result<TMessage, RpcError>;
 }

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -253,7 +253,7 @@ impl<TMessage> FusedStream for NetworkEvents<TMessage> {
 /// `MempoolNetworkSender` only exposes a `send_to` function.
 ///
 /// Provide Protobuf wrapper over `[peer_manager::PeerManagerRequestSender]`
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct NetworkSender<TMessage> {
     peer_mgr_reqs_tx: PeerManagerRequestSender,
     connection_reqs_tx: ConnectionRequestSender,

--- a/network/src/protocols/network/mod.rs
+++ b/network/src/protocols/network/mod.rs
@@ -355,13 +355,17 @@ impl<TMessage: Message> NetworkSender<TMessage> {
 /// It was already being implemented for every application, but is now standardized
 #[async_trait]
 pub trait ApplicationNetworkSender<TMessage: Send>: Clone {
-    fn send_to(&mut self, recipient: PeerId, message: TMessage) -> Result<(), NetworkError>;
+    fn send_to(&mut self, _recipient: PeerId, _message: TMessage) -> Result<(), NetworkError> {
+        unimplemented!()
+    }
 
     fn send_to_many(
         &mut self,
-        recipients: impl Iterator<Item = PeerId>,
-        message: TMessage,
-    ) -> Result<(), NetworkError>;
+        _recipients: impl Iterator<Item = PeerId>,
+        _message: TMessage,
+    ) -> Result<(), NetworkError> {
+        unimplemented!()
+    }
 
     async fn send_rpc(
         &mut self,

--- a/state-sync/state-sync-v1/Cargo.toml
+++ b/state-sync/state-sync-v1/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.42"
 bcs = "0.1.2"
 fail = "0.4.0"
 futures = "0.3.12"

--- a/state-sync/state-sync-v1/src/network.rs
+++ b/state-sync/state-sync-v1/src/network.rs
@@ -3,17 +3,21 @@
 
 //! Interface between State Sync and Network layers.
 
-use crate::{
-    chunk_request::GetChunkRequest, chunk_response::GetChunkResponse, counters, error::Error,
-};
+use crate::{chunk_request::GetChunkRequest, chunk_response::GetChunkResponse, counters};
+use async_trait::async_trait;
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_types::PeerId;
 use network::{
+    error::NetworkError,
     peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
-    protocols::network::{AppConfig, NetworkEvents, NetworkSender, NewNetworkSender},
+    protocols::network::{
+        AppConfig, ApplicationNetworkSender, NetworkEvents, NetworkSender, NewNetworkSender,
+        RpcError,
+    },
     ProtocolId,
 };
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 const STATE_SYNC_MAX_BUFFER_SIZE: usize = 1;
 
@@ -56,10 +60,24 @@ impl NewNetworkSender for StateSyncSender {
     }
 }
 
-impl StateSyncSender {
-    pub fn send_to(&mut self, recipient: PeerId, message: StateSyncMessage) -> Result<(), Error> {
+#[async_trait]
+impl ApplicationNetworkSender<StateSyncMessage> for StateSyncSender {
+    fn send_to(
+        &mut self,
+        recipient: PeerId,
+        message: StateSyncMessage,
+    ) -> Result<(), NetworkError> {
         let protocol = ProtocolId::StateSyncDirectSend;
-        Ok(self.inner.send_to(recipient, protocol, message)?)
+        self.inner.send_to(recipient, protocol, message)
+    }
+
+    async fn send_rpc(
+        &mut self,
+        _recipient: PeerId,
+        _req_msg: StateSyncMessage,
+        _timeout: Duration,
+    ) -> Result<StateSyncMessage, RpcError> {
+        unimplemented!()
     }
 }
 

--- a/testsuite/cluster-test/src/experiments/load_test.rs
+++ b/testsuite/cluster-test/src/experiments/load_test.rs
@@ -18,8 +18,10 @@ use diem_time_service::TimeService;
 use diem_types::{account_config::diem_root_address, chain_id::ChainId};
 use futures::{sink::SinkExt, StreamExt};
 use network::{
-    application::storage::PeerMetadataStorage, connectivity_manager::DiscoverySource,
-    protocols::network::Event, ConnectivityRequest,
+    application::storage::PeerMetadataStorage,
+    connectivity_manager::DiscoverySource,
+    protocols::network::{ApplicationNetworkSender, Event},
+    ConnectivityRequest,
 };
 use network_builder::builder::NetworkBuilder;
 use state_sync_v1::network::{StateSyncEvents, StateSyncSender};


### PR DESCRIPTION
## Motivation

Step 1 of refactoring mempool to use network interface.  This has it use the network interface as a replacement for Network senders.  Step 2 will be to use the network interface as a data store for logic around PeerSyncStates.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Current tests