### PR TITLE
[forge] add drop for k8s_factory struct

### DIFF
--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -80,6 +80,14 @@ impl K8sFactory {
     }
 }
 
+impl Drop for K8sFactory {
+    // When the K8sSwarm struct goes out of scope we need to wipe the chain state and scale down
+    fn drop(&mut self) {
+        uninstall_from_k8s_cluster().unwrap();
+        set_eks_nodegroup_size(self.cluster_name.clone(), 0, true).unwrap();
+    }
+}
+
 impl Factory for K8sFactory {
     fn versions<'a>(&'a self) -> Box<dyn Iterator<Item = Version> + 'a> {
         let version = vec![

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -3,8 +3,7 @@
 
 use crate::{
     backend::k8s::node::K8sNode, create_k8s_client, query_sequence_numbers, remove_helm_release,
-    set_eks_nodegroup_size, set_validator_image_tag, uninstall_from_k8s_cluster, ChainInfo,
-    FullNode, Node, Result, Swarm, Validator, Version,
+    set_validator_image_tag, ChainInfo, FullNode, Node, Result, Swarm, Validator, Version,
 };
 use anyhow::{anyhow, bail, format_err};
 use diem_config::config::NodeConfig;
@@ -139,14 +138,6 @@ impl K8sSwarm {
     #[allow(dead_code)]
     fn get_kube_client(&self) -> K8sClient {
         self.kube_client.clone()
-    }
-}
-
-impl Drop for K8sSwarm {
-    // When the K8sSwarm struct goes out of scope we need to wipe the chain state and scale down
-    fn drop(&mut self) {
-        uninstall_from_k8s_cluster().unwrap();
-        set_eks_nodegroup_size(self.cluster_name.clone(), 0, true).unwrap();
     }
 }
 


### PR DESCRIPTION
Added drop crates implementation for k8sFactory to handle cluster cleanup instead of drop for k8sSwarm, Since some cluster operation errors happened before k8sSwarm constructed.

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
