### PR TITLE
ci: use ghcr.io as the container registry for the ci base image

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -40,16 +40,6 @@ runs:
           mv /Users/runner/work/diem/diem /opt/git/diem
           ln -s /opt/git/diem /Users/runner/work/diem/diem
           cd /opt/git/diem
-        else
-          # FIXME delete after GHA image pull outage; this temporarily sets up
-          # the work dir that the rest of the workflow depends on.
-          if [[ ! -d /opt/git/diem ]]; then
-            sudo mkdir -p /opt/git && sudo mkdir -p /opt/cargo
-            sudo chmod -R g+rw /opt/
-            mv /home/runner/work/diem/diem /opt/git/diem
-            ln -s /opt/git/diem /home/runner/work/diem/diem
-            cd /opt/git/diem
-          fi
         fi
 
         # prepare move lang prover tooling.

--- a/.github/actions/build-teardown/action.yml
+++ b/.github/actions/build-teardown/action.yml
@@ -5,8 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Check for changed and untracked files
-      run: |
-        ./scripts/changed-files.sh
+      run: ./scripts/changed-files.sh
       shell: bash
     - name: Clean target directory
       run: |

--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -61,7 +61,7 @@ jobs:
       name: Sccache
     runs-on: ubuntu-20.04-xl
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
@@ -95,7 +95,7 @@ jobs:
     environment:
       name: Sccache
     container:
-      image: diem/build_environment:main
+      image: ghcr.io/diem/diem_build_environment:main
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
@@ -359,7 +359,7 @@ jobs:
     if: ${{ needs.prepare.outputs.changes-target-branch == 'main' && needs.prepare.outputs.rust-changes == 'true'}}
     runs-on: ubuntu-20.04
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:

--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -164,6 +164,33 @@ jobs:
         env:
           DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
 
+  build_ci_base_docker_image_github:
+    needs: prepare
+    runs-on: ubuntu-latest-xl
+    if: ${{ needs.prepare.outputs.base-image-changes == 'true' || github.event_name == 'create' }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}_build_environment
+      IMAGE_TAG: ${{ needs.prepare.outputs.changes-target-branch }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
+          # On `push` this value will be empty and will "do-the-right-thing"
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0 #get all the history!!!
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: build image
+        run: docker build -f docker/ci/github/Dockerfile -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} .
+      - name: Push to ghcr
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+
   run-cluster-test-pre-release-suite:
     needs: prepare
     name: Run the pre-release suite of Cluster Test

--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -127,47 +127,6 @@ jobs:
     needs: prepare
     runs-on: ubuntu-20.04-xl
     if: ${{ needs.prepare.outputs.base-image-changes == 'true' || github.event_name == 'create' }}
-    continue-on-error: false
-    env:
-      DOCKERHUB_ORG: diem
-    environment:
-      name: Docker
-      url: https://hub.docker.com/u/diem
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          # This ensures that the tip of the PR is checked out instead of the merge between the base ref and the tip
-          # On `push` this value will be empty and will "do-the-right-thing"
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0 #get all the history!!!
-      - name: Git Hooks and Checks
-        run: ./scripts/git-checks.sh
-      - name: build image
-        run: docker build -f docker/ci/github/Dockerfile -t ${{ env.DOCKERHUB_ORG }}/build_environment:${{ needs.prepare.outputs.changes-target-branch }} .
-      - name: Sign in to dockerhub, install image signing cert.
-        uses: ./.github/actions/dockerhub_login
-        with:
-          username: ${{ secrets.ENV_DOCKERHUB_USERNAME }}
-          password: ${{ secrets.ENV_DOCKERHUB_PASSWORD }}
-          key_material: ${{ secrets.ENV_DOCKERHUB_KEY_MATERIAL }}
-          key_name: ${{ secrets.ENV_DOCKERHUB_KEY_NAME }}
-          key_password: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
-      - name: Push to dockerhub.
-        run: |
-          if [[ "$DOCKERHUB_LOGGED_IN" == true ]]; then
-            disable_content_trust=true
-            if [[ "$DOCKERHUB_CAN_SIGN" == true ]]; then
-              disable_content_trust=false
-            fi
-            docker push --disable-content-trust=${disable_content_trust} ${{ env.DOCKERHUB_ORG }}/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-          fi
-        env:
-          DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE: ${{ secrets.ENV_DOCKERHUB_KEY_PASSWORD }}
-
-  build_ci_base_docker_image_github:
-    needs: prepare
-    runs-on: ubuntu-latest-xl
-    if: ${{ needs.prepare.outputs.base-image-changes == 'true' || github.event_name == 'create' }}
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}_build_environment

