### PR TITLE
[State Sync] Add a new Data Streaming Service crate and a client implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "channel",
+ "claim",
  "diem-types",
  "diem-workspace-hack",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-streaming-service"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "channel",
+ "diem-types",
+ "diem-workspace-hack",
+ "futures",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "datatest-stable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ members = [
     "state-sync/inter-component/mempool-notifications",
     "state-sync/state-sync-v1",
     "state-sync/state-sync-v2",
+    "state-sync/state-sync-v2/data-streaming-service",
     "state-sync/storage-service/server",
     "state-sync/storage-service/types",
     "storage/accumulator",

--- a/state-sync/state-sync-v2/data-streaming-service/Cargo.toml
+++ b/state-sync/state-sync-v2/data-streaming-service/Cargo.toml
@@ -20,3 +20,4 @@ diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [dev-dependencies]
+claim = "0.5.0"

--- a/state-sync/state-sync-v2/data-streaming-service/Cargo.toml
+++ b/state-sync/state-sync-v2/data-streaming-service/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "data-streaming-service"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+repository = "https://github.com/diem/diem"
+description = "The data streaming service that sends data notifications to clients"
+homepage = "https://diem.com"
+license = "Apache-2.0"
+publish = false
+edition = "2018"
+
+[dependencies]
+async-trait = "0.1.42"
+futures = "0.3.12"
+serde = { version = "1.0.124", default-features = false }
+thiserror = "1.0.24"
+
+channel = { path = "../../../common/channel" }
+diem-types = { path = "../../../types" }
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+
+[dev-dependencies]

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
@@ -1,0 +1,52 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::{stream::FusedStream, Stream};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// A unique ID used to identify each notification.
+pub type NotificationId = u64;
+
+/// A single data notification.
+/// TODO(joshlind): complete me!
+#[derive(Debug)]
+pub struct DataNotification {
+    pub notification_id: NotificationId,
+}
+
+/// Allows listening to data streams (i.e., streams of data notifications).
+///
+/// Note: when the data stream is finished (i.e., empty) a data notification
+/// containing an `EndOfDataStream` payload is sent to the listener.
+#[derive(Debug)]
+pub struct DataStreamListener {
+    notification_receiver: channel::diem_channel::Receiver<(), DataNotification>,
+}
+
+impl DataStreamListener {
+    #[allow(dead_code)]
+    pub fn new(
+        notification_receiver: channel::diem_channel::Receiver<(), DataNotification>,
+    ) -> Self {
+        Self {
+            notification_receiver,
+        }
+    }
+}
+
+impl Stream for DataStreamListener {
+    type Item = DataNotification;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.get_mut().notification_receiver).poll_next(cx)
+    }
+}
+
+impl FusedStream for DataStreamListener {
+    fn is_terminated(&self) -> bool {
+        self.notification_receiver.is_terminated()
+    }
+}

--- a/state-sync/state-sync-v2/data-streaming-service/src/error.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/error.rs
@@ -1,0 +1,26 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use futures::channel::{mpsc::SendError, oneshot::Canceled};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Clone, Debug, Deserialize, Error, PartialEq, Serialize)]
+pub enum Error {
+    #[error("The requested data is unavailable and cannot be found in the network! Error: {0}")]
+    DataIsUnavailable(String),
+    #[error("Unexpected error encountered: {0}")]
+    UnexpectedErrorEncountered(String),
+}
+
+impl From<SendError> for Error {
+    fn from(error: SendError) -> Self {
+        Error::UnexpectedErrorEncountered(error.to_string())
+    }
+}
+
+impl From<Canceled> for Error {
+    fn from(canceled: Canceled) -> Self {
+        Error::UnexpectedErrorEncountered(canceled.to_string())
+    }
+}

--- a/state-sync/state-sync-v2/data-streaming-service/src/lib.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/lib.rs
@@ -6,3 +6,6 @@
 mod data_stream;
 mod error;
 mod streaming_client;
+
+#[cfg(test)]
+mod streaming_client_tests;

