### PR TITLE
[data-client] methods return actual type rather than enum

### DIFF
--- a/state-sync/diem-data-client/src/diemnet/tests.rs
+++ b/state-sync/diem-data-client/src/diemnet/tests.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    DataClientPayload, DataSummaryPoller, DiemDataClient, DiemNetDataClient, Error,
-    DATA_SUMMARY_POLL_INTERVAL,
+    DataSummaryPoller, DiemDataClient, DiemNetDataClient, Error, DATA_SUMMARY_POLL_INTERVAL,
 };
 use channel::{diem_channel, message_queues::QueueStyle};
 use claim::assert_matches;
@@ -177,8 +176,5 @@ async fn test_request_works_only_when_data_available() {
         .await
         .unwrap();
 
-    assert_eq!(
-        response.response_payload,
-        DataClientPayload::TransactionsWithProof(TransactionListWithProof::new_empty())
-    );
+    assert_eq!(response.payload, TransactionListWithProof::new_empty(),);
 }

--- a/state-sync/diem-data-client/src/lib.rs
+++ b/state-sync/diem-data-client/src/lib.rs
@@ -3,8 +3,6 @@
 
 #![forbid(unsafe_code)]
 
-use std::convert::TryFrom;
-
 use async_trait::async_trait;
 use diem_types::{
     account_state_blob::AccountStatesChunkWithProof,
@@ -15,10 +13,13 @@ use diem_types::{
     },
 };
 use serde::{Deserialize, Serialize};
-use storage_service_types::{CompleteDataRange, Epoch, StorageServiceResponse};
+use storage_service::UnexpectedResponseError;
+use storage_service_types::{self as storage_service, CompleteDataRange, Epoch};
 use thiserror::Error;
 
 pub mod diemnet;
+
+pub type Result<T, E = Error> = ::std::result::Result<T, E>;
 
 // TODO(philiphayes): a Error { kind: ErrorKind, inner: BoxError } would be more convenient
 /// An error returned by the Diem Data Client for failed API calls.
@@ -43,6 +44,13 @@ pub enum Error {
     UnexpectedErrorEncountered(String),
 }
 