--- a/.github/workflows/ci-post-land.yml
+++ b/.github/workflows/ci-post-land.yml
@@ -60,10 +60,10 @@ jobs:
     environment:
       name: Sccache
     runs-on: ubuntu-20.04-xl
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -94,10 +94,10 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     environment:
       name: Sccache
-    #container:
-      #image: diem/build_environment:main
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:main
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -331,10 +331,10 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.changes-target-branch == 'main' && needs.prepare.outputs.rust-changes == 'true'}}
     runs-on: ubuntu-20.04
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -497,7 +497,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-non-rust-lint == 'true'  }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -527,7 +527,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.any-changes-founds == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
@@ -559,7 +559,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
@@ -605,7 +605,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
@@ -641,7 +641,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     strategy:
@@ -728,7 +728,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' && needs.prepare.outputs.test-compatibility == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
@@ -803,7 +803,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
@@ -831,7 +831,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-test-coverage == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
@@ -939,7 +939,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:
@@ -967,7 +967,7 @@ jobs:
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
     container:
-      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     steps:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -825,38 +825,39 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
 
-  coverage-unit-test:
-    runs-on: ubuntu-20.04-xl
-    timeout-minutes: 30
-    needs: prepare
-    if: ${{ needs.prepare.outputs.test-test-coverage == 'true' }}
-    container:
-      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      volumes:
-        - "${{github.workspace}}:/opt/git/diem"
-    steps:
-      - uses: actions/checkout@v2.3.4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: ./.github/actions/build-setup
-      - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
-        with:
-          key: ${{ needs.prepare.outputs.changes-target-branch }}
-      - name: run coverage tests and verify coverage is calculated.
-        run: |
-          cargo xtest --html-cov-dir=/tmp/results/ -p diem-logger
-          export line_coverage=$( cat /tmp/results/index.html | grep '<abbr' | head -1 | sed 's/<[^>]*>//g' |  sed 's/\..*//g' | sed 's/[[:blank:]]//g' )
-          echo Line Coverage: $line_coverage
-          if (( line_coverage < 80 )); then
-            echo Coverage appears to be broken, diem/logger should report more than 80% line coverage.
-            exit 1;
-          fi
-      - uses: ./.github/actions/build-teardown
-      - name: Early terminate workflow
-        if: ${{ failure() }}
-        uses: ./.github/actions/early-terminator
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+  # Disabling temporarily since code coverage is currently broken with the latest rust release
+  # coverage-unit-test:
+  #   runs-on: ubuntu-20.04-xl
+  #   timeout-minutes: 30
+  #   needs: prepare
+  #   if: ${{ needs.prepare.outputs.test-test-coverage == 'true' }}
+  #   container:
+  #     image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+  #     volumes:
+  #       - "${{github.workspace}}:/opt/git/diem"
+  #   steps:
+  #     - uses: actions/checkout@v2.3.4
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha }}
+  #     - uses: ./.github/actions/build-setup
+  #     - uses: Swatinem/rust-cache@c5ed9ba6b7e1bb8aff90d43acd2f0af4990fa57c
+  #       with:
+  #         key: ${{ needs.prepare.outputs.changes-target-branch }}
+  #     - name: run coverage tests and verify coverage is calculated.
+  #       run: |
+  #         cargo xtest --html-cov-dir=/tmp/results/ -p diem-logger
+  #         export line_coverage=$( cat /tmp/results/index.html | grep '<abbr' | head -1 | sed 's/<[^>]*>//g' |  sed 's/\..*//g' | sed 's/[[:blank:]]//g' )
+  #         echo Line Coverage: $line_coverage
+  #         if (( line_coverage < 80 )); then
+  #           echo Coverage appears to be broken, diem/logger should report more than 80% line coverage.
+  #           exit 1;
+  #         fi
+  #     - uses: ./.github/actions/build-teardown
+  #     - name: Early terminate workflow
+  #       if: ${{ failure() }}
+  #       uses: ./.github/actions/early-terminator
+  #       with:
+  #         github-token: ${{secrets.GITHUB_TOKEN}}
 
   helm-test:
     runs-on: ubuntu-20.04-xl

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -496,8 +496,8 @@ jobs:
     timeout-minutes: 10
     needs: prepare
     if: ${{ needs.prepare.outputs.test-non-rust-lint == 'true'  }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -526,10 +526,10 @@ jobs:
     timeout-minutes: 30
     needs: prepare
     if: ${{ needs.prepare.outputs.any-changes-founds == 'true' }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -558,10 +558,10 @@ jobs:
     timeout-minutes: 60
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -604,10 +604,10 @@ jobs:
     timeout-minutes: 60
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -640,10 +640,10 @@ jobs:
     timeout-minutes: 60
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     strategy:
       fail-fast: false
       matrix:
@@ -727,10 +727,10 @@ jobs:
     timeout-minutes: 40
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' && needs.prepare.outputs.test-compatibility == 'true' }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -802,10 +802,10 @@ jobs:
     timeout-minutes: 60
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -830,10 +830,10 @@ jobs:
     timeout-minutes: 30
     needs: prepare
     if: ${{ needs.prepare.outputs.test-test-coverage == 'true' }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -938,10 +938,10 @@ jobs:
     timeout-minutes: 30
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:
@@ -966,10 +966,10 @@ jobs:
     timeout-minutes: 30
     needs: prepare
     if: ${{ needs.prepare.outputs.test-rust == 'true' }}
-      #container:
-      #image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
-      #volumes:
-      #  - "${{github.workspace}}:/opt/git/diem"
+    container:
+      image: diem/build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -11,7 +11,7 @@ jobs:
   audit:
     runs-on: ubuntu-20.04
     container:
-      image: diem/build_environment:main
+      image: ghcr.io/diem/diem_build_environment:main
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     strategy:
@@ -58,7 +58,7 @@ jobs:
   coverage:
     runs-on: ubuntu-20.04-xl
     container:
-      image: diem/build_environment:main
+      image: ghcr.io/diem/diem_build_environment:main
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     environment:
@@ -106,7 +106,7 @@ jobs:
     # json-rpc interface.
     runs-on: ubuntu-20.04-xl
     container:
-      image: diem/build_environment:main
+      image: ghcr.io/diem/diem_build_environment:main
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     env:
@@ -139,7 +139,7 @@ jobs:
   prover-inconsistency-test:
     runs-on: ubuntu-20.04-xl
     container:
-      image: diem/build_environment:${{ matrix.target-branch }}
+      image: ghcr.io/diem/diem_build_environment:${{ matrix.target-branch }}
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     env:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -9,7 +9,7 @@ jobs:
   dep-report:
     runs-on: ubuntu-latest
     container:
-      image: diem/build_environment:main
+      image: ghcr.io/diem/diem_build_environment:main
     env:
       MESSAGE_PAYLOAD_FILE: /tmp/message
     steps:
@@ -29,7 +29,7 @@ jobs:
   transaction-replay:
     runs-on: ubuntu-latest-xl
     container:
-      image: diem/build_environment:main
+      image: ghcr.io/diem/diem_build_environment:main
       volumes:
         - "${{github.workspace}}:/opt/git/diem"
     env:


### PR DESCRIPTION
Over the past 2 weeks we've been seeing a very large number of CI jobs fail due to a failure to pull the base docker image from dockerhub. In order to avoid this problem use ghcr.io instead of dockerhub as the container registery.