### PR TITLE
[diem-vm] Create the parallel execution api for diem-vm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,6 +2751,7 @@ dependencies = [
  "diem-framework-releases",
  "diem-logger",
  "diem-metrics",
+ "diem-parallel-executor",
  "diem-state-view",
  "diem-types",
  "diem-workspace-hack",
@@ -2761,6 +2762,7 @@ dependencies = [
  "move-stdlib",
  "move-vm-runtime",
  "move-vm-types",
+ "mvhashmap",
  "once_cell",
  "proptest",
  "rayon",
@@ -4596,6 +4598,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.4",
+ "read-write-set",
  "serde",
  "vm-genesis",
 ]
@@ -4624,6 +4627,7 @@ dependencies = [
  "move-vm-runtime",
  "move-vm-types",
  "proptest",
+ "read-write-set",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2602,10 +2602,14 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "criterion-cpu-time",
+ "diem-framework-releases",
  "diem-types",
+ "diem-vm",
  "diem-workspace-hack",
  "language-e2e-tests",
  "proptest",
+ "read-write-set",
+ "read-write-set-dynamic",
 ]
 
 [[package]]

--- a/language/diem-transaction-benchmarks/Cargo.toml
+++ b/language/diem-transaction-benchmarks/Cargo.toml
@@ -18,6 +18,10 @@ diem-types = { path = "../../types", features = ["fuzzing"] }
 language-e2e-tests = { path = "../testing-infra/e2e-tests" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 
+read-write-set = { path = "../tools/read-write-set" }
+read-write-set-dynamic = { path = "../tools/read-write-set/dynamic" }
+diem-vm = { path = "../diem-vm" }
+diem-framework-releases = { path = "../diem-framework/DPN/releases" }
 
 [[bench]]
 name = "transaction_benches"

--- a/language/diem-transaction-benchmarks/benches/transaction_benches.rs
+++ b/language/diem-transaction-benchmarks/benches/transaction_benches.rs
@@ -3,7 +3,7 @@
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, Criterion};
 use diem_transaction_benchmarks::{
-    measurement::cpu_time_measurement, transactions::TransactionBencher,
+    measurement::wall_time_measurement, transactions::TransactionBencher,
 };
 use language_e2e_tests::account_universe::P2PTransferGen;
 use proptest::prelude::*;
@@ -17,11 +17,16 @@ fn peer_to_peer<M: Measurement + 'static>(c: &mut Criterion<M>) {
         let bencher = TransactionBencher::new(any_with::<P2PTransferGen>((1_000, 1_000_000)));
         bencher.bench(b)
     });
+
+    c.bench_function("peer_to_peer_parallel", |b| {
+        let bencher = TransactionBencher::new(any_with::<P2PTransferGen>((1_000, 1_000_000)));
+        bencher.bench_parallel(b)
+    });
 }
 
 criterion_group!(
     name = txn_benches;
-    config = cpu_time_measurement();
+    config = wall_time_measurement().sample_size(10);
     targets = peer_to_peer
 );
 

--- a/language/diem-vm/Cargo.toml
+++ b/language/diem-vm/Cargo.toml
@@ -34,6 +34,8 @@ serde_json = "1.0.64"
 serde = { version = "1.0.124", default-features = false }
 read-write-set-dynamic = { path = "../tools/read-write-set/dynamic"}
 