--- a/state-sync/state-sync-v2/data-streaming-service/src/lib.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/lib.rs
@@ -1,0 +1,8 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#![forbid(unsafe_code)]
+
+mod data_stream;
+mod error;
+mod streaming_client;

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_client.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_client.rs
@@ -1,0 +1,341 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    data_stream::{DataStreamListener, NotificationId},
+    error::Error,
+};
+use async_trait::async_trait;
+use diem_types::transaction::Version;
+use futures::{
+    channel::{mpsc, oneshot},
+    stream::FusedStream,
+    SinkExt, Stream,
+};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub type Epoch = u64;
+
+/// The streaming client used by state sync to fetch data from the Diem network
+/// to synchronize local state.
+///
+/// Note: the streaming service streams data sequentially, so clients (e.g.,
+/// state sync) can process data notifications in the order they're received.
+/// For example, if we're streaming transactions with proofs, state sync can
+/// assume the transactions are returned in monotonically increasing versions.
+#[async_trait]
+pub trait DataStreamingClient {
+    /// Fetches all account states at the specified version. The specified
+    /// version must be an epoch ending version, otherwise an error will be
+    /// returned. Account state proofs are at the same specified version.
+    async fn get_all_accounts(&self, version: Version) -> Result<DataStreamListener, Error>;
+
+    /// Fetches all epoch ending ledger infos starting at `start_epoch`
+    /// (inclusive) and ending at the last known epoch advertised in the network.
+    async fn get_all_epoch_ending_ledger_infos(
+        &self,
+        start_epoch: Epoch,
+    ) -> Result<DataStreamListener, Error>;
+
+    /// Fetches all transactions with proofs from `start_version` to
+    /// `end_version` (inclusive), where the proof versions can be up to the
+    /// specified `max_proof_version` (inclusive). If `include_events` is true,
+    /// events are also included in the proofs.
+    async fn get_all_transactions(
+        &self,
+        start_version: Version,
+        end_version: Version,
+        max_proof_version: Version,
+        include_events: bool,
+    ) -> Result<DataStreamListener, Error>;
+
+    /// Fetches all transaction outputs with proofs from `start_version` to
+    /// `end_version` (inclusive), where the proof versions can be up to the
+    /// specified `max_proof_version` (inclusive).
+    async fn get_all_transaction_outputs(
+        &self,
+        start_version: Version,
+        end_version: Version,
+        max_proof_version: Version,
+    ) -> Result<DataStreamListener, Error>;
+
+    /// Refetches the payload for the data notification corresponding to the
+    /// specified `notification_id`.
+    ///
+    /// Note: this is required because data payloads may be invalid, e.g., due
+    /// to invalid or malformed data returned by a misbehaving peer or a failure
+    /// to verify a proof. The refetch request forces a refetch of the payload
+    /// and the `refetch_reason` notifies the streaming service as to why the
+    /// payload must be refetched.
+    async fn refetch_notification_payload(
+        &self,
+        notification_id: NotificationId,
+        refetch_reason: PayloadRefetchReason,
+    ) -> Result<DataStreamListener, Error>;
+
+    /// Continuously streams transactions with proofs as the blockchain grows.
+    /// The stream starts at `start_version` and `start_epoch` (inclusive).
+    /// Transaction proof versions are tied to ledger infos within the same
+    /// epoch, otherwise epoch ending ledger infos will signify epoch changes.
+    /// If `include_events` is true, events are also included in the proofs.
+    async fn continuously_stream_transactions(
+        &self,
+        start_version: Version,
+        start_epoch: Epoch,
+        include_events: bool,
+    ) -> Result<DataStreamListener, Error>;
+
+    /// Continuously streams transaction outputs with proofs as the blockchain
+    /// grows. The stream starts at `start_version` and `start_epoch` (inclusive).
+    /// Transaction output proof versions are tied to ledger infos within the
+    /// same epoch, otherwise epoch ending ledger infos will signify epoch changes.
+    async fn continuously_stream_transaction_outputs(
+        &self,
+        start_version: Version,
+        start_epoch: Epoch,
+    ) -> Result<DataStreamListener, Error>;
+}
+
+/// Messages used by the data streaming client for communication with the
+/// streaming service. The streaming service will respond to the client request
+/// through the given `response_sender`.
+#[derive(Debug)]
+pub struct StreamRequestMessage {
+    pub stream_request: StreamRequest,
+    pub response_sender: oneshot::Sender<Result<DataStreamListener, Error>>,
+}
+
+/// The data streaming request from the client.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StreamRequest {
+    GetAllAccounts(GetAllAccountsRequest),
+    GetAllEpochEndingLedgerInfos(GetAllEpochEndingLedgerInfosRequest),
+    GetAllTransactions(GetAllTransactionsRequest),
+    GetAllTransactionOutputs(GetAllTransactionOutputsRequest),
+    ContinuouslyStreamTransactions(ContinuouslyStreamTransactionsRequest),
+    ContinuouslyStreamTransactionOutputs(ContinuouslyStreamTransactionOutputsRequest),
+    RefetchNotificationPayload(RefetchNotificationPayloadRequest),
+}
+
+/// A client request for fetching all account states at a specified version.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetAllAccountsRequest {
+    pub version: Version,
+}
+
+/// A client request for fetching all available epoch ending ledger infos.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetAllEpochEndingLedgerInfosRequest {
+    pub start_epoch: Epoch,
+}
+
+/// A client request for fetching all transactions with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetAllTransactionsRequest {
+    pub start_version: Version,
+    pub end_version: Version,
+    pub max_proof_version: Version,
+    pub include_events: bool,
+}
+
+/// A client request for fetching all transaction outputs with proofs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetAllTransactionOutputsRequest {
+    pub start_version: Version,
+    pub end_version: Version,
+    pub max_proof_version: Version,
+}
+
+/// A client request for continuously streaming transactions with proofs (with no end).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContinuouslyStreamTransactionsRequest {
+    pub start_version: Version,
+    pub start_epoch: Epoch,
+    pub include_events: bool,
+}
+
+/// A client request for continuously streaming transaction outputs with proofs (with no end).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContinuouslyStreamTransactionOutputsRequest {
+    pub start_version: Version,
+    pub start_epoch: Epoch,
+}
+
+/// A client request for refetching a notification payload.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RefetchNotificationPayloadRequest {
+    pub notification_id: NotificationId,
+    pub refetch_reason: PayloadRefetchReason,
+}
+
+/// The reason for having to refetch a data payload in a data notification.
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub enum PayloadRefetchReason {
+    InvalidPayloadData,
+    PayloadTypeIsIncorrect,
+    ProofVerificationFailed,
+}
+
+/// The streaming service client that talks to the streaming service.
+pub struct StreamingServiceClient {
+    request_sender: mpsc::UnboundedSender<StreamRequestMessage>,
+}
+
+impl StreamingServiceClient {
+    #[allow(dead_code)]
+    pub fn new(request_sender: mpsc::UnboundedSender<StreamRequestMessage>) -> Self {
+        Self { request_sender }
+    }
+
+    async fn send_stream_request(
+        &self,
+        client_request: StreamRequest,
+    ) -> Result<DataStreamListener, Error> {
+        let mut request_sender = self.request_sender.clone();
+        let (response_sender, response_receiver) = oneshot::channel();
+        let request_message = StreamRequestMessage {
+            stream_request: client_request,
+            response_sender,
+        };
+
+        request_sender.send(request_message).await?;
+        response_receiver.await?
+    }
+}
+
+#[async_trait]
+impl DataStreamingClient for StreamingServiceClient {
+    async fn get_all_accounts(&self, version: u64) -> Result<DataStreamListener, Error> {
+        let client_request = StreamRequest::GetAllAccounts(GetAllAccountsRequest { version });
+        self.send_stream_request(client_request).await
+    }
+
+    async fn get_all_epoch_ending_ledger_infos(
+        &self,
+        start_epoch: u64,
+    ) -> Result<DataStreamListener, Error> {
+        let client_request =
+            StreamRequest::GetAllEpochEndingLedgerInfos(GetAllEpochEndingLedgerInfosRequest {
+                start_epoch,
+            });
+        self.send_stream_request(client_request).await
+    }
+
+    async fn get_all_transactions(
+        &self,
+        start_version: u64,
+        end_version: u64,
+        max_proof_version: u64,
+        include_events: bool,
+    ) -> Result<DataStreamListener, Error> {
+        let client_request = StreamRequest::GetAllTransactions(GetAllTransactionsRequest {
+            start_version,
+            end_version,
+            max_proof_version,
+            include_events,
+        });
+        self.send_stream_request(client_request).await
+    }
+
+    async fn get_all_transaction_outputs(
+        &self,
+        start_version: u64,
+        end_version: u64,
+        max_proof_version: u64,
+    ) -> Result<DataStreamListener, Error> {
+        let client_request =
+            StreamRequest::GetAllTransactionOutputs(GetAllTransactionOutputsRequest {
+                start_version,
+                end_version,
+                max_proof_version,
+            });
+        self.send_stream_request(client_request).await
+    }
+
+    async fn refetch_notification_payload(
+        &self,
+        notification_id: u64,
+        refetch_reason: PayloadRefetchReason,
+    ) -> Result<DataStreamListener, Error> {
+        let client_request =
+            StreamRequest::RefetchNotificationPayload(RefetchNotificationPayloadRequest {
+                notification_id,
+                refetch_reason,
+            });
+        self.send_stream_request(client_request).await
+    }
+
+    async fn continuously_stream_transactions(
+        &self,
+        start_version: u64,
+        start_epoch: u64,
+        include_events: bool,
+    ) -> Result<DataStreamListener, Error> {
+        let client_request =
+            StreamRequest::ContinuouslyStreamTransactions(ContinuouslyStreamTransactionsRequest {
+                start_version,
+                start_epoch,
+                include_events,
+            });
+        self.send_stream_request(client_request).await
+    }
+
+    async fn continuously_stream_transaction_outputs(
+        &self,
+        start_version: u64,
+        start_epoch: u64,
+    ) -> Result<DataStreamListener, Error> {
+        let client_request = StreamRequest::ContinuouslyStreamTransactionOutputs(
+            ContinuouslyStreamTransactionOutputsRequest {
+                start_version,
+                start_epoch,
+            },
+        );
+        self.send_stream_request(client_request).await
+    }
+}
+
+/// The component that enables listening to requests from streaming service
+/// clients (e.g., state sync).
+#[derive(Debug)]
+pub struct StreamingServiceListener {
+    request_receiver: mpsc::UnboundedReceiver<StreamRequestMessage>,
+}
+
+impl StreamingServiceListener {
+    #[allow(dead_code)]
+    pub fn new(request_receiver: mpsc::UnboundedReceiver<StreamRequestMessage>) -> Self {
+        Self { request_receiver }
+    }
+}
+
+impl Stream for StreamingServiceListener {
+    type Item = StreamRequestMessage;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.get_mut().request_receiver).poll_next(cx)
+    }
+}
+
+impl FusedStream for StreamingServiceListener {
+    fn is_terminated(&self) -> bool {
+        self.request_receiver.is_terminated()
+    }
+}
+
+/// This method returns a (StreamingServiceClient, StreamingServiceListener) pair that can be used
+/// to allow clients to make requests to the streaming service.
+#[allow(dead_code)]
+pub fn new_streaming_service_client_listener_pair(
+) -> (StreamingServiceClient, StreamingServiceListener) {
+    let (request_sender, request_listener) = mpsc::unbounded();
+
+    let streaming_service_client = StreamingServiceClient::new(request_sender);
+    let streaming_service_listener = StreamingServiceListener::new(request_listener);
+
+    (streaming_service_client, streaming_service_listener)
+}

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_client_tests.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_client_tests.rs
@@ -1,0 +1,278 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    data_stream::{DataNotification, DataStreamListener},
+    error::Error,
+    streaming_client::{
+        new_streaming_service_client_listener_pair, ContinuouslyStreamTransactionOutputsRequest,
+        ContinuouslyStreamTransactionsRequest, DataStreamingClient, GetAllAccountsRequest,
+        GetAllEpochEndingLedgerInfosRequest, GetAllTransactionOutputsRequest,
+        GetAllTransactionsRequest, PayloadRefetchReason, RefetchNotificationPayloadRequest,
+        StreamRequest, StreamingServiceListener,
+    },
+};
+use channel::{diem_channel, message_queues::QueueStyle};
+use claim::assert_ok;
+use futures::{executor::block_on, FutureExt, StreamExt};
+use std::thread::JoinHandle;
+
+#[test]
+fn test_client_service_error() {
+    // Create a new streaming service client and listener
+    let (streaming_service_client, streaming_service_listener) =
+        new_streaming_service_client_listener_pair();
+
+    // Spawn a new server thread to handle any requests and respond with an error
+    let response_error = Error::UnexpectedErrorEncountered("Oops! Something went wrong!".into());
+    let _handler =
+        spawn_service_and_respond_with_error(streaming_service_listener, response_error.clone());
+
+    // Send an epoch ending stream request and verify the expected error is returned
+    let response = block_on(streaming_service_client.get_all_epoch_ending_ledger_infos(0));
+    assert_eq!(response.unwrap_err(), response_error);
+}
+
+#[test]
+fn test_get_all_accounts() {
+    // Create a new streaming service client and listener
+    let (streaming_service_client, streaming_service_listener) =
+        new_streaming_service_client_listener_pair();
+
+    // Note the request we expect to receive on the streaming service side
+    let request_version = 100;
+    let expected_request = StreamRequest::GetAllAccounts(GetAllAccountsRequest {
+        version: request_version,
+    });
+
+    // Spawn a new server thread to handle any account stream requests
+    let _handler = spawn_service_and_expect_request(streaming_service_listener, expected_request);
+
+    // Send an account stream request and verify we get a data stream listener
+    let response = block_on(streaming_service_client.get_all_accounts(request_version));
+    assert_ok!(response);
+}
+
+#[test]
+fn test_get_all_epoch_ending_ledger_infos() {
+    // Create a new streaming service client and listener
+    let (streaming_service_client, streaming_service_listener) =
+        new_streaming_service_client_listener_pair();
+
+    // Note the request we expect to receive on the streaming service side
+    let request_start_epoch = 10;
+    let expected_request =
+        StreamRequest::GetAllEpochEndingLedgerInfos(GetAllEpochEndingLedgerInfosRequest {
+            start_epoch: request_start_epoch,
+        });
+
+    // Spawn a new server thread to handle any epoch ending stream requests
+    let _handler = spawn_service_and_expect_request(streaming_service_listener, expected_request);
+
+    // Send an epoch ending stream request and verify we get a data stream listener
+    let response =
+        block_on(streaming_service_client.get_all_epoch_ending_ledger_infos(request_start_epoch));
+    assert_ok!(response);
+}
+
+#[test]
+fn test_get_all_transactions() {
+    // Create a new streaming service client and listener
+    let (streaming_service_client, streaming_service_listener) =
+        new_streaming_service_client_listener_pair();
+
+    // Note the request we expect to receive on the streaming service side
+    let request_start_version = 101;
+    let request_end_version = 200;
+    let request_max_proof_version = 300;
+    let request_include_events = true;
+    let expected_request = StreamRequest::GetAllTransactions(GetAllTransactionsRequest {
+        start_version: request_start_version,
+        end_version: request_end_version,
+        max_proof_version: request_max_proof_version,
+        include_events: request_include_events,
+    });
+
+    // Spawn a new server thread to handle any transaction stream requests
+    let _handler = spawn_service_and_expect_request(streaming_service_listener, expected_request);
+
+    // Send a transaction stream request and verify we get a data stream listener
+    let response = block_on(streaming_service_client.get_all_transactions(
+        request_start_version,
+        request_end_version,
+        request_max_proof_version,
+        request_include_events,
+    ));
+    assert_ok!(response);
+}
+
+#[test]
+fn test_get_all_transaction_outputs() {
+    // Create a new streaming service client and listener
+    let (streaming_service_client, streaming_service_listener) =
+        new_streaming_service_client_listener_pair();
+
+    // Note the request we expect to receive on the streaming service side
+    let request_start_version = 101;
+    let request_end_version = 200;
+    let request_max_proof_version = 300;
+    let expected_request =
+        StreamRequest::GetAllTransactionOutputs(GetAllTransactionOutputsRequest {
+            start_version: request_start_version,
+            end_version: request_end_version,
+            max_proof_version: request_max_proof_version,
+        });
+
+    // Spawn a new server thread to handle any transaction output stream requests
+    let _handler = spawn_service_and_expect_request(streaming_service_listener, expected_request);
+
+    // Send a transaction output stream request and verify we get a data stream listener
+    let response = block_on(streaming_service_client.get_all_transaction_outputs(
+        request_start_version,
+        request_end_version,
+        request_max_proof_version,
+    ));
+    assert_ok!(response);
+}
+
+#[test]
+fn test_continuously_stream_transactions() {
+    // Create a new streaming service client and listener
+    let (streaming_service_client, streaming_service_listener) =
+        new_streaming_service_client_listener_pair();
+
+    // Note the request we expect to receive on the streaming service side
+    let request_start_version = 101;
+    let request_start_epoch = 2;
+    let request_include_events = false;
+    let expected_request =
+        StreamRequest::ContinuouslyStreamTransactions(ContinuouslyStreamTransactionsRequest {
+            start_version: request_start_version,
+            start_epoch: request_start_epoch,
+            include_events: request_include_events,
+        });
+
+    // Spawn a new server thread to handle any continuous transaction stream requests
+    let _handler = spawn_service_and_expect_request(streaming_service_listener, expected_request);
+
+    // Send a continuous transaction stream request and verify we get a data stream listener
+    let response = block_on(streaming_service_client.continuously_stream_transactions(
+        request_start_version,
+        request_start_epoch,
+        request_include_events,
+    ));
+    assert_ok!(response);
+}
+
+#[test]
+fn test_continuously_stream_transaction_outputs() {
+    // Create a new streaming service client and listener
+    let (streaming_service_client, streaming_service_listener) =
+        new_streaming_service_client_listener_pair();
+
+    // Note the request we expect to receive on the streaming service side
+    let request_start_version = 101;
+    let request_start_epoch = 2;
+    let expected_request = StreamRequest::ContinuouslyStreamTransactionOutputs(
+        ContinuouslyStreamTransactionOutputsRequest {
+            start_version: request_start_version,
+            start_epoch: request_start_epoch,
+        },
+    );
+
+    // Spawn a new server thread to handle any continuous transaction output stream requests
+    let _handler = spawn_service_and_expect_request(streaming_service_listener, expected_request);
+
+    // Send a continuous transaction output stream request and verify we get a data stream listener
+    let response = block_on(
+        streaming_service_client
+            .continuously_stream_transaction_outputs(request_start_version, request_start_epoch),
+    );
+    assert_ok!(response);
+}
+
+#[test]
+fn test_refetch_notification_payloads() {
+    // Create a new streaming service client and listener
+    let (streaming_service_client, streaming_service_listener) =
+        new_streaming_service_client_listener_pair();
+
+    // Note the request we expect to receive on the streaming service side
+    let request_notification_id = 19478;
+    let request_refetch_reason = PayloadRefetchReason::InvalidPayloadData;
+    let expected_request =
+        StreamRequest::RefetchNotificationPayload(RefetchNotificationPayloadRequest {
+            notification_id: request_notification_id,
+            refetch_reason: request_refetch_reason.clone(),
+        });
+
+    // Spawn a new server thread to handle any refetch payload requests
+    let _handler = spawn_service_and_expect_request(streaming_service_listener, expected_request);
+
+    // Send a refetch payload request and verify we get a data stream listener
+    let response = block_on(
+        streaming_service_client
+            .refetch_notification_payload(request_notification_id, request_refetch_reason),
+    );
+    assert_ok!(response);
+}
+
+/// Spawns a new thread that listens to the given streaming service listener and
+/// responds successfully to any requests that match the specified `expected_request`.
+/// Otherwise, an error is returned.
+fn spawn_service_and_expect_request(
+    mut streaming_service_listener: StreamingServiceListener,
+    expected_request: StreamRequest,
+) -> JoinHandle<()> {
+    std::thread::spawn(move || loop {
+        if let Some(stream_request_message) =
+            streaming_service_listener.select_next_some().now_or_never()
+        {
+            // Create a new data stream sender and listener pair
+            let (_, listener) = new_data_stream_sender_listener();
+
+            // Verify the client request is as expected and respond appropriately
+            let stream_request = stream_request_message.stream_request;
+            let response = if stream_request == expected_request {
+                Ok(listener)
+            } else {
+                Err(Error::UnexpectedErrorEncountered(format!(
+                    "Unexpected stream request! Got: {:?} but expected: {:?}",
+                    stream_request, expected_request
+                )))
+            };
+
+            // Send the response to the client
+            let _send_result = stream_request_message.response_sender.send(response);
+        }
+    })
+}
+
+/// Spawns a new thread that listens to the given streaming service listener and
+/// responds with the specified error.
+fn spawn_service_and_respond_with_error(
+    mut streaming_service_listener: StreamingServiceListener,
+    response_error: Error,
+) -> JoinHandle<()> {
+    std::thread::spawn(move || loop {
+        if let Some(stream_request_message) =
+            streaming_service_listener.select_next_some().now_or_never()
+        {
+            let _result = stream_request_message
+                .response_sender
+                .send(Err(response_error.clone()));
+        }
+    })
+}
+
+/// Creates and returns a new data stream sender and listener pair.
+fn new_data_stream_sender_listener() -> (
+    channel::diem_channel::Sender<(), DataNotification>,
+    DataStreamListener,
+) {
+    let (notification_sender, notification_receiver) =
+        diem_channel::new(QueueStyle::KLAST, 1, None);
+    let data_stream_listener = DataStreamListener::new(notification_receiver);
+
+    (notification_sender, data_stream_listener)
+}

