### PR TITLE
Fix dead link pointing to example move lang tests

### DIFF
--- a/language/README.md
+++ b/language/README.md
@@ -25,6 +25,6 @@ Diem Core components interact with the language component through the VM. Specif
 
 ## Exploring the Move language
 
-- You can find many small Move examples in the [tests](move-lang/tests/functional/) directory. The easiest way to experiment with Move is to create a new test in this directory and run it with `cargo test`.
+- You can find many small Move examples in the [tests](move-lang/tests/move_check/examples/) directory. The easiest way to experiment with Move is to create a new test in this directory and run it with `cargo test`.
 - More substantial examples can be found in the [standard library](stdlib/modules) directory. The Two particularly notable ones are [DiemAccount](stdlib/modules/diem_account.move), which implements accounts on the Diem blockchain, and [Diem](stdlib/modules/diem.move), which implements generic currency logic used by all of the currencies the Diem payment network supports.
 - The transaction scripts supported in the Diem blockchain are also in the standard library directory. Move tests and local instances of the Diem blockchain can execute arbitrary transaction scripts, but the Diem blockchain and testnet are limited to accepting the scripts in this directory.


### PR DESCRIPTION
## Motivation

I noticed that there is a broken link on the README pointing to some example move lang tests. I'm updating this broken link so that other developers can get to the right directory that contains the tests and use them to ramp up.

## Related Issue

Merging would help to resolve Issue #9319.