### PR TITLE
[WIP][move] Add failing test for toycoin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5011,6 +5011,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-documentation-book-transactional-tests"
+version = "0.0.0"
+dependencies = [
+ "datatest-stable",
+ "diem-workspace-hack",
+ "move-transactional-test-runner",
+]
+
+[[package]]
 name = "move-explain"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ members = [
     "language/diem-vm",
     "language/diem-vm/mvhashmap",
     "language/diem-vm/parallel-executor",
+    "language/documentation/book/transactional-tests",
     "language/e2e-testsuite",
     "language/ir-testsuite",
     "language/move-analyzer",

--- a/language/documentation/book/transactional-tests/Cargo.toml
+++ b/language/documentation/book/transactional-tests/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "move-documentation-book-transactional-tests"
+version = "0.0.0"
+authors = ["Diem Association <opensource@diem.com>"]
+publish = false
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+diem-workspace-hack = { path = "../../../../common/workspace-hack" }
+
+[dev-dependencies]
+datatest-stable = "0.1.1"
+move-transactional-test-runner = { path = "../../../testing-infra/transactional-test-runner" }
+
+[[test]]
+name = "tests"
+harness = false

--- a/language/documentation/book/transactional-tests/tests/creating-coins.exp
+++ b/language/documentation/book/transactional-tests/tests/creating-coins.exp
@@ -1,0 +1,9 @@
+processed 2 tasks
+
+task 1 'run'. lines 10-17:
+Error: error[E04001]: restricted visibility
+   ┌─ <tmp-file-name>:14:21
+   │
+14 │         let _coin = Coin { value: 100 };
+   │                     ^^^^^^^^^^^^^^^^^^^ Invalid instantiation of '0x2::Coin::Coin'.
+All structs can only be constructed in the module in which they are declared

--- a/language/documentation/book/transactional-tests/tests/creating-coins.move
+++ b/language/documentation/book/transactional-tests/tests/creating-coins.move
@@ -1,0 +1,17 @@
+//# publish
+address 0x2 {
+    module Coin {
+        struct Coin {
+            value: u64,
+        }
+    }
+}
+
+//# run
+script {
+    use 0x2::Coin::Coin;
+
+    fun main() {
+        let _coin = Coin { value: 100 };
+    }
+}

--- a/language/documentation/book/transactional-tests/tests/tests.rs
+++ b/language/documentation/book/transactional-tests/tests/tests.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub const TEST_DIR: &str = "tests";
+use move_transactional_test_runner::vm_test_harness::run_test;
+
+datatest_stable::harness!(run_test, TEST_DIR, r".*\.move$");

--- a/language/move-lang/src/diagnostics/codes.rs
+++ b/language/move-lang/src/diagnostics/codes.rs
@@ -149,7 +149,7 @@ codes!(
     ],
     // errors for typing rules. mostly typing/translate
     TypeSafety: [
-        Visibility: { msg: "restricted visibility", severity: NonblockingError },
+        Visibility: { msg: "restricted visibility", severity: BlockingError },
         ScriptContext: { msg: "requires script context", severity: NonblockingError },
         BuiltinOperation: { msg: "built-in operation not supported", severity: BlockingError },
         ExpectedBaseType: { msg: "expected a single non-reference type", severity: BlockingError },


### PR DESCRIPTION
When following the instructions in the Move book to create a toy coin module and script, the first script example fails to compile:

```
env RUST_BACKTRACE=1 ~/src/diem/target/debug/move sandbox run src/scripts/test-coin.move
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', language/move-lang/src/to_bytecode/translate.rs:1005:77
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/std/src/panicking.rs:515:5
   1: core::panicking::panic_fmt
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/panicking.rs:92:14
   2: core::panicking::panic
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/panicking.rs:50:5
   3: core::option::Option<T>::unwrap
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/option.rs:388:21
   4: move_lang::to_bytecode::translate::exp_
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/to_bytecode/translate.rs:1005:52
   5: move_lang::to_bytecode::translate::exp
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/to_bytecode/translate.rs:906:5
   6: move_lang::to_bytecode::translate::command
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/to_bytecode/translate.rs:825:13
   7: move_lang::to_bytecode::translate::function_body
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/to_bytecode/translate.rs:659:13
   8: move_lang::to_bytecode::translate::function
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/to_bytecode/translate.rs:536:34
   9: move_lang::to_bytecode::translate::script
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/to_bytecode/translate.rs:276:29
  10: move_lang::to_bytecode::translate::program
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/to_bytecode/translate.rs:135:29
  11: move_lang::command_line::compiler::run
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:756:17
  12: move_lang::command_line::compiler::run
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:746:13
  13: move_lang::command_line::compiler::run
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:735:13
  14: move_lang::command_line::compiler::run
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:724:13
  15: move_lang::command_line::compiler::run
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:713:13
  16: move_lang::command_line::compiler::run
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:702:13
  17: move_lang::command_line::compiler::SteppedCompiler<_>::run_impl
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:236:24
  18: move_lang::command_line::compiler::SteppedCompiler<_>::run
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:293:21
  19: move_lang::command_line::compiler::Compiler::run::{{closure}}
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:179:13
  20: core::result::Result<T,E>::and_then
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/result.rs:704:22
  21: move_lang::command_line::compiler::Compiler::run
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:178:43
  22: move_lang::command_line::compiler::Compiler::build
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:203:28
  23: move_lang::command_line::compiler::Compiler::build_and_report
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/move-lang/src/command_line/compiler.rs:211:34
  24: move_cli::sandbox::commands::run::run::compile_script
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/tools/move-cli/src/sandbox/commands/run.rs:50:40
  25: move_cli::sandbox::commands::run::run
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/tools/move-cli/src/sandbox/commands/run.rs:96:26
  26: move_cli::sandbox::cli::SandboxCommand::handle_command
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/tools/move-cli/src/sandbox/cli.rs:214:17
  27: move_cli::run_cli
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/tools/move-cli/src/lib.rs:171:13
  28: move_cli::move_cli
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/tools/move-cli/src/lib.rs:185:5
  29: move::main
             at /mnt/2f619639-61cb-4088-9cde-d4cf731903e4/diem/language/tools/move-cli/src/main.rs:9:5
  30: core::ops::function::FnOnce::call_once
             at /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

Currently I don't believe we have tests for the examples in the Move book. Add a test harness for these, as well as a failing test for the toy coin example.