### PR TITLE
[api] change type representation to string format instead of nested object

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -496,7 +496,7 @@ components:
         Prefixed with `0x` and leading zeros are trimmed.
 
 
-        See [doc](https://github.com/diem/diem/blob/main/language/documentation/book/src/address.md) for more details.
+        See [doc](https://diem.github.io/move/address.html) for more details.
       example: "0xdd"
     HexEncodedBytes:
       type: string
@@ -573,168 +573,138 @@ components:
         - value
       properties:
         type:
-          $ref: '#/components/schemas/MoveTypeStruct'
+          $ref: '#/components/schemas/MoveStructTagID'
         value:
           type: "object"
           description: >-
             Account resource data value, deserialized from Move data, field name map to field value, use `type` field information to decode.
-    MoveTypeBool:
-      type: object
-      description: >-
-        Move type `bool`
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - bool
-    MoveTypeU8:
-      type: object
-      description: >-
-        Move type `u8`
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - u8
-    MoveTypeU64:
-      type: object
-      description: >-
-        Move type `u64`
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - u64
-    MoveTypeU128:
-      type: object
-      description: >-
-        Move type `u128`
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - u128
-    MoveTypeAddress:
-      type: object
-      description: >-
-        Move type `address`
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - address
-    MoveTypeSigner:
-      type: object
-      description: >-
-        Move type `signer`
-      required:
-        - type
-      properties:
-        type:
-          type: string
-          enum:
-            - signer
-    MoveTypeVector:
-      type: object
-      description: Move type `vector`.
-      required:
-        - type
-        - items
-      properties:
-        type:
-          type: string
-          enum:
-            - vector
-          items:
-            $ref: '#/components/schemas/MoveType'
-    MoveTypeStruct:
-      type: object
-      description: >-
-        Move type `struct` referencing to an on-chain struct definition.
-      required:
-        - type
-        - address
-        - module
-        - name
-        - generic_type_params
-      properties:
-        type:
-          type: string
-          enum:
-            - struct
-        address:
-          $ref: '#/components/schemas/address'
-        module:
-          type: string
-          description: Module identifier / name, case sensitive.
-          example: "Diem"
-        name:
-          type: string
-          description: Struct name, case sensitive.
-          example: "Diem"
-        generic_type_params:
-          type: array
-          items:
-            $ref: '#/components/schemas/MoveType'
-    MoveTypeGenericTypeParam:
-      type: object
-      description: >-
-        Move type generic type param, used for referencing to a generic type param defined
-        in the struct / function generaic type parameters.
-      required:
-        - type
-        - index
-      properties:
-        type:
-          type: string
-          enum:
-            - generic_type_param
-        index:
-          type: integer
-    MoveTypeReference:
-      type: object
-      description: >-
-        Move type reference, used for defining a reference type.
-      required:
-        - type
-        - mutable
-        - to
-      properties:
-        type:
-          type: string
-          enum:
-            - reference
-        mutable:
-          type: boolean
-        to:
-          $ref: '#/components/schemas/MoveType'
-    MoveType:
+    MoveTypeTagID:
       oneOf:
-        - $ref: '#/components/schemas/MoveTypeBool'
-        - $ref: '#/components/schemas/MoveTypeU8'
-        - $ref: '#/components/schemas/MoveTypeU64'
-        - $ref: '#/components/schemas/MoveTypeU128'
-        - $ref: '#/components/schemas/MoveTypeAddress'
-        - $ref: '#/components/schemas/MoveTypeSigner'
-        - $ref: '#/components/schemas/MoveTypeVector'
-        - $ref: '#/components/schemas/MoveTypeStruct'
-        - $ref: '#/components/schemas/MoveTypeGenericTypeParam'
-        - $ref: '#/components/schemas/MoveTypeReference'
+        - $ref: '#/components/schemas/MovePrimitiveTypeID'
+        - $ref: '#/components/schemas/MoveVectorTypeID'
+        - $ref: '#/components/schemas/MoveStructTagID'
+    MoveTypeID:
+      oneOf:
+        - $ref: '#/components/schemas/MovePrimitiveTypeID'
+        - $ref: '#/components/schemas/MoveVectorTypeID'
+        - $ref: '#/components/schemas/MoveStructTagID'
+        - $ref: '#/components/schemas/MoveReferenceTypeID'
+        - $ref: '#/components/schemas/MoveGenericTypeID'
+    MovePrimitiveTypeID:
+      type: string
+      format: move_type
+      enum:
+        - bool
+        - u8
+        - u64
+        - u128
+        - address
+        - signer
+    MoveVectorTypeID:
+      type: string
+      format: move_type
+      pattern: '^vector<.+>$'
+      description: >-
+        String representation of an on-chain Move vector: `vector<{non-reference MoveTypeID}>`
+
+
+        Examples:
+          * `vector<u8>`
+          * `vector<vector<u64>>`
+          * `vector<0x1::DiemAccount::Balance<0x1::XDX::XDX>>`
+
+
+        See [doc](https://diem.github.io/move/vector.html) for more details.
+      example:
+        - "vector<u8>"
+    MoveStructTagID:
+      type: string
+      format: move_type
+      pattern: '^0x[0-9a-zA-Z:_<>]+$'
+      description: >-
+        String representation of an on-chain Move struct.
+
+
+        It is a combination of:
+          1. `Move module address`, `module name` and `struct name` joined by `::`.
+          2. `struct generic type parameters` joined by `, `.
+
+
+        Examples:
+          * `0x1::Diem::Diem<0x1::XDX::XDX>`
+          * `0x1::Abc::Abc<vector<u8>, vector<u64>>`
+          * `0x1::DiemAccount::AccountOperationsCapability`
+
+
+        Note:
+          1. Empty chars should be ignored when comparing 2 struct tag ids.
+          2. When used in an URL path, should be encoded by url-encoding (AKA percent-encoding).
+
+
+        See [doc](https://diem.github.io/move/structs-and-resources.html) for more details.
+      example:
+        - "0x1::DiemAccount::DiemAccount"
+    MoveReferenceTypeID:
+      type: string
+      format: move_type
+      pattern: '^&(mut )?.+$'
+      description: >-
+        A reference type string representation.
+
+
+        Move has two types of references: immutable `&` and mutable `&mut`.
+        For example:
+          * `&signer`
+          * `&mut address`
+          * `&mut vector<u8>`
+
+
+        See [doc](https://diem.github.io/move/references.html) for more details.
+      example: >-
+        &signer
+    MoveGenericTypeID:
+      type: string
+      format: move_type
+      pattern: '^T\d+$'
+      description: >-
+        A generic type parameter type string representation.
+
+
+        It is always start with `T` and following an index number, which
+        is the position of the generic type parameter in the `struct` or
+        `function` generic type parameters definition.
+
+
+        For example, the following is `0x1::TransactionFee::TransactionFee` JSON representation:
+
+            {
+                "name": "TransactionFee",
+                "is_native": false,
+                "abilities": ["key"],
+                "generic_type_params": [
+                    {"constraints": [], "is_phantom": true}
+                ],
+                "fields": [
+                    { "name": "balance", "type": "0x1::Diem::Diem<T0>" },
+                    { "name": "preburn", "type": "0x1::Diem::Preburn<T0>" }
+                ]
+            }
+
+        It's Move source code:
+
+            module DiemFramework::TransactionFee {
+                struct TransactionFee<phantom CoinType> has key {
+                    balance: Diem<CoinType>,
+                    preburn: Preburn<CoinType>,
+                }
+            }
+
+        The `T0` in the above JSON representation is the generic type place holder for
+        the `CoinType` in the Move source code.
     MoveModuleBytecode:
       type: object
       required:
         - bytecode
-        - abi
       properties:
         bytecode:
           $ref: '#/components/schemas/HexEncodedBytes'
@@ -766,32 +736,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MoveStruct'
-    MoveStructTagID:
-      type: string
-      format: struct_tag_id
-      description: >-
-        String representation of an on-chain Move struct.
-
-
-        It is a combination of:
-          1. `Move module address`, `module name` and `struct name` joined by `::`.
-          2. `struct generic type parameters` joined by `, `.
-
-
-        Examples:
-          * `0x1::Diem::Diem<0x1::XDX::XDX>`
-          * `0x1::Abc::Abc<vector<u8>, vector<u64>>`
-          * `0x1::DiemAccount::AccountOperationsCapability`
-
-
-        Note:
-          1. Empty chars should be ignored when comparing 2 struct tag ids.
-          2. When used in an URL path, should be encoded by url-encoding (AKA percent-encoding).
-
-
-        See [doc](https://github.com/diem/diem/blob/main/language/documentation/book/src/structs-and-resources.md) for more details.
-      example:
-        - "0x1::DiemAccount::DiemAccount"
     MoveStruct:
       type: object
       required:
@@ -836,7 +780,7 @@ components:
         name:
           type: string
         type:
-          $ref: '#/components/schemas/MoveType'
+          $ref: '#/components/schemas/MoveTypeID'
     MoveFunction:
       type: object
       required:
@@ -870,11 +814,11 @@ components:
         params:
           type: array
           items:
-            $ref: '#/components/schemas/MoveType'
+            $ref: '#/components/schemas/MoveTypeID'
         return:
           type: array
           items:
-            $ref: '#/components/schemas/MoveType'
+            $ref: '#/components/schemas/MoveTypeID'
     MoveAbility:
       type: string
       enum:
@@ -882,6 +826,11 @@ components:
         - drop
         - store
         - key
+      description: >-
+        Abilities are a typing feature in Move that control what actions are permissible for values of a given type.
+
+
+        See [doc](https://diem.github.io/move/abilities.html) for more details.
     MoveModuleId:
       type: object
       required:
@@ -1152,7 +1101,7 @@ components:
           type: array
           description: Generic type arguments required by the script function.
           items:
-            $ref: '#/components/schemas/MoveType'
+            $ref: '#/components/schemas/MoveTypeTagID'
         arguments:
           type: array
           description: The script function arguments.
@@ -1175,7 +1124,7 @@ components:
         type_arguments:
           type: array
           items:
-            $ref: '#/components/schemas/MoveType'
+            $ref: '#/components/schemas/MoveTypeTagID'
         arguments:
           type: array
           items:
@@ -1280,7 +1229,7 @@ components:
         address:
           $ref: '#/components/schemas/address'
         resource:
-          $ref: '#/components/schemas/MoveTypeStruct'
+          $ref: '#/components/schemas/MoveStructTagID'
     WriteModule:
       type: object
       description: Write move module
@@ -1325,7 +1274,7 @@ components:
         type_arguments:
           type: array
           items:
-            $ref: '#/components/schemas/MoveType'
+            $ref: '#/components/schemas/MoveTypeTagID'
         arguments:
           type: array
           items:
@@ -1392,7 +1341,7 @@ components:
         sequence_number:
           $ref: '#/components/schemas/EventSequenceNumber'
         type:
-          $ref: '#/components/schemas/MoveType'
+          $ref: '#/components/schemas/MoveTypeTagID'
         data:
           $ref: '#/components/schemas/MoveValue'
     TransactionSignature:

--- a/api/src/tests/accounts_test.rs
+++ b/api/src/tests/accounts_test.rs
@@ -73,26 +73,12 @@ async fn test_account_resources_response() {
     let resp = context.get(&account_resources(address)).await;
 
     let res = find_value(&resp, |v| {
-        v["type"]["name"] == "Balance" && v["type"]["generic_type_params"][0]["name"] == "XDX"
+        v["type"] == "0x1::DiemAccount::Balance<0x1::XDX::XDX>"
     });
     assert_json(
         res,
         json!({
-            "type": {
-                "type": "struct",
-                "address": "0x1",
-                "module": "DiemAccount",
-                "name": "Balance",
-                "generic_type_params": [
-                    {
-                        "type": "struct",
-                        "address": "0x1",
-                        "module": "XDX",
-                        "name": "XDX",
-                        "generic_type_params": []
-                    }
-                ]
-            },
+            "type": "0x1::DiemAccount::Balance<0x1::XDX::XDX>",
             "value": {
                 "coin": {
                     "value": "0"
@@ -127,23 +113,9 @@ async fn test_account_modules() {
                         }
                     ],
                     "params": [
-                        {
-                            "type": "reference",
-                            "mutable": false,
-                            "to": {
-                                "type": "generic_type_param",
-                                "index": 0
-                            }
-                        }
+                        "&T0"
                     ],
-                    "return": [
-                        {
-                            "type": "vector",
-                            "items": {
-                                "type": "u8"
-                            }
-                        }
-                    ]
+                    "return": ["vector<u8>"]
                 }
             ],
             "structs": []
@@ -174,13 +146,10 @@ async fn test_get_module_with_script_functions() {
                         }
                     ],
                     "params": [
-                        {"type": "signer"},
-                        {"type": "signer"},
-                        {"type": "u64"},
-                        {
-                            "type": "vector",
-                            "items": {"type": "u8"}
-                        }
+                        "signer",
+                        "signer",
+                        "u64",
+                        "vector<u8>"
                     ],
                     "return": []
                 },
@@ -193,17 +162,11 @@ async fn test_get_module_with_script_functions() {
                         }
                     ],
                     "params": [
-                        {"type": "signer"},
-                        {"type": "address"},
-                        {"type": "u64"},
-                        {
-                            "type": "vector",
-                            "items": {"type": "u8"}
-                        },
-                        {
-                            "type": "vector",
-                            "items": {"type": "u8"}
-                        }
+                        "signer",
+                        "address",
+                        "u64",
+                        "vector<u8>",
+                        "vector<u8>"
                     ],
                     "return": []
                 }
@@ -266,10 +229,7 @@ async fn test_get_module_diem_config() {
                     ],
                     "params": [],
                     "return": [
-                        {
-                            "type": "generic_type_param",
-                            "index": 0
-                        }
+                        "T0"
                     ]
                 },
                 {
@@ -277,13 +237,7 @@ async fn test_get_module_diem_config() {
                     "visibility": "public",
                     "generic_type_params": [],
                     "params": [
-                        {
-                            "type": "reference",
-                            "mutable": false,
-                            "to": {
-                                "type": "signer"
-                            }
-                        }
+                        "&signer"
                     ],
                     "return": []
                 },
@@ -300,17 +254,8 @@ async fn test_get_module_diem_config() {
                         }
                     ],
                     "params": [
-                        {
-                            "type": "reference",
-                            "mutable": false,
-                            "to": {
-                                "type": "signer"
-                            }
-                        },
-                        {
-                            "type": "generic_type_param",
-                            "index": 0
-                        }
+                        "&signer",
+                        "T0"
                     ],
                     "return": []
                 },
@@ -327,31 +272,11 @@ async fn test_get_module_diem_config() {
                         }
                     ],
                     "params": [
-                        {
-                            "type": "reference",
-                            "mutable": false,
-                            "to": {
-                                "type": "signer"
-                            }
-                        },
-                        {
-                            "type": "generic_type_param",
-                            "index": 0
-                        }
+                        "&signer",
+                        "T0"
                     ],
                     "return": [
-                        {
-                            "type": "struct",
-                            "address": "0x1",
-                            "module": "DiemConfig",
-                            "name": "ModifyConfigCapability",
-                            "generic_type_params": [
-                                {
-                                    "type": "generic_type_param",
-                                    "index": 0
-                                }
-                            ]
-                        }
+                        "0x1::DiemConfig::ModifyConfigCapability<T0>"
                     ]
                 },
                 {
@@ -359,13 +284,7 @@ async fn test_get_module_diem_config() {
                     "visibility": "public",
                     "generic_type_params": [],
                     "params": [
-                        {
-                            "type": "reference",
-                            "mutable": false,
-                            "to": {
-                                "type": "signer"
-                            }
-                        }
+                        "&signer"
                     ],
                     "return": []
                 },
@@ -382,17 +301,8 @@ async fn test_get_module_diem_config() {
                         }
                     ],
                     "params": [
-                        {
-                            "type": "reference",
-                            "mutable": false,
-                            "to": {
-                                "type": "signer"
-                            }
-                        },
-                        {
-                            "type": "generic_type_param",
-                            "index": 0
-                        }
+                        "&signer",
+                        "T0"
                     ],
                     "return": []
                 },
@@ -409,26 +319,8 @@ async fn test_get_module_diem_config() {
                         }
                     ],
                     "params": [
-                        {
-                            "type": "reference",
-                            "mutable": false,
-                            "to": {
-                                "type": "struct",
-                                "address": "0x1",
-                                "module": "DiemConfig",
-                                "name": "ModifyConfigCapability",
-                                "generic_type_params": [
-                                    {
-                                        "type": "generic_type_param",
-                                        "index": 0
-                                    }
-                                ]
-                            }
-                        },
-                        {
-                            "type": "generic_type_param",
-                            "index": 0
-                        }
+                        "&0x1::DiemConfig::ModifyConfigCapability<T0>",
+                        "T0"
                     ],
                     "return": []
                 }
