### PR TITLE
[move-model] remove redundant built-ins

### DIFF
--- a/language/move-model/src/builder/spec_builtins.rs
+++ b/language/move-model/src/builder/spec_builtins.rs
@@ -273,29 +273,6 @@ pub(crate) fn declare_spec_builtins(trans: &mut ModelBuilder<'_>) {
                 result_type: param_t.clone(),
             },
         );
-        // TODO(emmazzz): declaring these as builtins will allow users to
-        // use borrow_global and borrow_global_mut in specs. Later we should
-        // map them to `global` instead.
-        trans.define_spec_fun(
-            trans.builtin_qualified_symbol("borrow_global"),
-            SpecFunEntry {
-                loc: loc.clone(),
-                oper: Operation::Global(None),
-                type_params: vec![param_t.clone()],
-                arg_types: vec![address_t.clone()],
-                result_type: param_t.clone(),
-            },
-        );
-        trans.define_spec_fun(
-            trans.builtin_qualified_symbol("borrow_global_mut"),
-            SpecFunEntry {
-                loc: loc.clone(),
-                oper: Operation::Global(None),
-                type_params: vec![param_t.clone()],
-                arg_types: vec![address_t.clone()],
-                result_type: param_t.clone(),
-            },
-        );
         trans.define_spec_fun(
             trans.builtin_qualified_symbol("exists"),
             SpecFunEntry {


### PR DESCRIPTION
We probably don't need this and should educate the users to use `global`
consistently.

## Motivation

Consistency of the spec language.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI, there should be no dependencies on these two functions.
