### PR TITLE
[move-model] allow extra checks in type instantiations for built-ins

### DIFF
--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -1468,6 +1468,25 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     expected_type,
                     "in expression",
                 );
+                // calls to built-in functions might have additional requirements on the types
+                match cand.oper {
+                    Operation::Exists(_) | Operation::Global(_) => {
+                        let ty_inst = &instantiation[0];
+                        if !matches!(ty_inst, Type::Struct(..)) {
+                            self.error(
+                                loc,
+                                &format!(
+                                    "Expect a struct type as the type instantiation for an \
+                                    operation on the global state, found: {}",
+                                    ty_inst.display(&self.type_display_context())
+                                ),
+                            );
+                            return self.new_error_exp();
+                        }
+                    }
+                    _ => (),
+                };
+
                 // Construct result.
                 let id = self.new_node_id_with_type_loc(&ty, loc);
                 self.set_node_instantiation(id, instantiation);

--- a/language/move-model/src/builder/exp_translator.rs
+++ b/language/move-model/src/builder/exp_translator.rs
@@ -1476,8 +1476,8 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                             self.error(
                                 loc,
                                 &format!(
-                                    "Expect a struct type as the type instantiation for an \
-                                    operation on the global state, found: {}",
+                                    "The type argument to `exists` and `global` must be a struct \
+                                    type but {} is not a struct type.",
                                     ty_inst.display(&self.type_display_context())
                                 ),
                             );

--- a/language/move-model/tests/sources/invariants_err.exp
+++ b/language/move-model/tests/sources/invariants_err.exp
@@ -19,6 +19,24 @@ error: invalid reference to post state
    │     │         expression referring to post state
    │     not allowed to refer to post state
 
+error: The type argument to `exists` and `global` must be a struct type but u64 is not a struct type.
+   ┌─ tests/sources/invariants_err.move:36:15
+   │
+36 │     invariant exists<u64>(@0x0);
+   │               ^^^^^^^^^^^^^^^^^
+
+error: The type argument to `exists` and `global` must be a struct type but #0 is not a struct type.
+   ┌─ tests/sources/invariants_err.move:37:18
+   │
+37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);
+   │                  ^^^^^^^^^^^^^^^
+
+error: The type argument to `exists` and `global` must be a struct type but #0 is not a struct type.
+   ┌─ tests/sources/invariants_err.move:37:37
+   │
+37 │     invariant<T> global<T>(@0x1) == global<T>(@0x2);
+   │                                     ^^^^^^^^^^^^^^^
+
 error: data invariants cannot depend on global state (directly or indirectly uses a global spec var or resource storage).
    ┌─ tests/sources/invariants_err.move:13:5
    │

--- a/language/move-model/tests/sources/invariants_err.move
+++ b/language/move-model/tests/sources/invariants_err.move
@@ -31,4 +31,8 @@ module 0x42::M {
          rec_fun(!c)
       }
     }
+
+    // Type instantiation for global memory operations is not a struct type
+    invariant exists<u64>(@0x0);
+    invariant<T> global<T>(@0x1) == global<T>(@0x2);
 }


### PR DESCRIPTION
Some built-in spec functions have more restricted rules on what can go
into a type instantiation than normal user functions.

For example, `exists<T>`, in this case, the instantiation for `T` must
be a struct type and cannot be other types.

This commit added the check for `exists` and `global`.

Before this commit, if we have an invariant
```
invariant<T> exists<T>(@0x2);
```
The invariant will lead to a panic in the model building phase.

With this commit, it triggers an error with some illustration printed
out.

## Motivation

Panics don't help much with writing correct spec. Error messages do.

In fact, I was trying to write a test case to illustrate the potential loophole
in our invariant analysis framework, until I realize that this is not possible.

```move
module 0x2::M {
  invariant<T> global<T>(@0x1) == global<T>(@0x2);
}

module 0x2::A {
  struct S has key, store, drop {}
  fun foo() acquires S {
    move_from<S>(@0x2);
  }
}
```

This counter example is supposed to show that our claim:
> All functions that can ever be constrained by the invariant are in `GlobalEnv`, might not hold
Because `foo` is constrained by `invariant<T>` but these two modules might not live in the same file.

And then I realize that it is impossible to write such an invariant, precisely because we do not allow
a type parameter in `exists` or `global`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

A new test case is added