@@ -444,33 +336,15 @@ async fn test_get_module_diem_config() {
                     "fields": [
                         {
                             "name": "epoch",
-                            "type": {
-                                "type": "u64"
-                            }
+                            "type": "u64"
                         },
                         {
                             "name": "last_reconfiguration_time",
-                            "type": {
-                                "type": "u64"
-                            }
+                            "type": "u64"
                         },
                         {
                             "name": "events",
-                            "type": {
-                                "type": "struct",
-                                "address": "0x1",
-                                "module": "Event",
-                                "name": "EventHandle",
-                                "generic_type_params": [
-                                    {
-                                        "type": "struct",
-                                        "address": "0x1",
-                                        "module": "DiemConfig",
-                                        "name": "NewEpochEvent",
-                                        "generic_type_params": []
-                                    }
-                                ]
-                            }
+                            "type": "0x1::Event::EventHandle<0x1::DiemConfig::NewEpochEvent>"
                         }
                     ]
                 },
@@ -494,10 +368,7 @@ async fn test_get_module_diem_config() {
                     "fields": [
                         {
                             "name": "payload",
-                            "type": {
-                                "type": "generic_type_param",
-                                "index": 0
-                            }
+                            "type": "T0"
                         }
                     ]
                 },
@@ -511,9 +382,7 @@ async fn test_get_module_diem_config() {
                     "fields": [
                         {
                             "name": "dummy_field",
-                            "type": {
-                                "type": "bool"
-                            }
+                            "type": "bool"
                         }
                     ]
                 },