+mvhashmap = { path = "mvhashmap" }
+diem-parallel-executor = {path = "parallel-executor" }
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/language/diem-vm/parallel-executor/src/executor.rs
+++ b/language/diem-vm/parallel-executor/src/executor.rs
@@ -79,6 +79,9 @@ where
         task_initial_arguments: E::Argument,
         signature_verified_block: Vec<T>,
     ) -> Result<Vec<E::Output>, E::Error> {
+        if signature_verified_block.is_empty() {
+            return Ok(vec![]);
+        }
         let num_txns = signature_verified_block.len();
         let chunks_size = max(1, num_txns / self.num_cpus);
 
@@ -117,6 +120,11 @@ where
 
         let (versioned_data_cache, max_dependency_level) =
             MVHashMap::new_from_parallel(path_version_tuples);
+
+        if max_dependency_level == 0 {
+            return Err(Error::InferencerError);
+        }
+
         let outcomes = OutcomeArray::new(num_txns);
 
         let scheduler = Arc::new(Scheduler::new(num_txns));

--- a/language/diem-vm/src/lib.rs
+++ b/language/diem-vm/src/lib.rs
@@ -111,18 +111,16 @@ pub mod data_cache;
 pub mod foreign_contracts;
 
 mod adapter_common;
+pub mod diem_vm;
 mod diem_vm_impl;
 mod errors;
-pub mod natives;
-pub mod transaction_metadata;
-
-// pub mod diem_transaction_executor;
-// pub mod diem_transaction_validator;
-pub mod diem_vm;
 pub mod logging;
+pub mod natives;
+pub mod parallel_executor;
 pub mod read_write_set_analysis;
 pub mod script_to_script_function;
 pub mod system_module_names;
+pub mod transaction_metadata;
 
 #[cfg(test)]
 mod unit_tests;

--- a/language/diem-vm/src/parallel_executor/mod.rs
+++ b/language/diem-vm/src/parallel_executor/mod.rs
@@ -1,0 +1,110 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+mod read_write_set_analyzer;
+mod storage_wrapper;
+mod vm_wrapper;
+
+use crate::{
+    adapter_common::{preprocess_transaction, PreprocessedTransaction},
+    data_cache::RemoteStorage,
+    diem_vm::DiemVM,
+    parallel_executor::{
+        read_write_set_analyzer::ReadWriteSetAnalysisWrapper, vm_wrapper::DiemVMWrapper,
+    },
+    VMExecutor,
+};
+use diem_parallel_executor::{
+    errors::Error,
+    executor::ParallelTransactionExecutor,
+    task::{Transaction as PTransaction, TransactionOutput as PTransactionOutput},
+};
+use diem_state_view::StateView;
+use diem_types::{
+    access_path::AccessPath,
+    transaction::{Transaction, TransactionOutput, TransactionStatus},
+    write_set::{WriteOp, WriteSet},
+};
+use move_core_types::vm_status::{StatusCode, VMStatus};
+use rayon::prelude::*;
+use read_write_set_dynamic::NormalizedReadWriteSetAnalysis;
+
+impl PTransaction for PreprocessedTransaction {
+    type Key = AccessPath;
+    type Value = WriteOp;
+}
+
+// Wrapper to avoid orphan rule
+pub(crate) struct DiemTransactionOutput(TransactionOutput);
+
+impl DiemTransactionOutput {
+    pub fn new(output: TransactionOutput) -> Self {
+        Self(output)
+    }
+    pub fn into(self) -> TransactionOutput {
+        self.0
+    }
+}
+
+impl PTransactionOutput for DiemTransactionOutput {
+    type T = PreprocessedTransaction;
+
+    fn get_writes(&self) -> Vec<(AccessPath, WriteOp)> {
+        self.0.write_set().iter().cloned().collect()
+    }
+
+    /// Execution output for transactions that comes after SkipRest signal.
+    fn skip_output() -> Self {
+        Self(TransactionOutput::new(
+            WriteSet::default(),
+            vec![],
+            0,
+            TransactionStatus::Retry,
+        ))
+    }
+}
+
+pub struct ParallelDiemVM();
+
+impl ParallelDiemVM {
+    pub fn execute_block<S: StateView>(
+        analysis_result: &NormalizedReadWriteSetAnalysis,
+        transactions: Vec<Transaction>,
+        state_view: &S,
+    ) -> Result<(Vec<TransactionOutput>, Option<Error<VMStatus>>), VMStatus> {
+        let blockchain_view = RemoteStorage::new(state_view);
+        let analyzer = ReadWriteSetAnalysisWrapper::new(analysis_result, &blockchain_view);
+
+        // Verify the signatures of all the transactions in parallel.
+        // This is time consuming so don't wait and do the checking
+        // sequentially while executing the transactions.
+
+        let signature_verified_block: Vec<PreprocessedTransaction> = transactions
+            .par_iter()
+            .map(|txn| preprocess_transaction::<DiemVM>(txn.clone()))
+            .collect();
+
+        match ParallelTransactionExecutor::<
+            PreprocessedTransaction,
+            DiemVMWrapper<S>,
+            ReadWriteSetAnalysisWrapper<RemoteStorage<S>>,
+        >::new(analyzer)
+        .execute_transactions_parallel(state_view, signature_verified_block)
+        {
+            Ok(results) => Ok((
+                results
+                    .into_iter()
+                    .map(DiemTransactionOutput::into)
+                    .collect(),
+                None,
+            )),
+            Err(err @ Error::InferencerError) | Err(err @ Error::UnestimatedWrite) => {
+                Ok((DiemVM::execute_block(transactions, state_view)?, Some(err)))
+            }
+            Err(Error::InvariantViolation) => Err(VMStatus::Error(
+                StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
+            )),
+            Err(Error::UserError(err)) => Err(err),
+        }
+    }
+}

--- a/language/diem-vm/src/parallel_executor/read_write_set_analyzer.rs
+++ b/language/diem-vm/src/parallel_executor/read_write_set_analyzer.rs
@@ -1,0 +1,42 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    adapter_common::PreprocessedTransaction, read_write_set_analysis::ReadWriteSetAnalysis,
+};
+use anyhow::Result;
+use diem_parallel_executor::task::{Accesses, ReadWriteSetInferencer};
+use diem_types::access_path::AccessPath;
+use move_core_types::resolver::MoveResolver;
+use read_write_set_dynamic::NormalizedReadWriteSetAnalysis;
+
+pub(crate) struct ReadWriteSetAnalysisWrapper<'a, S: MoveResolver> {
+    analyzer: ReadWriteSetAnalysis<'a, S>,
+}
+
+impl<'a, S: MoveResolver> ReadWriteSetAnalysisWrapper<'a, S> {
+    pub fn new(analysis_result: &'a NormalizedReadWriteSetAnalysis, view: &'a S) -> Self {
+        Self {
+            analyzer: ReadWriteSetAnalysis::new(analysis_result, view),
+        }
+    }
+}
+
+impl<'a, S: MoveResolver + std::marker::Sync> ReadWriteSetInferencer
+    for ReadWriteSetAnalysisWrapper<'a, S>
+{
+    type T = PreprocessedTransaction;
+    fn infer_reads_writes(&self, txn: &Self::T) -> Result<Accesses<AccessPath>> {
+        let (keys_read, keys_written) = self.analyzer.get_keys_transaction(txn, false)?;
+        Ok(Accesses {
+            keys_read: keys_read
+                .into_iter()
+                .map(AccessPath::resource_access_path)
+                .collect(),
+            keys_written: keys_written
+                .into_iter()
+                .map(AccessPath::resource_access_path)
+                .collect(),
+        })
+    }
+}

