### PR TITLE
[gha] retire v1.3 release

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         #this is a painful solution since it doesn't pick up new branches, other option is lotsa shell in one job....
         #to test in canary add in canary here.....
-        target-branch: [main, release-1.3, release-1.4]
+        target-branch: [main, release-1.5, release-1.4]
     env:
       AUDIT_SUMMARY_FILE: /tmp/summary
     steps:
@@ -116,7 +116,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release-branch: [release-1.3, release-1.4]
+        release-branch: [release-1.5, release-1.4]
     steps:
       - uses: actions/checkout@v2.3.4
         with:


### PR DESCRIPTION
## Motivation
retire `release-1.3` as it is no longer in prod.  add `releas-1.5` to next release.

## Test Plan
no test besides lint in CI.