### PR TITLE
Cherry-pick PR #9456 into release-1.5: [easy] [move-book] Add packages to SUMMARY

### DIFF
--- a/language/documentation/book/src/SUMMARY.md
+++ b/language/documentation/book/src/SUMMARY.md
@@ -31,6 +31,7 @@
 - [Type Abilities](abilities.md)
 - [Uses and Aliases](uses.md)
 - [Friends](friends.md)
+- [Packages](packages.md)
 
 ## Global Storage
 


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #9456
Please review the diff to ensure there are not any unexpected changes.

> This adds Move packages to the SUMMARY file so that it will be included in the Move Book. 

            
cc @tzakian


Simple edits to Move book documentation so Move package documentation will be picked up.

## If targeting a release branch, please fill the below out as well

* Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)

While we have documentation on how to use Move packages in the Move book due to the file not being in the `SUMMARY` it does not appear on the Move book site. This is a documentation-only change.

* Comprehensive test results that demonstrate the fix working and not breaking existing workflows.

This is a documentation-only change. So will not break any existing code or workflows.

* Why we must have it for V1 launch.

It will be much harder for Move users to understand how to use and work with the Move package system without this documentation being included in the Move book.

* What workarounds and alternative we have if we do not push the PR.

We want to create the book off of a release branch. If we do not push this PR, we would either have to accept not having documentation for packages in the Move book until the next release, or we would have to create the book off of a non-release branch (not optimal either). 