--- a/language/diem-vm/src/parallel_executor/storage_wrapper.rs
+++ b/language/diem-vm/src/parallel_executor/storage_wrapper.rs
@@ -1,0 +1,70 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::data_cache::RemoteStorage;
+use diem_parallel_executor::executor::MVHashMapView;
+use diem_state_view::{StateView, StateViewId};
+use diem_types::{access_path::AccessPath, write_set::WriteOp};
+use move_binary_format::errors::VMError;
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag},
+    resolver::{ModuleResolver, ResourceResolver},
+};
+
+pub(crate) struct VersionedView<'a, S: StateView> {
+    base_view: &'a S,
+    hashmap_view: &'a MVHashMapView<'a, AccessPath, WriteOp>,
+}
+
+impl<'a, S: StateView> VersionedView<'a, S> {
+    pub fn new_view(
+        base_view: &'a S,
+        hashmap_view: &'a MVHashMapView<'a, AccessPath, WriteOp>,
+    ) -> VersionedView<'a, S> {
+        VersionedView {
+            base_view,
+            hashmap_view,
+        }
+    }
+}
+
+impl<'a, S: StateView> StateView for VersionedView<'a, S> {
+    fn id(&self) -> StateViewId {
+        self.base_view.id()
+    }
+
+    // Get some data either through the cache or the `StateView` on a cache miss.
+    fn get(&self, access_path: &AccessPath) -> anyhow::Result<Option<Vec<u8>>> {
+        match self.hashmap_view.read(access_path) {
+            Ok(Some(WriteOp::Value(v))) => Ok(Some(v.clone())),
+            Ok(Some(WriteOp::Deletion)) => Ok(None),
+            Ok(None) => self.base_view.get(access_path),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn is_genesis(&self) -> bool {
+        self.base_view.is_genesis()
+    }
+}
+
+impl<'a, S: StateView> ModuleResolver for VersionedView<'a, S> {
+    type Error = VMError;
+
+    fn get_module(&self, module_id: &ModuleId) -> Result<Option<Vec<u8>>, Self::Error> {
+        RemoteStorage::new(self).get_module(module_id)
+    }
+}
+
+impl<'a, S: StateView> ResourceResolver for VersionedView<'a, S> {
+    type Error = VMError;
+
+    fn get_resource(
+        &self,
+        address: &AccountAddress,
+        tag: &StructTag,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        RemoteStorage::new(self).get_resource(address, tag)
+    }
+}

--- a/language/diem-vm/src/parallel_executor/vm_wrapper.rs
+++ b/language/diem-vm/src/parallel_executor/vm_wrapper.rs
@@ -1,0 +1,72 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    adapter_common::{PreprocessedTransaction, VMAdapter},
+    diem_vm::DiemVM,
+    logging::AdapterLogSchema,
+    parallel_executor::{storage_wrapper::VersionedView, DiemTransactionOutput},
+};
+use diem_logger::prelude::*;
+use diem_parallel_executor::{
+    executor::MVHashMapView,
+    task::{ExecutionStatus, ExecutorTask},
+};
+use diem_state_view::StateView;
+use diem_types::{access_path::AccessPath, write_set::WriteOp};
+use move_core_types::vm_status::VMStatus;
+
+pub(crate) struct DiemVMWrapper<'a, S> {
+    vm: DiemVM,
+    base_view: &'a S,
+}
+
+impl<'a, S: 'a + StateView> ExecutorTask for DiemVMWrapper<'a, S> {
+    type T = PreprocessedTransaction;
+    type Output = DiemTransactionOutput;
+    type Error = VMStatus;
+    type Argument = &'a S;
+
+    fn init(argument: &'a S) -> Self {
+        Self {
+            vm: DiemVM::new(argument),
+            base_view: argument,
+        }
+    }
+
+    fn execute_transaction(
+        &self,
+        view: &MVHashMapView<AccessPath, WriteOp>,
+        txn: &PreprocessedTransaction,
+    ) -> ExecutionStatus<DiemTransactionOutput, VMStatus> {
+        let log_context = AdapterLogSchema::new(self.base_view.id(), view.version());
+        let versioned_view = VersionedView::new_view(self.base_view, view);
+
+        match self
+            .vm
+            .execute_single_transaction(txn, &versioned_view, &log_context)
+        {
+            Ok((vm_status, output, sender)) => {
+                if output.status().is_discarded() {
+                    match sender {
+                        Some(s) => trace!(
+                            log_context,
+                            "Transaction discarded, sender: {}, error: {:?}",
+                            s,
+                            vm_status,
+                        ),
+                        None => {
+                            trace!(log_context, "Transaction malformed, error: {:?}", vm_status,)
+                        }
+                    };
+                }
+                if DiemVM::should_restart_execution(&output) {
+                    ExecutionStatus::SkipRest(DiemTransactionOutput::new(output))
+                } else {
+                    ExecutionStatus::Success(DiemTransactionOutput::new(output))
+                }
+            }
+            Err(err) => ExecutionStatus::Abort(err),
+        }
+    }
+}

