### PR TITLE
[State Sync] Added "include_events" flag to transaction proof requests.

### DIFF
--- a/state-sync/diem-data-client/src/lib.rs
+++ b/state-sync/diem-data-client/src/lib.rs
@@ -80,13 +80,15 @@ pub trait DiemDataClient {
 
     /// Returns a transaction list with proof object, with transactions from
     /// start to end versions (inclusive). The proof is relative to the specified
-    /// `proof_version`. If the data cannot be fetched (e.g., the number of
-    /// transactions is too large), an error is returned.
+    /// `proof_version`. If `include_events` is true, events are included in the
+    /// proof. If the data cannot be fetched (e.g., the number of transactions is
+    /// too large), an error is returned.
     async fn get_transactions_with_proof(
         &self,
         proof_version: u64,
         start_version: u64,
         end_version: u64,
+        include_events: bool,
     ) -> Result<DataClientResponse, Error>;
 
     /// Notifies the Diem Data Client about a previously received response that


### PR DESCRIPTION
## Motivation

This (tiny) PR adds an "include_events" boolean to the `get_transactions_with_proof()` API request of the Diem Data Client. This argument was previously missed. Note that the storage service correctly [includes](https://github.com/diem/diem/blob/690a060ede4f42d84150c808608085810e5e3bb6/state-sync/storage-service/server/src/lib.rs#L204) this argument.

For reader context, the reason we may not wish to include events in the transaction list with proof is in the case that we're also download transaction output lists with proofs (which will always include events). Hence, if we're downloading both data types, it becomes unnecessary to duplicate the events returned in the API calls.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

This is only the interface. No tests required.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906