### PR TITLE
deno only lints ./shuffle

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -493,7 +493,7 @@ jobs:
       - name: docker lints
         uses: ./.github/actions/docker-checks
       - name: deno lints
-        run: deno lint ./shuffle && deno lint ./language/move-analyzer
+        run: deno lint ./shuffle
 
   lint:
     runs-on: ubuntu-20.04-xl


### PR DESCRIPTION

## Motivation

`deno lint ./language/move-analyzer` is breaking in https://github.com/diem/diem/runs/4053327842?check_suite_focus=true despite correct deno ignore. This lint step was motivated by shuffle, let's not block move-analyzer.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

deno lint ./shuffle
This PR's CI.

## Related PRs

https://github.com/diem/diem/pull/9570