--- a/language/e2e-testsuite/Cargo.toml
+++ b/language/e2e-testsuite/Cargo.toml
@@ -31,6 +31,7 @@ diem-framework-releases = { path = "../diem-framework/DPN/releases" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 diem-writeset-generator = { path = "../../diem-move/writeset-transaction-generator"}
 diem-state-view = { path = "../../storage/state-view" }
+read-write-set = { path = "../tools/read-write-set" }
 
 [features]
 default = ["diem-transaction-builder/fuzzing"]

--- a/language/e2e-testsuite/src/tests/mod.rs
+++ b/language/e2e-testsuite/src/tests/mod.rs
@@ -24,6 +24,7 @@ mod mint;
 mod module_publishing;
 mod multi_agent;
 mod on_chain_configs;
+mod parallel_execution;
 mod peer_to_peer;
 mod preburn_queue;
 mod rotate_key;

--- a/language/e2e-testsuite/src/tests/parallel_execution.rs
+++ b/language/e2e-testsuite/src/tests/parallel_execution.rs
@@ -1,0 +1,123 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::tests::peer_to_peer::{check_and_apply_transfer_output, create_cyclic_transfers};
+use diem_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, Uniform};
+use diem_framework_releases::current_modules;
+use diem_types::{
+    block_metadata::BlockMetadata,
+    on_chain_config::{OnChainConfig, ValidatorSet},
+    transaction::{authenticator::AuthenticationKey, Transaction, TransactionStatus},
+    vm_status::{KeptVMStatus, StatusCode},
+};
+use diem_vm::{parallel_executor::ParallelDiemVM, read_write_set_analysis::add_on_functions_list};
+use language_e2e_tests::{account, common_transactions::rotate_key_txn, executor::FakeExecutor};
+use read_write_set::analyze;
+
+#[test]
+fn peer_to_peer_with_prologue_parallel() {
+    let mut executor = FakeExecutor::from_fresh_genesis();
+    let account_size = 1000usize;
+    let initial_balance = 2_000_000u64;
+    let initial_seq_num = 10u64;
+    let accounts = executor.create_accounts(account_size, initial_balance, initial_seq_num);
+
+    // set up the transactions
+    let transfer_amount = 1_000;
+
+    // insert a block prologue transaction
+    let (txns_info, transfer_txns) = create_cyclic_transfers(&executor, &accounts, transfer_amount);
+
+    let analyze_result = analyze(current_modules().iter())
+        .unwrap()
+        .normalize_all_scripts(add_on_functions_list());
+
+    let mut txns = transfer_txns
+        .into_iter()
+        .map(Transaction::UserTransaction)
+        .collect::<Vec<_>>();
+    let validator_set = ValidatorSet::fetch_config(executor.get_state_view())
+        .expect("Unable to retrieve the validator set from storage");
+    let new_block = BlockMetadata::new(
+        HashValue::zero(),
+        0,
+        1,
+        vec![],
+        *validator_set.payload()[0].account_address(),
+    );
+
+    txns.insert(0, Transaction::BlockMetadata(new_block));
+
+    let (mut results, parallel_status) =
+        ParallelDiemVM::execute_block(&analyze_result, txns, executor.get_state_view()).unwrap();
+
+    assert!(parallel_status.is_none());
+
+    results.remove(0);
+
+    check_and_apply_transfer_output(&mut executor, &txns_info, &results)
+}
+
+#[test]
+fn rotate_ed25519_key() {
+    let balance = 1_000_000;
+    let mut executor = FakeExecutor::from_fresh_genesis();
+
+    // create and publish sender
+    let mut sender = executor.create_raw_account_data(balance, 10);
+    executor.add_account_data(&sender);
+
+    let privkey = Ed25519PrivateKey::generate_for_testing();
+    let pubkey = privkey.public_key();
+    let new_key_hash = AuthenticationKey::ed25519(&pubkey).to_vec();
+    let txn = rotate_key_txn(sender.account(), new_key_hash.clone(), 10);
+
+    let analyze_result = analyze(current_modules().iter())
+        .unwrap()
+        .normalize_all_scripts(add_on_functions_list());
+
+    // execute transaction
+    let (mut results, parallel_status) = ParallelDiemVM::execute_block(
+        &analyze_result,
+        vec![Transaction::UserTransaction(txn)],
+        executor.get_state_view(),
+    )
+    .unwrap();
+
+    assert!(parallel_status.is_none());
+
+    let output = results.pop().unwrap();
+    assert_eq!(
+        output.status(),
+        &TransactionStatus::Keep(KeptVMStatus::Executed),
+    );
+    executor.apply_write_set(output.write_set());
+
+    // Check that numbers in store are correct.
+    let updated_sender = executor
+        .read_account_resource(sender.account())
+        .expect("sender must exist");
+    let updated_sender_balance = executor
+        .read_balance_resource(sender.account(), account::xus_currency_code())
+        .expect("sender balance must exist");
+    assert_eq!(new_key_hash, updated_sender.authentication_key().to_vec());
+    assert_eq!(balance, updated_sender_balance.coin());
+    assert_eq!(11, updated_sender.sequence_number());
+
+    // Check that transactions cannot be sent with the old key any more.
+    let old_key_txn = rotate_key_txn(sender.account(), vec![], 11);
+    let old_key_output = &executor.execute_transaction(old_key_txn);
+    assert_eq!(
+        old_key_output.status(),
+        &TransactionStatus::Discard(StatusCode::INVALID_AUTH_KEY),
+    );
+
+    // Check that transactions can be sent with the new key.
+    sender.rotate_key(privkey, pubkey);
+    let new_key_txn = rotate_key_txn(sender.account(), new_key_hash, 11);
+    let new_key_output = &executor.execute_transaction(new_key_txn);
+    assert_eq!(
+        new_key_output.status(),
+        &TransactionStatus::Keep(KeptVMStatus::Executed),
+    );
+}