@@ -533,9 +402,7 @@ async fn test_get_module_diem_config() {
                     "fields": [
                         {
                             "name": "dummy_field",
-                            "type": {
-                                "type": "bool"
-                            }
+                            "type": "bool"
                         }
                     ]
                 },
@@ -550,9 +417,7 @@ async fn test_get_module_diem_config() {
                     "fields": [
                         {
                             "name": "epoch",
-                            "type": {
-                                "type": "u64"
-                            }
+                            "type": "u64"
                         }
                     ]
                 }
@@ -589,18 +454,7 @@ async fn test_account_modules_structs() {
             "fields": [
                 {
                     "name": "coin",
-                    "type": {
-                        "type": "struct",
-                        "address": "0x1",
-                        "module": "Diem",
-                        "name": "Diem",
-                        "generic_type_params": [
-                            {
-                                "type": "generic_type_param",
-                                "index": 0
-                            }
-                        ]
-                    }
+                    "type": "0x1::Diem::Diem<T0>"
                 }
             ]
         }),
@@ -625,9 +479,7 @@ async fn test_account_modules_structs() {
             "fields": [
                 {
                     "name": "value",
-                    "type": {
-                        "type": "u64"
-                    }
+                    "type": "u64"
                 }
             ]
         }),
@@ -647,7 +499,7 @@ async fn test_get_account_resources_by_ledger_version() {
         ))
         .await;
     let tc_account = find_value(&ledger_version_1_resources, |f| {
-        f["type"]["name"] == "DiemAccount"
+        f["type"] == "0x1::DiemAccount::DiemAccount"
     });
     assert_eq!(tc_account["value"]["sequence_number"], "1");
 
