### PR TITLE
[shuffle] shuffle transactions with --tailing flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7524,9 +7524,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
+checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -7746,16 +7746,20 @@ dependencies = [
  "move-package",
  "once_cell",
  "rand 0.8.4",
+ "reqwest",
  "serde",
  "serde-generate",
  "serde-reflection",
+ "serde_json",
  "serde_yaml",
  "shuffle-custom-node",
  "shuffle-transaction-builder",
  "structopt 0.3.21",
  "tempfile",
+ "tokio",
  "toml",
  "transaction-builder-generator",
+ "url",
 ]
 
 [[package]]

--- a/common/workspace-hack/Cargo.toml
+++ b/common/workspace-hack/Cargo.toml
@@ -54,7 +54,7 @@ regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
 serde = { version = "1.0.130", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.67", features = ["default", "indexmap", "preserve_order", "std"] }
+serde_json = { version = "1.0.68", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
@@ -114,7 +114,7 @@ regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
 serde = { version = "1.0.130", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.67", features = ["default", "indexmap", "preserve_order", "std"] }
+serde_json = { version = "1.0.68", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }
@@ -173,7 +173,7 @@ regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
 serde = { version = "1.0.130", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.67", features = ["default", "indexmap", "preserve_order", "std"] }
+serde_json = { version = "1.0.68", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 tiny-keccak = { version = "2.0.2", features = ["default", "sha3"] }
@@ -233,7 +233,7 @@ regex-syntax = { version = "0.6.23", features = ["default", "unicode", "unicode-
 reqwest = { version = "0.11.2", features = ["__tls", "blocking", "default", "default-tls", "hyper-tls", "json", "native-tls-crate", "serde_json", "stream", "tokio-native-tls"] }
 rusty-fork = { version = "0.3.0", features = ["default", "timeout", "wait-timeout"] }
 serde = { version = "1.0.130", features = ["alloc", "default", "derive", "rc", "serde_derive", "std"] }
-serde_json = { version = "1.0.67", features = ["default", "indexmap", "preserve_order", "std"] }
+serde_json = { version = "1.0.68", features = ["default", "indexmap", "preserve_order", "std"] }
 standback = { version = "0.2.15", default-features = false, features = ["std"] }
 subtle = { version = "2.4.0", default-features = false, features = ["std"] }
 syn-3575ec1268b04181 = { package = "syn", version = "0.15.44", features = ["clone-impls", "default", "derive", "extra-traits", "full", "parsing", "printing", "proc-macro", "quote", "visit"] }

--- a/shuffle/cli/Cargo.toml
+++ b/shuffle/cli/Cargo.toml
@@ -17,9 +17,12 @@ hex = "0.4.3"
 include_dir = { version = "0.6.0", features = ["glob"] }
 once_cell = "1.7.2"
 rand = "0.8.4"
+reqwest = { version = "0.11.2", features = ["blocking", "json"] }
 serde = { version = "1.0.124", features = ["derive"] }
 structopt = "0.3.21"
+tokio = { version = "1.8.1", features = ["full"] }
 toml = "0.5.8"
+url = { version = "2.2.2" }
 
 abigen = { path = "../../language/move-prover/abigen" }
 diemdb = { path = "../../storage/diemdb" }
@@ -41,6 +44,7 @@ shuffle-custom-node = { path = "../genesis" }
 shuffle-transaction-builder = { path = "../transaction-builder" }
 serde-reflection = "0.3.4"
 serde-generate = "0.20.2"
+serde_json = "1.0.68"
 serde_yaml = "0.8.17"
 transaction-builder-generator = { path = "../../language/transaction-builder/generator" }
 

--- a/shuffle/cli/src/transactions.rs
+++ b/shuffle/cli/src/transactions.rs
@@ -1,0 +1,241 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+use crate::shared::{get_home_path, Home};
+use anyhow::{anyhow, Result};
+use diem_types::account_address::AccountAddress;
+use reqwest::{Client, Response};
+use serde_json::Value;
+use std::{cmp::max, fs, io, io::Write, str::FromStr, thread, time};
+use url::Url;
+
+// Will list the last 10 transactions and has the ability to block and stream future transactions.
+pub async fn handle(network: Url, tail: bool) -> Result<()> {
+    let home = Home::new(get_home_path().as_path())?;
+    let address_str = fs::read_to_string(home.get_latest_address_path())?;
+    let address = AccountAddress::from_str(address_str.as_str())?;
+    let client = reqwest::Client::new();
+
+    let account_seq_num = get_account_sequence_number(&client, &network, address).await?;
+    let mut prev_seq_num = max(account_seq_num as i64 - 10, 0);
+
+    let resp =
+        get_account_transactions_response(&client, address, &network, prev_seq_num, 10).await?;
+    let json_with_txns: serde_json::Value = serde_json::from_str(resp.text().await?.as_str())?;
+
+    let all_transactions = json_with_txns
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("Failed to get transactions"))?;
+
+    write_out_txns(all_transactions.to_vec(), &mut io::stdout())?;
+
+    if !all_transactions.is_empty() {
+        prev_seq_num = parse_txn_for_seq_num(
+            all_transactions
+                .last()
+                .ok_or_else(|| anyhow!("Couldn't get last transaction"))?,
+        )?
+    } else {
+        // Setting to -1 to handle the case where sequence number is 0 and
+        // we don't have a previous sequence number
+        prev_seq_num = -1;
+    }
+
+    if tail {
+        // listening for incoming transactions
+        loop {
+            thread::sleep(time::Duration::from_millis(1000));
+            let resp = get_account_transactions_response(
+                &client,
+                address,
+                &network,
+                prev_seq_num + 1,
+                100,
+            )
+            .await?;
+            let json_with_txns: serde_json::Value =
+                serde_json::from_str(resp.text().await?.as_str())?;
+            let txn_array = json_with_txns
+                .as_array()
+                .ok_or_else(|| anyhow!("Couldn't convert to array"))?
+                .to_vec();
+
+            // checking if there are transactions
+            if txn_array.is_empty() {
+                continue;
+            }
+            let last_txn_seq_num = parse_txn_for_seq_num(
+                txn_array
+                    .last()
+                    .ok_or_else(|| anyhow!("Couldn't get last transaction"))?,
+            )?;
+            if last_txn_seq_num > prev_seq_num {
+                write_out_txns(txn_array, &mut io::stdout())?;
+            }
+            prev_seq_num = last_txn_seq_num;
+        }
+    }
+    Ok(())
+}
+
+fn write_out_txns<W: Write>(all_transactions: Vec<Value>, mut stdout: W) -> Result<()> {
+    for txn in all_transactions.iter() {
+        write_into(&mut stdout, txn)?;
+    }
+
+    Ok(())
+}
+
+async fn get_account_transactions_response(
+    client: &Client,
+    address: AccountAddress,
+    network: &Url,
+    start: i64,
+    limit: u64,
+) -> Result<Response> {
+    let path = network.join(format!("accounts/{}/transactions", address).as_str())?;
+    Ok(client
+        .get(path.as_str())
+        .query(&[("start", start.to_string().as_str())])
+        .query(&[("limit", limit.to_string().as_str())])
+        .send()
+        .await?)
+}
+
+async fn get_account_sequence_number(
+    client: &Client,
+    network: &Url,
+    address: AccountAddress,
+) -> Result<u64> {
+    let path =
+        network.join(format!("accounts/{}/resources/", address.to_hex_literal()).as_str())?;
+    let resp = client.get(path.as_str()).send().await?;
+    let json: Vec<Value> = serde_json::from_str(resp.text().await?.as_str())?;
+    parse_json_for_account_seq_num(json)
+}
+
+fn parse_txn_for_seq_num(last_txn: &Value) -> Result<i64> {
+    Ok(last_txn["sequence_number"]
+        .to_string()
+        .replace('"', "")
+        .parse::<i64>()?)
+}
+
+fn parse_json_for_account_seq_num(json_objects: Vec<Value>) -> Result<u64> {
+    let mut seq_number_string = "";
+    for object in &json_objects {
+        if object["type"]["name"] == "DiemAccount" {
+            seq_number_string = object["value"]["sequence_number"]
+                .as_str()
+                .ok_or_else(|| anyhow!("Invalid sequence number string"))?;
+            break;
+        };
+    }
+    let seq_number: u64 = seq_number_string.parse()?;
+    Ok(seq_number)
+}
+
+fn write_into<W>(writer: &mut W, json: &serde_json::Value) -> io::Result<()>
+where
+    W: Write,
+{
+    writeln!(writer, "{}", json)?;
+    writeln!(writer)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json::{json, Value};
+
+    fn get_sample_txn() -> Value {
+        json!([{
+            "type":"user_transaction",
+            "version":"268",
+            "hash":"0x8be63c23e88f9d0290f060e33fe09e8a755e45f41ee0fc9447f3b5d97a8b88d1",
+            "state_root_hash":"0x8d903f9df4092946f036164fa925c6716a172ee0140f2404371393e517b7058e",
+            "event_root_hash":"0x414343554d554c41544f525f504c414345484f4c4445525f4841534800000000",
+            "gas_used":"8",
+            "success":true,
+            "vm_status":"Executed successfully",
+            "sender":"0x24163afcc6e33b0a9473852e18327fa9",
+            "sequence_number":"2",
+            "max_gas_amount":"1000000",
+            "gas_unit_price":"0",
+            "gas_currency_code":"XUS",
+            "expiration_timestamp_secs":"1635800460",
+            "payload":{}
+        },{
+            "type":"user_transaction",
+            "version":"270",
+            "hash":"0x42343251",
+            "state_root_hash":"0x3434235",
+            "event_root_hash":"0x3434235",
+            "gas_used":"5",
+            "success":true,
+            "vm_status":"Executed successfully",
+            "sender":"0x24163afcc6e33b0a9473852e18327fa9",
+            "sequence_number":"3",
+            "max_gas_amount":"1000000",
+            "gas_unit_price":"0",
+            "gas_currency_code":"XUS",
+            "expiration_timestamp_secs":"1635800460",
+            "payload":{}
+        }])
+    }
+
+    #[test]
+    fn test_parse_json_for_seq_num() {
+        let value_obj = json!({
+            "type" : {
+                "type": "struct",
+                "address": "0x1",
+                "module": "DiemAccount",
+                "name": "DiemAccount",
+            },
+            "value": {
+                "authentication_key": "0x1",
+                "received_events" : {
+                    "counter":"0",
+                    "guid": {}
+                },
+                "sent_events":{},
+                "sequence_number": "3",
+                "withdraw_capability":{}
+            }
+        });
+
+        let json_obj: Vec<Value> = vec![value_obj];
+        let ret_seq_num = parse_json_for_account_seq_num(json_obj).unwrap();
+        assert_eq!(ret_seq_num, 3);
+    }
+
+    #[test]
+    fn test_write_into() {
+        let mut stdout = Vec::new();
+        let txn = get_sample_txn();
+        write_into(&mut stdout, &txn[0]).unwrap();
+        assert_eq!(
+            txn[0].to_string() + "\n\n",
+            String::from_utf8(stdout).unwrap().as_str()
+        );
+    }
+
+    #[test]
+    fn test_write_out_txns_stdout() {
+        let all_txns = get_sample_txn();
+        let txn_array = all_txns.as_array().unwrap();
+        let mut stdout = Vec::new();
+        write_out_txns(txn_array.to_vec(), &mut stdout).unwrap();
+        assert_eq!(
+            String::from_utf8(stdout).unwrap().as_str(),
+            txn_array[0].to_string() + "\n\n" + &*txn_array[1].to_string() + "\n\n"
+        )
+    }
+
+    #[test]
+    fn test_parse_seq_num() {
+        let txn = get_sample_txn();
+        let seq_num = parse_txn_for_seq_num(&txn[0]).unwrap();
+        assert_eq!(seq_num, 2);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We want a command that will list the last 10 transactions and have an option to block and stream future transactions as they happen. This PR does this!

## Test Plan

I ran cargo run -p shuffle -- transactions -t in a terminal. Notice how the terminal is waiting: 

<img width="1169" alt="Screen Shot 2021-10-28 at 1 41 24 PM" src="https://user-images.githubusercontent.com/55404786/139333921-7b391c5a-775e-4b65-b2bb-d7c97a1c5133.png">

I ran cargo run -p shuffle -- deploy "project_path" in another terminal:

<img width="769" alt="Screen Shot 2021-10-28 at 1 44 30 PM" src="https://user-images.githubusercontent.com/55404786/139334057-dec92d58-054e-47e9-a1b0-54e1b32ba6ca.png">

When I return to the window with shuffle transactions running, I see a populated list of transactions:

<img width="1780" alt="Screen Shot 2021-11-01 at 11 54 05 AM" src="https://user-images.githubusercontent.com/55404786/139725517-c9a4a816-d865-4660-8501-684b136f91a1.png">

To confirm that this worked properly, I ran shuffle console in another window and ran await Shuffle.accountTransactions() to get a list of my last transactions. 

<img width="1780" alt="Screen Shot 2021-11-01 at 11 54 27 AM" src="https://user-images.githubusercontent.com/55404786/139725489-4dc897be-8977-4e94-9121-7ae621b2cbdf.png">

Notice that the hash in this picture (0x789...) matches the hash of the last transaction in the transactions window. 


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