--- a/language/e2e-testsuite/src/tests/peer_to_peer.rs
+++ b/language/e2e-testsuite/src/tests/peer_to_peer.rs
@@ -263,7 +263,7 @@ fn zero_amount_peer_to_peer() {
 }
 
 // Holder for transaction data; arguments to transactions.
-struct TxnInfo {
+pub(crate) struct TxnInfo {
     pub sender: Account,
     pub receiver: Account,
     pub transfer_amount: u64,
@@ -281,7 +281,7 @@ impl TxnInfo {
 
 // Create a cyclic transfer around a slice of Accounts.
 // Each Account makes a transfer for the same amount to the next DiemAccount.
-fn create_cyclic_transfers(
+pub(crate) fn create_cyclic_transfers(
     executor: &FakeExecutor,
     accounts: &[Account],
     transfer_amount: u64,
@@ -364,7 +364,7 @@ fn create_many_to_one_transfers(
 // state after a successful transfer.
 // The transaction arguments are provided in txn_args.
 // Apply the WriteSet to the data store.
-fn check_and_apply_transfer_output(
+pub(crate) fn check_and_apply_transfer_output(
     executor: &mut FakeExecutor,
     txn_args: &[TxnInfo],
     output: &[TransactionOutput],

--- a/language/testing-infra/e2e-tests/Cargo.toml
+++ b/language/testing-infra/e2e-tests/Cargo.toml
@@ -36,4 +36,5 @@ diem-framework-releases = { path = "../../diem-framework/DPN/releases" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-transaction-builder = { path = "../../../sdk/transaction-builder" }
 move-command-line-common = { path = "../../move-command-line-common" }
+read-write-set = { path = "../../tools/read-write-set" }
 hex = "0.4.3"

--- a/language/testing-infra/e2e-tests/src/account_universe.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use diem_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use diem_types::{
-    transaction::{SignedTransaction, TransactionStatus},
+    transaction::{SignedTransaction, Transaction, TransactionStatus},
     vm_status::{known_locations, KeptVMStatus, StatusCode},
 };
 use once_cell::sync::Lazy;
@@ -382,9 +382,18 @@ pub fn run_and_assert_universe(
         .iter()
         .map(|transaction_gen| transaction_gen.clone().apply(&mut universe))
         .unzip();
-    let outputs = executor.execute_block(transactions).unwrap();
+    let outputs = executor.execute_block(transactions.clone()).unwrap();
+    let outputs_parallel = executor
+        .execute_transaction_block_parallel(
+            transactions
+                .into_iter()
+                .map(Transaction::UserTransaction)
+                .collect(),
+        )
+        .unwrap();
 
     prop_assert_eq!(outputs.len(), expected_values.len());
+    prop_assert_eq!(outputs.clone(), outputs_parallel);
 
     for (idx, (output, expected)) in outputs.iter().zip(&expected_values).enumerate() {
         prop_assert!(

--- a/x.toml
+++ b/x.toml
@@ -190,7 +190,6 @@ members = [
     "diem-fuzzer",
     "diem-json-rpc-client",
     "diem-keygen",
-    "diem-parallel-executor", # Will be removed once parallel execution is used in production.
     "diem-proptest-helpers",
     "diem-retrier",
     "data-streaming-service", # Will be removed once state sync v2 is plugged into diem-node.
@@ -222,7 +221,6 @@ members = [
     "move-transactional-test-runner",
     "move-vm-integration-tests",
     "move-vm-transactional-tests",
-    "mvhashmap", # Will be removed once mvhashmap is used in production.
     "offchain",
     "public-script-helper",
     "scratchpad-benchmark",


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Parallel execute diem transactions via the `parallel-executor` crate implemented previously by implementing a few adapter traits needed by the parallel executor.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Implemented a few simple test to test correctness for p2p transactions. Proptests are also upgraded to run with sequential and parallel execution to make sure the execution results are the same.

Here's the benchmark result for running 1000 transactions in parallel:

```
peer_to_peer            time:   [408.74 ms 415.81 ms 422.46 ms]                       
                        change: [-88.342% -88.048% -87.747%] (p = 0.00 < 0.05)
                        Performance has improved.

peer_to_peer_parallel   time:   [170.13 ms 183.82 ms 199.73 ms]                                
                        change: [-83.878% -82.464% -80.356%] (p = 0.00 < 0.05)
                        Performance has improved.
```

And the numbers for 5000 transactions:
```
Benchmarking peer_to_peer: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 24.6s.
peer_to_peer            time:   [1.8377 s 1.9229 s 2.0069 s]                          
                        change: [+342.04% +362.44% +383.44%] (p = 0.00 < 0.05)
                        Performance has regressed.

Benchmarking peer_to_peer_parallel: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 10.1s.
peer_to_peer_parallel   time:   [580.81 ms 609.38 ms 641.22 ms]                                
                        change: [+201.81% +231.50% +264.16%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

All those transactions are generated by randomly transacting between 100 accounts.