@@ -658,7 +510,7 @@ async fn test_get_account_resources_by_ledger_version() {
         ))
         .await;
     let tc_account = find_value(&ledger_version_0_resources, |f| {
-        f["type"]["name"] == "DiemAccount"
+        f["type"] == "0x1::DiemAccount::DiemAccount"
     });
     assert_eq!(tc_account["value"]["sequence_number"], "0");
 }

--- a/api/src/tests/events_test.rs
+++ b/api/src/tests/events_test.rs
@@ -18,13 +18,7 @@ async fn test_get_events() {
         json!({
           "key": "0x00000000000000000000000000000000000000000a550c18",
           "sequence_number": "0",
-          "type": {
-            "type": "struct",
-            "address": "0x1",
-            "module": "DiemAccount",
-            "name": "CreateAccountEvent",
-            "generic_type_params": []
-          },
+          "type": "0x1::DiemAccount::CreateAccountEvent",
           "data": {
             "created": "0xa550c18",
             "role_id": "0"
@@ -46,13 +40,7 @@ async fn test_get_events_filter_by_start_sequence_number() {
         json!({
           "key": "0x00000000000000000000000000000000000000000a550c18",
           "sequence_number": "1",
-          "type": {
-            "type": "struct",
-            "address": "0x1",
-            "module": "DiemAccount",
-            "name": "CreateAccountEvent",
-            "generic_type_params": []
-          },
+          "type": "0x1::DiemAccount::CreateAccountEvent",
           "data": {
             "created": "0xb1e55ed",
             "role_id": "1"
@@ -103,13 +91,7 @@ async fn test_get_events_by_account_event_handle() {
         json!({
           "key": "0x00000000000000000000000000000000000000000a550c18",
           "sequence_number": "0",
-          "type": {
-            "type": "struct",
-            "address": "0x1",
-            "module": "DiemAccount",
-            "name": "CreateAccountEvent",
-            "generic_type_params": []
-          },
+          "type": "0x1::DiemAccount::CreateAccountEvent",
           "data": {
             "created": "0xa550c18",
             "role_id": "0"

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -74,27 +74,15 @@ async fn test_get_transactions_output_genesis_transaction() {
                             "visibility": "public",
                             "generic_type_params": [],
                             "params": [],
-                            "return": [
-                                {
-                                    "type": "u8"
-                                }
-                            ]
+                            "return": ["u8"]
                         },
                         {
                             "name": "initialize",
                             "visibility": "public",
                             "generic_type_params": [],
                             "params": [
-                                {
-                                    "type": "reference",
-                                    "mutable": false,
-                                    "to": {
-                                        "type": "signer"
-                                    }
-                                },
-                                {
-                                    "type": "u8"
-                                }
+                                "&signer",
+                                "u8"
                             ],
                             "return": []
                         }
@@ -110,9 +98,7 @@ async fn test_get_transactions_output_genesis_transaction() {
                             "fields": [
                                 {
                                     "name": "id",
-                                    "type": {
-                                        "type": "u8"
-                                    }
+                                    "type": "u8"
                                 }
                             ]
                         }
@@ -125,7 +111,7 @@ async fn test_get_transactions_output_genesis_transaction() {
     let chain_id = find_value(&txn["payload"]["write_set"]["changes"], |val| {
         val["type"] == "write_resource"
             && val["address"] == "0xdd"
-            && val["data"]["type"]["name"] == "RoleId"
+            && val["data"]["type"] == "0x1::Roles::RoleId"
     });
     assert_json(
         chain_id,
@@ -133,13 +119,7 @@ async fn test_get_transactions_output_genesis_transaction() {
             "type": "write_resource",
             "address": "0xdd",
             "data": {
-                "type": {
-                    "type": "struct",
-                    "address": "0x1",
-                    "module": "Roles",
-                    "name": "RoleId",
-                    "generic_type_params": []
-                },
+                "type": "0x1::Roles::RoleId",
                 "value": {
                     "role_id": "2"
                 }
@@ -158,13 +138,7 @@ async fn test_get_transactions_output_genesis_transaction() {
         json!({
             "key": "0x00000000000000000000000000000000000000000a550c18",
             "sequence_number": "0",
-            "type": {
-                "type": "struct",
-                "address": "0x1",
-                "module": "DiemAccount",
-                "name": "CreateAccountEvent",
-                "generic_type_params": []
-            },
+            "type": "0x1::DiemAccount::CreateAccountEvent",
             "data": {
                 "created": "0xa550c18",
                 "role_id": "0"
@@ -326,13 +300,7 @@ async fn test_get_transactions_output_user_transaction_with_script_function_payl
                 {
                     "key": "0x00000000000000000000000000000000000000000a550c18",
                     "sequence_number": "5",
-                    "type": {
-                        "type": "struct",
-                        "address": "0x1",
-                        "module": "DiemAccount",
-                        "name": "CreateAccountEvent",
-                        "generic_type_params": []
-                    },
+                    "type": "0x1::DiemAccount::CreateAccountEvent",
                     "data": {
                         "created": account.address().to_hex_literal(),
                         "role_id": "5"
@@ -347,13 +315,7 @@ async fn test_get_transactions_output_user_transaction_with_script_function_payl
                 },
                 "function": "create_parent_vasp_account",
                 "type_arguments": [
-                    {
-                        "type": "struct",
-                        "address": "0x1",
-                        "module": "XUS",
-                        "name": "XUS",
-                        "generic_type_params": []
-                    }
+                    "0x1::XUS::XUS"
                 ],
                 "arguments": [
                     "0",
@@ -404,19 +366,8 @@ async fn test_get_transactions_output_user_transaction_with_script_payload() {
                     "visibility": "script",
                     "generic_type_params": [],
                     "params": [
-                        {
-                            "type": "reference",
-                            "mutable": false,
-                            "to": {
-                                "type": "signer"
-                            }
-                        },
-                        {
-                            "type": "vector",
-                            "items": {
-                                "type": "u8"
-                            }
-                        }
+                        "&signer",
+                        "vector<u8>"
                     ],
                     "return": []
                 }
@@ -462,11 +413,7 @@ async fn test_get_transactions_output_user_transaction_with_module_payload() {
                         "visibility": "public",
                         "generic_type_params": [],
                         "params": [],
-                        "return": [
-                            {
-                                "type": "u8"
-                            }
-                        ]
+                        "return": ["u8"]
                     }
                 ],
                 "structs": []
@@ -536,13 +483,7 @@ async fn test_get_transactions_output_user_transaction_with_write_set_payload() 
                     {
                         "type": "delete_resource",
                         "address": "0xb1e55ed",
-                        "resource": {
-                            "type": "struct",
-                            "address": "0x1",
-                            "module": "AccountFreezing",
-                            "name": "FreezingBit",
-                            "generic_type_params": []
-                        }
+                        "resource": "0x1::AccountFreezing::FreezingBit"
                     }
                 ],
                 "events": []
@@ -592,13 +533,7 @@ async fn test_post_bcs_format_transaction() {
                 },
                 "function": "create_parent_vasp_account",
                 "type_arguments": [
-                    {
-                        "type": "struct",
-                        "address": "0x1",
-                        "module": "XUS",
-                        "name": "XUS",
-                        "generic_type_params": []
-                    }
+                    "0x1::XUS::XUS"
                 ],
                 "arguments": [
                     "0",
@@ -940,13 +875,7 @@ async fn test_signing_message_with_script_function_payload() {
         "module": { "address": "0x1", "name": "AccountCreationScripts"},
         "function": "create_parent_vasp_account",
         "type_arguments": [
-            {
-                "type": "struct",
-                "address": "0x1",
-                "module": "XUS",
-                "name": "XUS",
-                "generic_type_params": []
-            }
+            "0x1::XUS::XUS"
         ],
         "arguments": [
             "0",     // sliding_nonce
@@ -1062,13 +991,7 @@ async fn test_signing_message_with_write_set_payload() {
                 {
                     "type": "delete_resource",
                     "address": "0xb1e55ed",
-                    "resource": {
-                        "type": "struct",
-                        "address": "0x1",
-                        "module": "AccountFreezing",
-                        "name": "FreezingBit",
-                        "generic_type_params": []
-                    }
+                    "resource": "0x1::AccountFreezing::FreezingBit"
                 }
             ],
             "events": []

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -22,8 +22,7 @@ pub use hash::HashValue;
 pub use ledger_info::LedgerInfo;
 pub use move_types::{
     HexEncodedBytes, MoveFunction, MoveModule, MoveModuleBytecode, MoveModuleId, MoveResource,
-    MoveResourceType, MoveScriptBytecode, MoveStructTag, MoveStructValue, MoveType, MoveValue,
-    U128, U64,
+    MoveScriptBytecode, MoveStructTag, MoveStructValue, MoveType, MoveValue, U128, U64,
 };
 pub use response::{Response, X_DIEM_CHAIN_ID, X_DIEM_LEDGER_TIMESTAMP, X_DIEM_LEDGER_VERSION};
 pub use transaction::{

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     Address, EventKey, HashValue, HexEncodedBytes, MoveModuleBytecode, MoveModuleId, MoveResource,
-    MoveResourceType, MoveScriptBytecode, MoveType, MoveValue, U64,
+    MoveScriptBytecode, MoveStructTag, MoveType, MoveValue, U64,
 };
 
 use diem_crypto::{
@@ -340,7 +340,7 @@ pub enum WriteSetChange {
     },
     DeleteResource {
         address: Address,
-        resource: MoveResourceType,
+        resource: MoveStructTag,
     },
     WriteModule {
         address: Address,

--- a/shuffle/cli/repl.ts
+++ b/shuffle/cli/repl.ts
@@ -73,20 +73,14 @@ export async function modules(addr: string | undefined) {
 // Gets the sender address's account resource from the developer API.
 // Example payload below:
 // {
-//   "type": {
-//     "type": "struct",
-//     "address": "0x1",
-//     "module": "DiemAccount",
-//     "name": "DiemAccount",
-//     "generic_type_params": []
-//   },
+//   "type": "0x1::DiemAccount::DiemAccount",
 //   "value": {
 //     "sequence_number": "2",
 export async function account() {
   const res = await resources(senderAddress);
   return res.
   find(
-      (entry: any) => entry["type"]["name"] == "DiemAccount"
+      (entry: any) => entry["type"] == "0x1::DiemAccount::DiemAccount"
   );
 }
 

--- a/shuffle/move/examples/main/mod.ts
+++ b/shuffle/move/examples/main/mod.ts
@@ -102,7 +102,7 @@ export async function createTestNFTScriptFunction(
 export function resourcesWithName(resources: any[], resourceName: string) {
   return resources
     .filter(
-      (entry) => entry["type"]["name"] == resourceName,
+      (entry) => entry["type"].split("::", 3)[2] == resourceName,
     );
 }
 


### PR DESCRIPTION
#9193 we render Move type as JSON object with nested type objects when there is generic type parameters. For example:

```
{
   "type": "struct",
   "address": "0x1",
   "module": "DiemAccount",
   "name": "Balance",
   "generic_type_params": [
       { "type": "struct", "address": "0x1", "module": "XDX", "name": "XDX" }
   ]
 }
```

We started with this representation because it is easier to be deserialized into `StructTag` type when a client send a request with type field (e.g. ScriptFunctionPayload generic type parameters).

This PR changes the move type representation to string format, for example, above struct definition can be rendered as:
```
"0x1::DiemAccount::Balance<0x1::XDX::XDX>"
```
This is much more cleaner and readable format comparing with above JSON object.

I found we have a parser can parse Move type string format into `TypeTag` (which includes `StructTag` type) recently, 
so parsing the string format is not a problem anymore.

For client language that is not Rust, they may need to build a parser to fully parse out this string, but in general I don't think it is must have.
Client can simply use string split or regex to parse out address, module name and struct name (with generic types), and it is very rare to define a type that has complex generic types (e.g. nested generic types).

Another API in plan is we are going to provide JSON schema API for a Move type, it's likely good enough for a client want to interpreter the Move type without building a parser.

