### PR TITLE
[language][diem-transactional-tests] parent vasp account creation

### DIFF
--- a/language/testing-infra/diem-transactional-test-harness/src/diem_test_harness.rs
+++ b/language/testing-infra/diem-transactional-test-harness/src/diem_test_harness.rs
@@ -11,8 +11,8 @@ use diem_state_view::StateView;
 use diem_types::{
     access_path::AccessPath,
     account_config::{
-        self, diem_root_address, type_tag_for_currency_code, AccountResource, BalanceResource,
-        XUS_NAME,
+        self, diem_root_address, treasury_compliance_account_address, type_tag_for_currency_code,
+        AccountResource, BalanceResource, XUS_IDENTIFIER, XUS_NAME,
     },
     chain_id::ChainId,
     transaction::{
@@ -29,7 +29,7 @@ use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::{GasAlgebra, GasConstants},
     identifier::{IdentStr, Identifier},
-    language_storage::{ModuleId, ResourceKey, TypeTag},
+    language_storage::{ModuleId, ResourceKey, StructTag, TypeTag},
     move_resource::MoveStructType,
     transaction_argument::{convert_txn_args, TransactionArgument},
 };
@@ -49,6 +49,13 @@ use std::{
 };
 use structopt::StructOpt;
 use vm_genesis::GENESIS_KEYPAIR;
+
+/*************************************************************************************************
+ *
+ * Definitions
+ *
+ *
+ ************************************************************************************************/
 
 /// The Diem transaction test adapter.
 ///
@@ -97,6 +104,9 @@ struct DiemInitArgs {
 
     #[structopt(long = "validators", parse(try_from_str = parse_identifier))]
     validators: Option<Vec<Identifier>>,
+
+    #[structopt(long = "parent-vasps", parse(try_from_str = ParentVaspInitArgs::parse))]
+    parent_vasps: Option<Vec<ParentVaspInitArgs>>,
 }
 
 /// A raw private key -- either a literal or an unresolved name.
@@ -104,6 +114,86 @@ struct DiemInitArgs {
 enum RawPrivateKey {
     Named(Identifier),
     Anonymous(Ed25519PrivateKey),
+}
+
+/// A fully qualified type name, where the address could be either a literal or an unresolved name.
+#[derive(Debug)]
+struct TypeName {
+    address: RawAddress,
+    module_name: Identifier,
+    type_name: Identifier,
+}
+
+/// Arguments to initialize a parent vasp account.
+#[derive(Debug)]
+struct ParentVaspInitArgs {
+    name: Identifier,
+    currency_type: TypeName,
+}
+
+/*************************************************************************************************
+ *
+ * Parsing
+ *
+ *
+ ************************************************************************************************/
+
+impl TypeName {
+    fn parse(s: &str) -> Result<Self> {
+        let parts = s.split("::").collect::<Vec<_>>();
+
+        if parts.len() != 3 {
+            bail!(
+                "Invalid type name {}. Must be of form <addr>::<module_name>::<type_name>",
+                s
+            )
+        }
+
+        let address = RawAddress::parse(parts[0])?;
+        let module_name = Identifier::new(parts[1])
+            .map_err(|_| format_err!("Invalid module name {}. Expected identifier.", parts[1]))?;
+        let type_name = Identifier::new(parts[1])
+            .map_err(|_| format_err!("Invalid type name {}. Expected identifier.", parts[2]))?;
+
+        Ok(Self {
+            address,
+            module_name,
+            type_name,
+        })
+    }
+}
+
+impl ParentVaspInitArgs {
+    fn parse(s: &str) -> Result<Self> {
+        if let Ok(name) = Identifier::new(s) {
+            return Ok(Self {
+                name,
+                currency_type: TypeName {
+                    address: RawAddress::Named(Identifier::new("DiemFramework").unwrap()),
+                    module_name: XUS_IDENTIFIER.to_owned(),
+                    type_name: XUS_IDENTIFIER.to_owned(),
+                },
+            });
+        }
+
+        let parts = s.split('=').collect::<Vec<_>>();
+        if parts.len() != 2 {
+            bail!("Invalid parent VSAP. Must be either <name> or <name>=<currency_type_tag>, but found {}.", s);
+        }
+
+        let name = Identifier::new(parts[0]).map_err(|_| {
+            format_err!(
+                "Invalid parent vasp name {}. Expected identifier.",
+                parts[0]
+            )
+        })?;
+        let currency_type = TypeName::parse(parts[1])?;
+
+        Ok(Self {
+            name,
+            currency_type,
+        })
+    }
 }
 
 fn parse_identifier(s: &str) -> Result<Identifier> {
@@ -139,6 +229,13 @@ fn parse_named_private_key(s: &str) -> Result<(Identifier, Ed25519PrivateKey)> {
     Ok((name, private_key))
 }
 
+/*************************************************************************************************
+ *
+ * Helpers
+ *
+ *
+ ************************************************************************************************/
+
 /// Default private key mappings for special Diem accounts.
 fn diem_framework_private_key_mapping() -> Vec<(String, Ed25519PrivateKey)> {
     vec![
@@ -147,6 +244,47 @@ fn diem_framework_private_key_mapping() -> Vec<(String, Ed25519PrivateKey)> {
         ("DesignatedDealer".to_string(), GENESIS_KEYPAIR.0.clone()),
     ]
 }
+
+fn panic_missing_private_key_named(cmd_name: &str, name: &IdentStr) -> ! {
+    panic!(
+        "Missing private key. Either add a `--private-key <priv_key>` argument \
+            to the {} command, or associate an address to the \
+            name '{}' in the init command.",
+        cmd_name, name,
+    )
+}
+
+fn panic_missing_private_key(cmd_name: &str) -> ! {
+    panic!(
+        "Missing private key. Try adding a `--private-key <priv_key>` \
+            argument to the {} command.",
+        cmd_name
+    )
+}
+
+static PRECOMPILED_DIEM_FRAMEWORK: Lazy<FullyCompiledProgram> = Lazy::new(|| {
+    let program_res = move_lang::construct_pre_compiled_lib(
+        &diem_framework::diem_stdlib_files(),
+        None,
+        move_lang::Flags::empty().set_sources_shadow_deps(false),
+        diem_framework::diem_framework_named_addresses(),
+    )
+    .unwrap();
+    match program_res {
+        Ok(df) => df,
+        Err((files, errors)) => {
+            eprintln!("!!!Diem Framework failed to compile!!!");
+            move_lang::diagnostics::report_diagnostics(&files, errors)
+        }
+    }
+});
+
+/*************************************************************************************************
+ *
+ * Test Adapter Implementation
+ *
+ *
+ ************************************************************************************************/
 
 impl<'a> DiemTestAdapter<'a> {
     /// Look up the named private key in the mapping.
@@ -278,8 +416,10 @@ impl<'a> DiemTestAdapter<'a> {
         Ok(())
     }
 
-    /// Create a validator account with random address and private key, and bind the generated address
-    /// and private key to the name.
+    /// Create a validator account with the given credentials.
+    ///
+    /// Note: this does not add it to the named address or private key mappings.
+    /// That needs to be done separately.
     fn create_validator_account(
         &mut self,
         validator_name: Identifier,
@@ -310,25 +450,60 @@ impl<'a> DiemTestAdapter<'a> {
         .into_inner();
 
         self.run_transaction(txn)
-            .expect("Failed to create account. This should not happen.")
+            .expect("Failed to create validator account. This should not happen.")
     }
-}
 
-fn panic_missing_private_key_named(cmd_name: &str, name: &IdentStr) -> ! {
-    panic!(
-        "Missing private key. Either add a `--private-key <priv_key>` argument \
-            to the {} command, or associate an address to the \
-            name '{}' in the init command.",
-        cmd_name, name,
-    )
-}
+    /// Create a parent vasp account with the given credentials.
+    ///
+    /// Note: this does not add it to the named address or private key mappings.
+    /// That needs to be done separately.
+    fn create_parent_vasp_account(
+        &mut self,
+        validator_name: Identifier,
+        auth_key_prefix: Vec<u8>,
+        account_addr: AccountAddress,
+        currency_type_name: TypeName,
+    ) {
+        let parameters = self
+            .fetch_default_transaction_parameters(&treasury_compliance_account_address())
+            .unwrap();
 
-fn panic_missing_private_key(cmd_name: &str) -> ! {
-    panic!(
-        "Missing private key. Try adding a `--private-key <priv_key>` \
-            argument to the {} command.",
-        cmd_name
-    )
+        let currency_type_tag = {
+            let address = self
+                .compiled_state()
+                .resolve_address(&currency_type_name.address);
+            TypeTag::Struct(StructTag {
+                address,
+                module: currency_type_name.module_name,
+                name: currency_type_name.type_name,
+                type_params: vec![],
+            })
+        };
+
+        let txn = RawTransaction::new(
+            treasury_compliance_account_address(),
+            parameters.sequence_number,
+            diem_transaction_builder::stdlib::encode_create_parent_vasp_account_script_function(
+                currency_type_tag,
+                0,
+                account_addr,
+                auth_key_prefix,
+                validator_name.as_bytes().into(),
+                false,
+            ),
+            parameters.max_gas_amount,
+            parameters.gas_unit_price,
+            parameters.gas_currency_code,
+            parameters.expiration_timestamp_secs,
+            ChainId::test(),
+        )
+        .sign(&GENESIS_KEYPAIR.0, GENESIS_KEYPAIR.1.clone())
+        .unwrap()
+        .into_inner();
+
+        self.run_transaction(txn)
+            .expect("Failed to create parent vasp account. This should not happen.")
+    }
 }
 
 impl<'a> MoveTestAdapter<'a> for DiemTestAdapter<'a> {
@@ -380,6 +555,7 @@ impl<'a> MoveTestAdapter<'a> for DiemTestAdapter<'a> {
         // Handle extra init args
         let mut keygen = KeyGen::from_seed([0; 32]);
         let mut validators_to_create = vec![];
+        let mut parent_vasps_to_create = vec![];
 
         if let Some(TaskInput {
             command: (_, init_args),
@@ -429,6 +605,43 @@ impl<'a> MoveTestAdapter<'a> for DiemTestAdapter<'a> {
                     validators_to_create.push((validator_name, auth_key_prefix, account_addr));
                 }
             }
+
+            // Parent Vasps
+            if let Some(parent_vasps) = init_args.parent_vasps {
+                for parent_vasp_init_args in parent_vasps {
+                    let parent_vasp_name = parent_vasp_init_args.name;
+                    if named_address_mapping.contains_key(parent_vasp_name.as_str()) {
+                        panic!(
+                            "Invalid validator name {} -- named address already exists.",
+                            parent_vasp_name
+                        )
+                    }
+                    if private_key_mapping.contains_key(&parent_vasp_name) {
+                        panic!(
+                            "Invalid validator name {} -- named private key already exists.",
+                            parent_vasp_name
+                        )
+                    }
+
+                    let (private_key, auth_key_prefix, account_addr) =
+                        keygen.generate_credentials_for_account_creation();
+                    named_address_mapping.insert(
+                        parent_vasp_name.to_string(),
+                        NumericalAddress::new(account_addr.into_bytes(), NumberFormat::Hex),
+                    );
+                    private_key_mapping.insert(parent_vasp_name.clone(), private_key);
+
+                    // Note: parent vasp accounts are created at a later time.
+                    // This is because we need to fetch the sequence number of DiemRoot, which is
+                    // only available after the DiemTestAdapter has been fully initialized.
+                    parent_vasps_to_create.push((
+                        parent_vasp_name,
+                        auth_key_prefix,
+                        account_addr,
+                        parent_vasp_init_args.currency_type,
+                    ));
+                }
+            }
         }
 
         let mut adapter = Self {
@@ -441,6 +654,18 @@ impl<'a> MoveTestAdapter<'a> for DiemTestAdapter<'a> {
         // Create validator accounts
         for (validator_name, auth_key_prefix, account_addr) in validators_to_create {
             adapter.create_validator_account(validator_name, auth_key_prefix, account_addr);
+        }
+
+        // Create parent vasp accounts
+        for (parent_vasp_name, auth_key_prefix, account_addr, currency_type_name) in
+            parent_vasps_to_create
+        {
+            adapter.create_parent_vasp_account(
+                parent_vasp_name,
+                auth_key_prefix,
+                account_addr,
+                currency_type_name,
+            );
         }
 
         adapter
@@ -613,22 +838,12 @@ impl<'a> MoveTestAdapter<'a> for DiemTestAdapter<'a> {
     }
 }
 
-static PRECOMPILED_DIEM_FRAMEWORK: Lazy<FullyCompiledProgram> = Lazy::new(|| {
-    let program_res = move_lang::construct_pre_compiled_lib(
-        &diem_framework::diem_stdlib_files(),
-        None,
-        move_lang::Flags::empty().set_sources_shadow_deps(false),
-        diem_framework::diem_framework_named_addresses(),
-    )
-    .unwrap();
-    match program_res {
-        Ok(df) => df,
-        Err((files, errors)) => {
-            eprintln!("!!!Diem Framework failed to compile!!!");
-            move_lang::diagnostics::report_diagnostics(&files, errors)
-        }
-    }
-});
+/*************************************************************************************************
+ *
+ * Misc
+ *
+ *
+ ************************************************************************************************/
 
 /// Run the Diem transactional test flow, using the given file as input.
 pub fn run_test(path: &Path) -> Result<(), Box<dyn std::error::Error>> {

--- a/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/account_creation.exp
+++ b/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/account_creation.exp
@@ -1,1 +1,1 @@
-processed 3 tasks
+processed 5 tasks

--- a/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/account_creation.move
+++ b/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/account_creation.move
@@ -1,4 +1,4 @@
-//# init --validators Alice Bob
+//# init --validators Alice Bob --parent-vasps Carol Derick=DiemFramework::XDX::XDX
 
 
 
@@ -8,4 +8,14 @@ script { fun main() {} }
 
 
 //# run --signers Bob --admin-script
+script { fun main() {} }
+
+
+
+//# run --signers Carol --admin-script
+script { fun main() {} }
+
+
+
+//# run --signers Derick --admin-script
 script { fun main() {} }

--- a/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/example.exp
+++ b/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/example.exp
@@ -1,15 +1,15 @@
 processed 10 tasks
 
-task 5 'run'. lines 54-62:
+task 5 'run'. lines 55-63:
 Error: Failed to execute transaction. VMStatus: status ABORTED of type Execution with sub status 42
 
-task 6 'run'. lines 63-70:
+task 6 'run'. lines 64-71:
 Error: Failed to execute transaction. VMStatus: status ABORTED of type Execution with sub status 42
 
-task 7 'run'. lines 71-78:
+task 7 'run'. lines 72-79:
 Error: Failed to execute transaction. VMStatus: status ABORTED of type Execution with sub status 42
 
-task 8 'view'. lines 79-85:
+task 8 'view'. lines 80-86:
 key 0x1::DiemAccount::DiemAccount {
     authentication_key: f75daa73fc071f93593335eb9033da804777eb94491650dd3f095ce6f778acb6
     withdraw_capability: copy drop store 0x1::Option::Option<0x1::DiemAccount::WithdrawCapability> {

--- a/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/example.move
+++ b/language/testing-infra/diem-transactional-test-harness/tests/diem_test_harness/example.move
@@ -43,6 +43,7 @@ module A::O {
 }
 
 
+
 // In order to get authenticated and run a transaction script successfully, you *must* provide
 // the correct private key that corresponds to the address and auth key prefix used to create
 // the account, as an additional argument to the run command.


### PR DESCRIPTION
This allows validator accounts to be created during initialization. See the modified test for an example.

Behind the scene, this is just a syntactic sugar for the account creation script.

## Dependencies
#9365, #9485 -- only the last commit belongs to this PR!