### PR TITLE
update zeroize-derive to v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9443,9 +9443,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f369ddb18862aba61aa49bf31e74d29f0f162dec753063200e1dc084345d16"
+checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
 dependencies = [
  "proc-macro2 1.0.28",
  "quote 1.0.9",


### PR DESCRIPTION
Update zeroize-derive in order to address [RUSTSEC-2021-0115](https://rustsec.org/advisories/RUSTSEC-2021-0115.html)

Fixes: #9268