+// TODO(philiphayes): better error wrapping
+impl From<UnexpectedResponseError> for Error {
+    fn from(err: UnexpectedResponseError) -> Self {
+        Self::InvalidResponse(err.0)
+    }
+}
+
 /// A response error that users of the Diem Data Client can use to notify
 /// the Data Client about invalid or malformed responses.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -55,58 +63,16 @@ pub enum ResponseError {
 /// The API offered by the Diem Data Client.
 #[async_trait]
 pub trait DiemDataClient {
-    /// Returns a single account states chunk with proof, containing the accounts
-    /// from start to end index (inclusive) at the specified version. The proof
-    /// version is the same as the specified version.
-    async fn get_account_states_with_proof(
-        &self,
-        version: u64,
-        start_index: u64,
-        end_index: u64,
-    ) -> Result<DataClientResponse, Error>;
-
-    /// Returns all epoch ending ledger infos between start and end (inclusive).
-    /// If the data cannot be fetched (e.g., the number of epochs is too large),
-    /// an error is returned.
-    async fn get_epoch_ending_ledger_infos(
-        &self,
-        start_epoch: u64,
-        end_epoch: u64,
-    ) -> Result<DataClientResponse, Error>;
-
     /// Returns a global summary of the data currently available in the network.
-    fn get_global_data_summary(&self) -> Result<DataClientResponse, Error>;
-
-    /// Returns the number of account states at the specified version.
-    async fn get_number_of_account_states(&self, version: u64)
-        -> Result<DataClientResponse, Error>;
-
-    /// Returns a transaction output list with proof object, with transaction
-    /// outputs from start to end versions (inclusive). The proof is relative to
-    /// the specified `proof_version`. If the data cannot be fetched (e.g., the
-    /// number of transaction outputs is too large), an error is returned.
-    async fn get_transaction_outputs_with_proof(
-        &self,
-        proof_version: u64,
-        start_version: u64,
-        end_version: u64,
-    ) -> Result<DataClientResponse, Error>;
-
-    /// Returns a transaction list with proof object, with transactions from
-    /// start to end versions (inclusive). The proof is relative to the specified
-    /// `proof_version`. If `include_events` is true, events are included in the
-    /// proof. If the data cannot be fetched (e.g., the number of transactions is
-    /// too large), an error is returned.
-    async fn get_transactions_with_proof(
-        &self,
-        proof_version: u64,
-        start_version: u64,
-        end_version: u64,
-        include_events: bool,
-    ) -> Result<DataClientResponse, Error>;
+    ///
+    /// This API is intended to be relatively cheap to call, usually returning a
+    /// cached view of this data client's available data.
+    fn get_global_data_summary(&self) -> GlobalDataSummary;
 
     /// Notifies the Diem Data Client about a previously received response that
     /// was bad (e.g., invalid or malformed).
+    ///
+    /// This API is intended to be relatively cheap to call.
     ///
     /// Note: this is required because the Diem Data Client can only fetch
     /// data from peers in the network, but it is not able to fully verify that
@@ -115,11 +81,53 @@ pub trait DiemDataClient {
     /// Data Client to alert it to bad responses so that the peers responsible
     /// for providing this data can be penalized. The `response_id` is the handle
     /// used by clients to notify the Diem Data Client of invalid responses.
-    async fn notify_bad_response(
+    fn notify_bad_response(&self, response_id: u64, response_error: ResponseError);
+
+    /// Returns a single account states chunk with proof, containing the accounts
+    /// from start to end index (inclusive) at the specified version. The proof
+    /// version is the same as the specified version.
+    async fn get_account_states_with_proof(
         &self,
-        response_id: u64,
-        response_error: ResponseError,
-    ) -> Result<(), Error>;
+        version: u64,
+        start_account_index: u64,
+        end_account_index: u64,
+    ) -> Result<Response<AccountStatesChunkWithProof>>;
+
+    /// Returns all epoch ending ledger infos between start and end (inclusive).
+    /// If the data cannot be fetched (e.g., the number of epochs is too large),
+    /// an error is returned.
+    async fn get_epoch_ending_ledger_infos(
+        &self,
+        start_epoch: Epoch,
+        expected_end_epoch: Epoch,
+    ) -> Result<Response<Vec<LedgerInfoWithSignatures>>>;
+
+    /// Returns the number of account states at the specified version.
+    async fn get_number_of_account_states(&self, version: Version) -> Result<Response<u64>>;
+
+    /// Returns a transaction output list with proof object, with transaction
+    /// outputs from start to end versions (inclusive). The proof is relative to
+    /// the specified `proof_version`. If the data cannot be fetched (e.g., the
+    /// number of transaction outputs is too large), an error is returned.
+    async fn get_transaction_outputs_with_proof(
+        &self,
+        proof_version: Version,
+        start_version: Version,
+        end_version: Version,
+    ) -> Result<Response<TransactionOutputListWithProof>>;
+
+    /// Returns a transaction list with proof object, with transactions from
+    /// start to end versions (inclusive). The proof is relative to the specified
+    /// `proof_version`. If `include_events` is true, events are included in the
+    /// proof. If the data cannot be fetched (e.g., the number of transactions is
+    /// too large), an error is returned.
+    async fn get_transactions_with_proof(
+        &self,
+        proof_version: Version,
+        start_version: Version,
+        end_version: Version,
+        include_events: bool,
+    ) -> Result<Response<TransactionListWithProof>>;
 }
 
 /// A response from the Data Client for a single API call.
@@ -130,38 +138,79 @@ pub trait DiemDataClient {
 /// the proof failed verification). This can be done using the
 /// `notify_bad_response()` API call above.
 #[derive(Clone, Debug)]
-pub struct DataClientResponse {
-    pub response_id: u64,
-    pub response_payload: DataClientPayload,
+pub struct Response<T> {
+    pub id: u64,
+    pub payload: T,
 }
 
-/// The payload returned in a Data Client response.
+impl<T> Response<T> {
+    pub fn new(id: u64, payload: T) -> Self {
+        Self { id, payload }
+    }
+
+    pub fn into_payload(self) -> T {
+        self.payload
+    }
+
+    pub fn into_parts(self) -> (u64, T) {
+        (self.id, self.payload)
+    }
+
+    pub fn map<U, F>(self, f: F) -> Response<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        let (id, payload) = self.into_parts();
+        Response::new(id, f(payload))
+    }
+
+    pub fn and_then<U, E, F>(self, f: F) -> Result<Response<U>, E>
+    where
+        F: FnOnce(T) -> Result<U, E>,
+    {
+        let (id, payload) = self.into_parts();
+        match f(payload) {
+            Ok(new_payload) => Ok(Response::new(id, new_payload)),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+/// The different data client response payloads as an enum.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum DataClientPayload {
+pub enum ResponsePayload {
     AccountStatesWithProof(AccountStatesChunkWithProof),
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
-    GlobalDataSummary(GlobalDataSummary),
     NumberOfAccountStates(u64),
     TransactionOutputsWithProof(TransactionOutputListWithProof),
     TransactionsWithProof(TransactionListWithProof),
 }
 
-impl TryFrom<StorageServiceResponse> for DataClientPayload {
-    type Error = Error;
+// Conversions from the inner enum variants to the outer enum
 
-    fn try_from(response: StorageServiceResponse) -> Result<Self, Self::Error> {
-        match response {
-            StorageServiceResponse::EpochEndingLedgerInfos(epochs) => Ok(
-                DataClientPayload::EpochEndingLedgerInfos(epochs.ledger_info_with_sigs),
-            ),
-            StorageServiceResponse::TransactionsWithProof(txns) => {
-                Ok(DataClientPayload::TransactionsWithProof(txns))
-            }
-            _ => Err(Error::InvalidResponse(format!(
-                "unrecognized storage service response variant: {:?}",
-                response
-            ))),
-        }
+impl From<AccountStatesChunkWithProof> for ResponsePayload {
+    fn from(inner: AccountStatesChunkWithProof) -> Self {
+        Self::AccountStatesWithProof(inner)
+    }
+}
+impl From<Vec<LedgerInfoWithSignatures>> for ResponsePayload {
+    fn from(inner: Vec<LedgerInfoWithSignatures>) -> Self {
+        Self::EpochEndingLedgerInfos(inner)
+    }
+}
+impl From<u64> for ResponsePayload {
+    fn from(inner: u64) -> Self {
+        Self::NumberOfAccountStates(inner)
+    }
+}
+impl From<TransactionOutputListWithProof> for ResponsePayload {
+    fn from(inner: TransactionOutputListWithProof) -> Self {
+        Self::TransactionOutputsWithProof(inner)
+    }
+}
+impl From<TransactionListWithProof> for ResponsePayload {
+    fn from(inner: TransactionListWithProof) -> Self {
+        Self::TransactionsWithProof(inner)
     }
 }
 

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::streaming_client::Epoch;
-use diem_data_client::DataClientResponse;
+use diem_data_client::{Response, ResponsePayload};
 use diem_types::{
     account_state_blob::AccountStatesChunkWithProof,
     ledger_info::LedgerInfoWithSignatures,
@@ -15,6 +15,9 @@ use std::fmt::{Debug, Formatter};
 
 /// A unique ID used to identify each notification.
 pub type NotificationId = u64;
+
+/// A generic data client response enum.
+pub type DataClientResponse = Response<ResponsePayload>;
 
 /// A single data notification with an ID and data payload.
 #[derive(Clone, Debug)]

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use claim::{assert_ge, assert_none};
 use diem_data_client::{
-    AdvertisedData, DataClientPayload, DataClientResponse, GlobalDataSummary, OptimalChunkSizes,
+    AdvertisedData, GlobalDataSummary, OptimalChunkSizes, Response, ResponsePayload,
 };
 use diem_id_generator::U64IdGenerator;
 use diem_infallible::Mutex;
@@ -95,10 +95,10 @@ async fn test_stream_invalid_response() {
     });
     let pending_response = PendingClientResponse {
         client_request: client_request.clone(),
-        client_response: Some(Ok(DataClientResponse {
-            response_id: 0,
-            response_payload: DataClientPayload::NumberOfAccountStates(10),
-        })),
+        client_response: Some(Ok(Response::new(
+            0,
+            ResponsePayload::NumberOfAccountStates(10),
+        ))),
     };
     insert_response_into_pending_queue(&mut data_stream, pending_response);
 
@@ -237,7 +237,7 @@ fn set_epoch_ending_response_in_queue(
     let (sent_requests, _) = data_stream.get_sent_requests_and_notifications();
     let pending_response = sent_requests.as_mut().unwrap().get_mut(index).unwrap();
     let client_response = Some(Ok(create_data_client_response(
-        DataClientPayload::EpochEndingLedgerInfos(vec![create_ledger_info(
+        ResponsePayload::EpochEndingLedgerInfos(vec![create_ledger_info(
             0,
             MIN_ADVERTISED_EPOCH,
             true,

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_progress_tracker.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_progress_tracker.rs
@@ -2,15 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_notification::{DataClientRequest, EpochEndingLedgerInfosRequest},
+    data_notification::{DataClientRequest, DataClientResponse, EpochEndingLedgerInfosRequest},
     error::Error,
     stream_progress_tracker::{DataStreamTracker, EpochEndingStreamTracker, StreamProgressTracker},
     streaming_client::{GetAllEpochEndingLedgerInfosRequest, StreamRequest},
 };
 use claim::{assert_matches, assert_ok};
-use diem_data_client::{
-    DataClientPayload, DataClientResponse, GlobalDataSummary, OptimalChunkSizes,
-};
+use diem_data_client::{GlobalDataSummary, OptimalChunkSizes, Response, ResponsePayload};
 use diem_id_generator::U64IdGenerator;
 use std::{cmp, sync::Arc};
 use storage_service_types::CompleteDataRange;
@@ -283,8 +281,5 @@ fn create_notification_id_generator() -> Arc<U64IdGenerator> {
 }
 
 fn create_empty_client_response() -> DataClientResponse {
-    DataClientResponse {
-        response_id: 0,
-        response_payload: DataClientPayload::EpochEndingLedgerInfos(vec![]),
-    }
+    Response::new(0, ResponsePayload::EpochEndingLedgerInfos(vec![]))
 }

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![forbid(unsafe_code)]
 
+use std::convert::TryFrom;
+
 use diem_types::{
     account_state_blob::AccountStatesChunkWithProof,
     epoch_change::EpochChangeProof,
@@ -68,6 +70,119 @@ pub enum StorageServiceResponse {
     StorageServerSummary(StorageServerSummary),
     TransactionOutputsWithProof(TransactionOutputListWithProof),
     TransactionsWithProof(TransactionListWithProof),
+}
+
+// TODO(philiphayes): is there a proc-macro for this?
+impl StorageServiceResponse {
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::AccountStatesChunkWithProof(_) => "AccountStatesChunkWithProof",
+            Self::EpochEndingLedgerInfos(_) => "EpochEndingLedgerInfos",
+            Self::NumberOfAccountsAtVersion(_) => "NumberOfAccountsAtVersion",
+            Self::ServerProtocolVersion(_) => "ServerProtocolVersion",
+            Self::StorageServerSummary(_) => "StorageServerSummary",
+            Self::TransactionOutputsWithProof(_) => "TransactionOutputsWithProof",
+            Self::TransactionsWithProof(_) => "TransactionsWithProof",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Error)]
+#[error("unexpected response variant: {0}")]
+pub struct UnexpectedResponseError(pub String);
+
+// Conversions from the outer StorageServiceResponse enum to the inner types.
+// TODO(philiphayes): is there a proc-macro for this?
+
+impl TryFrom<StorageServiceResponse> for AccountStatesChunkWithProof {
+    type Error = UnexpectedResponseError;
+    fn try_from(response: StorageServiceResponse) -> Result<Self, Self::Error> {
+        match response {
+            StorageServiceResponse::AccountStatesChunkWithProof(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected AccountStatesChunkWithProof found {}",
+                response.name()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for EpochChangeProof {
+    type Error = UnexpectedResponseError;
+    fn try_from(response: StorageServiceResponse) -> Result<Self, Self::Error> {
+        match response {
+            StorageServiceResponse::EpochEndingLedgerInfos(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected EpochEndingLedgerInfos found {}",
+                response.name()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for u64 {
+    type Error = UnexpectedResponseError;
+    fn try_from(response: StorageServiceResponse) -> Result<Self, Self::Error> {
+        match response {
+            StorageServiceResponse::NumberOfAccountsAtVersion(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected NumberOfAccountsAtVersion found {}",
+                response.name()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for ServerProtocolVersion {
+    type Error = UnexpectedResponseError;
+    fn try_from(response: StorageServiceResponse) -> Result<Self, Self::Error> {
+        match response {
+            StorageServiceResponse::ServerProtocolVersion(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected ServerProtocolVersion found {}",
+                response.name()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for StorageServerSummary {
+    type Error = UnexpectedResponseError;
+    fn try_from(response: StorageServiceResponse) -> Result<Self, Self::Error> {
+        match response {
+            StorageServiceResponse::StorageServerSummary(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected StorageServerSummary found {}",
+                response.name()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for TransactionOutputListWithProof {
+    type Error = UnexpectedResponseError;
+    fn try_from(response: StorageServiceResponse) -> Result<Self, Self::Error> {
+        match response {
+            StorageServiceResponse::TransactionOutputsWithProof(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected TransactionOutputsWithProof found {}",
+                response.name()
+            ))),
+        }
+    }
+}
+
+impl TryFrom<StorageServiceResponse> for TransactionListWithProof {
+    type Error = UnexpectedResponseError;
+    fn try_from(response: StorageServiceResponse) -> Result<Self, Self::Error> {
+        match response {
+            StorageServiceResponse::TransactionsWithProof(inner) => Ok(inner),
+            _ => Err(UnexpectedResponseError(format!(
+                "expected TransactionsWithProof found {}",
+                response.name()
+            ))),
+        }
+    }
 }
 
 /// A storage service request for fetching a list of account states at a


### PR DESCRIPTION
This change modifies the DiemDataClient API so that each method returns the actual, inner type rather than the outer generic enum. For example,

before:


```rust
trait DiemDataClient {
    async fn get_transactions_with_proof(..) -> Result<Response<ResponsePayload>>;
    // ..
}
```

after:

```rust
trait DiemDataClient {
    async fn get_transactions_with_proof(..) -> Result<Response<TransacationListWithProof>>;
    // ..
}
```

In order to keep the change small, I'm not touching anything in data-streaming-service too deeply, other than fixing up some conversions from the exact types to the generic enum (which is a bit silly imo). ideally, we can take advantage of the more precise API in data-streaming-service so we don't to match on the response type in every single method : p