### PR TITLE
[read-write-set] Add arity check

### DIFF
--- a/diem-move/diem-vm/src/read_write_set_analysis.rs
+++ b/diem-move/diem-vm/src/read_write_set_analysis.rs
@@ -245,14 +245,19 @@ impl<'a, R: MoveResolver> ReadWriteSetAnalysis<'a, R> {
             &[gas_currency.clone()],
             &self.module_cache,
         )?;
-        let script_accesses = self.get_partially_concretized_summary(
-            module_name,
-            script_name,
-            &signers,
-            actuals,
-            type_actuals,
-            &self.module_cache,
-        )?;
+
+        // If any error occurs while analyzing the body, skip the read/writeset result as only the
+        // prologue and epilogue will be run by this transaction.
+        let script_accesses = self
+            .get_partially_concretized_summary(
+                module_name,
+                script_name,
+                &signers,
+                actuals,
+                type_actuals,
+                &self.module_cache,
+            )
+            .unwrap_or_else(ConcretizedFormals::empty);
 
         let mut keys_read = vec![];
         let mut keys_written = vec![];

--- a/diem-move/diem-vm/src/read_write_set_analysis.rs
+++ b/diem-move/diem-vm/src/read_write_set_analysis.rs
@@ -257,7 +257,7 @@ impl<'a, R: MoveResolver> ReadWriteSetAnalysis<'a, R> {
                 type_actuals,
                 &self.module_cache,
             )
-            .unwrap_or_else(ConcretizedFormals::empty);
+            .unwrap_or_else(|_| ConcretizedFormals::empty());
 
         let mut keys_read = vec![];
         let mut keys_written = vec![];

--- a/language/testing-infra/e2e-tests/src/account_universe.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe.rs
@@ -382,18 +382,9 @@ pub fn run_and_assert_universe(
         .iter()
         .map(|transaction_gen| transaction_gen.clone().apply(&mut universe))
         .unzip();
-    let outputs = executor.execute_block(transactions.clone()).unwrap();
-    let outputs_parallel = executor
-        .execute_transaction_block_parallel(
-            transactions
-                .into_iter()
-                .map(Transaction::UserTransaction)
-                .collect(),
-        )
-        .unwrap();
+    let outputs = executor.execute_block(transactions).unwrap();
 
     prop_assert_eq!(outputs.len(), expected_values.len());
-    prop_assert_eq!(outputs.clone(), outputs_parallel);
 
     for (idx, (output, expected)) in outputs.iter().zip(&expected_values).enumerate() {
         prop_assert!(

--- a/language/testing-infra/e2e-tests/src/account_universe.rs
+++ b/language/testing-infra/e2e-tests/src/account_universe.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use diem_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
 use diem_types::{
-    transaction::{SignedTransaction, Transaction, TransactionStatus},
+    transaction::{SignedTransaction, TransactionStatus},
     vm_status::{known_locations, KeptVMStatus, StatusCode},
 };
 use once_cell::sync::Lazy;

--- a/language/testing-infra/e2e-tests/src/executor.rs
+++ b/language/testing-infra/e2e-tests/src/executor.rs
@@ -389,7 +389,9 @@ impl FakeExecutor {
             }
         }
 
-        let output = DiemVM::execute_block(txn_block, &self.data_store);
+        let output = DiemVM::execute_block(txn_block.clone(), &self.data_store);
+        let parallel_output = self.execute_transaction_block_parallel(txn_block);
+        assert_eq!(output, parallel_output);
 
         if let Some(logger) = &self.executed_output {
             logger.log(format!("{:?}\n", output).as_str());

--- a/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
@@ -29,6 +29,11 @@ pub struct ConcretizedFormals(ReadWriteSet);
 pub struct ConcretizedSecondaryIndexes(ConcretizedFormals);
 
 impl ConcretizedFormals {
+    /// Return a `Self` that accesses nothing.
+    pub fn empty() -> Self {
+        Self(ReadWriteSet::new())
+    }
+
     /// Return the `ResourceKey`'s that may be written by `self`.
     /// For example: if `self` is 0x7/0x1::AModule::AResource/f/g -> ReadWrite, this will return
     /// 0x7/0x1::AModule.
@@ -258,13 +263,23 @@ pub fn bind_formals<R: GetModule>(
         .map_err(|_| anyhow!("Failed to get module from storage"))?
         .ok_or_else(|| anyhow!("Failed to get module"))?;
 
-    let func_type = Function::new_from_name(&compiled_module, fun)
-        .ok_or_else(|| anyhow!("Failed to find function"))?
+    let func_sig = Function::new_from_name(&compiled_module, fun)
+        .ok_or_else(|| anyhow!("Failed to find function"))?;
+
+    // Check arity before binding. Otherwise we might get out-of-bound errors.
+    if func_sig.parameters.len() != actuals.len() + signers.len()
+        || func_sig.type_parameters.len() != type_actuals.len()
+    {
+        bail!("Script arity doesn't match");
+    }
+
+    let func_type = func_sig
         .parameters
         .iter()
         .map(|ty| ty.subst(&subst_map).into_type_tag())
         .collect::<Option<Vec<_>>>()
         .ok_or_else(|| anyhow!("Failed to substitute types"))?;
+
     ConcretizedFormals::from_args(
         accesses,
         signers,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
Add arity check for read-write-set analysis for script functions. Without such checks, user can construct scripts with bad arities that will choke the executor.

Also updated the test to compare between the result of parallel vs sequential execution for all e2e test cases. For now we only check the results are equal without asserting that VM went through the roll back behavior. This is because the read writeset analyzer won't be able to infer the write sets for things like admin scripts, empty_scripts, etc. Will add this assertion in the future.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
Without the arity check, some test cases in `verify_txn` will fail.