--- a/x.toml
+++ b/x.toml
@@ -194,6 +194,7 @@ members = [
     "diem-proptest-helpers",
     "diem-read-write-set",
     "diem-retrier",
+    "data-streaming-service", # Will be removed once state sync v2 is plugged into diem-node.
     "diem-swarm",
     "diem-transactional-test-harness",
     "diem-transaction-benchmarks",


### PR DESCRIPTION
## Motivation

```
Disclaimer: Even though this PR is quite big, it's mostly boilerplate, code comments
and some simple unit tests, so it hopefully shouldn't be as scary as it appears.
```

This PR adds a new `data-streaming-service` crate for state sync v2 and starts building out the new streaming service by offering a simple `DataStreamingClient` implementation. The data streaming service is the service used by state sync to stream (i.e., fetch) data from the network, fetching data via the Diem data client. State sync will use the streaming service client (i.e., `DataStreamingClient` interface ) to request data (e.g., all transactions from version 0 -> X) and be given a corresponding data stream through which the data will be forwarded. State sync can then listen to this stream to receive data chunks while it syncs.

The PR offers two commits:
1. We add a basic skeleton for the crate and implement the streaming service client.
2. We add unit tests that ensure the streaming service client communicates with the service correctly. These are mostly just verifying that message serialization is correct 😄 

The next PR will start working on the streaming service itself.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Simple unit tests have been added to ensure the client works correctly.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906