### PR TITLE
[WIP] move-analyer go to definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4872,6 +4872,7 @@ dependencies = [
  "lsp-types",
  "serde_json",
  "structopt 0.3.21",
+ "url",
 ]
 
 [[package]]

--- a/language/move-analyzer/Cargo.toml
+++ b/language/move-analyzer/Cargo.toml
@@ -14,6 +14,7 @@ lsp-server = "0.5.1"
 lsp-types = "0.90.1"
 serde_json = "1.0.64"
 structopt = "0.3.21"
+url = "2.2.2"
 
 [dev-dependencies]
 diem-workspace-hack = { path = "../../common/workspace-hack" }


### PR DESCRIPTION
This is just a preview of the work I'm doing to implement "go to definition" in move-analyzer. Currently at the time that I'm writing this, the code just demonstrates deserializing the language server client's request and returning a canned response.