### PR TITLE
[gha] msg to compare CT and Forge results

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -1265,7 +1265,7 @@ jobs:
           }}"
           if [[ "$success" != "true" ]]; then
             jq -n \
-              --arg msg "Alert: Two LBT tests results are mismatch." \
+              --arg msg "Alert: Two LBT tests results are mismatch. CT ${{needs.land-blocking-test.result}} != Forge ${{needs.land-blocking-test-forge.outputs.forge-result}}" \
               --arg url "https://github.com/${{ github.repository }}/actions/runs/${{github.run_id}}" \
               --arg pr_url "https://github.com/${{ github.repository }}/pull/${{ needs.prepare.outputs.changes-pull-request-number }}" \
             '{


### PR DESCRIPTION
So we can see which job failed from the message it posts, rather than needing to click into the provided link. This will help us better grep for these high level metrics in the time being before we monitor forge more rigorously.