### PR TITLE
[move-bytecode-util] Move ModuleCache to `move-bytecode-util`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,6 +2775,7 @@ dependencies = [
  "fail",
  "mirai-annotations",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-core-types",
  "move-stdlib",
  "move-vm-runtime",
@@ -6762,6 +6763,7 @@ dependencies = [
  "anyhow",
  "diem-workspace-hack",
  "move-binary-format",
+ "move-bytecode-utils",
  "move-core-types",
  "read-write-set-types",
 ]

--- a/diem-move/diem-vm/Cargo.toml
+++ b/diem-move/diem-vm/Cargo.toml
@@ -28,6 +28,7 @@ move-core-types = { path = "../../language/move-core/types" }
 move-vm-runtime = { path = "../../language/move-vm/runtime" }
 move-vm-types = { path = "../../language/move-vm/types" }
 move-binary-format = { path = "../../language/move-binary-format" }
+move-bytecode-utils = { path = "../../language/tools/move-bytecode-utils" }
 move-stdlib = { path = "../../language/move-stdlib" }
 diem-framework = { path = "../../diem-move/diem-framework" }
 serde_json = "1.0.64"

--- a/diem-move/diem-vm/src/read_write_set_analysis.rs
+++ b/diem-move/diem-vm/src/read_write_set_analysis.rs
@@ -13,7 +13,7 @@ use diem_types::{
     account_config,
     transaction::{SignedTransaction, TransactionPayload},
 };
-use move_binary_format::layout::ModuleCache;
+use move_bytecode_utils::module_cache::SyncModuleCache;
 use move_core_types::{
     ident_str,
     identifier::{IdentStr, Identifier},
@@ -27,7 +27,7 @@ use std::ops::Deref;
 
 pub struct ReadWriteSetAnalysis<'a, R: ModuleResolver> {
     normalized_analysis_result: &'a NormalizedReadWriteSetAnalysis,
-    module_cache: ModuleCache<&'a R>,
+    module_cache: SyncModuleCache<&'a R>,
     blockchain_view: &'a R,
 }
 
@@ -53,7 +53,7 @@ impl<'a, R: MoveResolver> ReadWriteSetAnalysis<'a, R> {
     pub fn new(rw: &'a NormalizedReadWriteSetAnalysis, blockchain_view: &'a R) -> Self {
         ReadWriteSetAnalysis {
             normalized_analysis_result: rw,
-            module_cache: ModuleCache::new(blockchain_view),
+            module_cache: SyncModuleCache::new(blockchain_view),
             blockchain_view,
         }
     }

--- a/language/move-binary-format/src/lib.rs
+++ b/language/move-binary-format/src/lib.rs
@@ -20,7 +20,6 @@ pub mod deserializer;
 pub mod file_format;
 pub mod file_format_common;
 pub mod internals;
-pub mod layout;
 pub mod normalized;
 #[cfg(any(test, feature = "fuzzing"))]
 pub mod proptest_types;

--- a/language/tools/move-bytecode-utils/src/lib.rs
+++ b/language/tools/move-bytecode-utils/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod dependency_graph;
+pub mod layout;
+pub mod module_cache;
 
 use crate::dependency_graph::DependencyGraph;
 use move_binary_format::{access::ModuleAccess, file_format::CompiledModule};

--- a/language/tools/move-bytecode-utils/src/module_cache.rs
+++ b/language/tools/move-bytecode-utils/src/module_cache.rs
@@ -1,0 +1,106 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use move_binary_format::CompiledModule;
+use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
+use std::{
+    cell::RefCell,
+    collections::{btree_map::Entry, BTreeMap},
+    fmt::Debug,
+    sync::RwLock,
+};
+
+/// A persistent storage that can fetch the bytecode for a given module id
+/// TODO: do we want to implement this in a way that allows clients to cache struct layouts?
+pub trait GetModule {
+    type Error: Debug;
+
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error>;
+}
+
+/// Simple in-memory module cache
+pub struct ModuleCache<R: ModuleResolver> {
+    cache: RefCell<BTreeMap<ModuleId, CompiledModule>>,
+    resolver: R,
+}
+
+impl<R: ModuleResolver> ModuleCache<R> {
+    pub fn new(resolver: R) -> Self {
+        ModuleCache {
+            cache: RefCell::new(BTreeMap::new()),
+            resolver,
+        }
+    }
+
+    pub fn add(&self, id: ModuleId, m: CompiledModule) {
+        self.cache.borrow_mut().insert(id, m);
+    }
+}
+
+impl<R: ModuleResolver> GetModule for ModuleCache<R> {
+    type Error = anyhow::Error;
+
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error> {
+        Ok(Some(match self.cache.borrow_mut().entry(id.clone()) {
+            Entry::Vacant(entry) => {
+                let module_bytes = self
+                    .resolver
+                    .get_module(id)
+                    .map_err(|_| anyhow!("Failed to get module {:?}", id))?
+                    .ok_or_else(|| anyhow!("Module {:?} doesn't exist", id))?;
+                let module = CompiledModule::deserialize(&module_bytes)
+                    .map_err(|_| anyhow!("Failure deserializing module {:?}", id))?;
+                entry.insert(module.clone());
+                module
+            }
+            Entry::Occupied(entry) => entry.get().clone(),
+        }))
+    }
+}
+
+/// Simple in-memory module cache that implements Sync
+pub struct SyncModuleCache<R: ModuleResolver> {
+    cache: RwLock<BTreeMap<ModuleId, CompiledModule>>,
+    resolver: R,
+}
+
+impl<R: ModuleResolver> SyncModuleCache<R> {
+    pub fn new(resolver: R) -> Self {
+        SyncModuleCache {
+            cache: RwLock::new(BTreeMap::new()),
+            resolver,
+        }
+    }
+
+    pub fn add(&self, id: ModuleId, m: CompiledModule) {
+        self.cache.write().unwrap().insert(id, m);
+    }
+}
+
+impl<R: ModuleResolver> GetModule for SyncModuleCache<R> {
+    type Error = anyhow::Error;
+
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error> {
+        if let Some(compiled_module) = self.cache.read().unwrap().get(id) {
+            return Ok(Some(compiled_module.clone()));
+        }
+
+        if let Some(module_bytes) = self
+            .resolver
+            .get_module(id)
+            .map_err(|_| anyhow!("Failed to get module {:?}", id))?
+        {
+            let module = CompiledModule::deserialize(&module_bytes)
+                .map_err(|_| anyhow!("Failure deserializing module {:?}", id))?;
+
+            self.cache
+                .write()
+                .unwrap()
+                .insert(id.clone(), module.clone());
+            Ok(Some(module))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/language/tools/move-cli/src/sandbox/commands/generate.rs
+++ b/language/tools/move-cli/src/sandbox/commands/generate.rs
@@ -3,7 +3,7 @@
 
 use crate::sandbox::utils::on_disk_state_view::OnDiskStateView;
 use anyhow::{bail, Result};
-use move_binary_format::layout::StructLayoutBuilder;
+use move_bytecode_utils::layout::StructLayoutBuilder;
 use move_core_types::{
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},

--- a/language/tools/move-cli/src/sandbox/utils/mod.rs
+++ b/language/tools/move-cli/src/sandbox/utils/mod.rs
@@ -36,7 +36,7 @@ pub mod on_disk_state_view;
 pub mod package;
 
 pub use mode::*;
-use move_binary_format::layout::GetModule;
+use move_bytecode_utils::module_cache::GetModule;
 pub use on_disk_state_view::*;
 pub use package::*;
 

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -8,8 +8,8 @@ use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,
     file_format::{CompiledModule, CompiledScript, FunctionDefinitionIndex},
-    layout::GetModule,
 };
+use move_bytecode_utils::module_cache::GetModule;
 use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
 use move_core_types::{
     account_address::AccountAddress,

--- a/language/tools/read-write-set/dynamic/Cargo.toml
+++ b/language/tools/read-write-set/dynamic/Cargo.toml
@@ -13,5 +13,6 @@ edition = "2018"
 anyhow = "1.0.38"
 diem-workspace-hack = { path = "../../../../common/workspace-hack" }
 move-binary-format = { path = "../../../move-binary-format" }
+move-bytecode-utils = { path = "../../move-bytecode-utils" }
 move-core-types = { path = "../../../move-core/types" }
 read-write-set-types = { path = "../types" }

--- a/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, bail, Result};
-use move_binary_format::{
-    layout::{GetModule, ModuleCache, TypeLayoutBuilder},
-    normalized::{Function, Type},
+use move_binary_format::normalized::{Function, Type};
+use move_bytecode_utils::{
+    layout::TypeLayoutBuilder,
+    module_cache::{GetModule, ModuleCache},
 };
 use move_core_types::{
     account_address::AccountAddress,
@@ -238,14 +239,14 @@ impl ConcretizedFormals {
 
 /// Bind all formals and type variables in `accesses` using `signers`, `actuals`, and
 /// `type_actuals`.
-pub fn bind_formals<R: MoveResolver>(
+pub fn bind_formals<R: GetModule>(
     accesses: &ReadWriteSet,
     module: &ModuleId,
     fun: &IdentStr,
     signers: &[AccountAddress],
     actuals: &[Vec<u8>],
     type_actuals: &[TypeTag],
-    module_cache: &ModuleCache<R>,
+    module_cache: &R,
 ) -> Result<ConcretizedFormals> {
     let subst_map = type_actuals
         .iter()

--- a/language/tools/read-write-set/dynamic/src/normalize.rs
+++ b/language/tools/read-write-set/dynamic/src/normalize.rs
@@ -5,7 +5,7 @@ use crate::dynamic_analysis::{
     bind_formals, concretize, ConcretizedFormals, ConcretizedSecondaryIndexes,
 };
 use anyhow::{anyhow, bail, Result};
-use move_binary_format::layout::ModuleCache;
+use move_bytecode_utils::module_cache::GetModule;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
@@ -146,14 +146,14 @@ impl NormalizedReadWriteSetAnalysis {
     ///
     /// We say "partially concretized" because the summary may contain secondary indexes that require reads from the current blockchain state to be concretized. If desired, the caller can concretized them using <add API for this>
     /// be resolved or not.
-    pub fn get_partially_concretized_summary<R: MoveResolver>(
+    pub fn get_partially_concretized_summary<R: GetModule>(
         &self,
         module: &ModuleId,
         fun: &IdentStr,
         signers: &[AccountAddress],
         actuals: &[Vec<u8>],
         type_actuals: &[TypeTag],
-        module_cache: &ModuleCache<R>,
+        module_cache: &R,
     ) -> Result<ConcretizedFormals> {
         let state = self
             .get_summary(module, fun)


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As promised in #9484 , I refactored `ModuleCache` to `move-bytecode-util` alogn with a sync and single thread version of ModuleCache.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes
