### PR TITLE
[move-stdlib] Added the experimental stdlib modules Role and ACL

### DIFF
--- a/language/move-stdlib/nursery/docs/ACL.md
+++ b/language/move-stdlib/nursery/docs/ACL.md
@@ -1,0 +1,205 @@
+
+<a name="0x1_ACL"></a>
+
+# Module `0x1::ACL`
+
+Access control list (ACL) module. An ACL is a list of account addresses who
+have the access permission to a certain object.
+This module uses a <code>vector</code> to represent the list, but can be refactored to
+use a "set" instead when it's available in the language in the future.
+
+
+-  [Struct `ACL`](#0x1_ACL_ACL)
+-  [Constants](#@Constants_0)
+-  [Function `empty`](#0x1_ACL_empty)
+-  [Function `add`](#0x1_ACL_add)
+-  [Function `remove`](#0x1_ACL_remove)
+-  [Function `contains`](#0x1_ACL_contains)
+-  [Function `assert_contains`](#0x1_ACL_assert_contains)
+
+
+<pre><code><b>use</b> <a href="">0x1::Errors</a>;
+<b>use</b> <a href="">0x1::Vector</a>;
+</code></pre>
+
+
+
+<a name="0x1_ACL_ACL"></a>
+
+## Struct `ACL`
+
+
+
+<pre><code><b>struct</b> <a href="ACL.md#0x1_ACL">ACL</a> has <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>list: vector&lt;address&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_ACL_ECONTAIN"></a>
+
+The ACL already contains the address.
+
+
+<pre><code><b>const</b> <a href="ACL.md#0x1_ACL_ECONTAIN">ECONTAIN</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_ACL_ENOT_CONTAIN"></a>
+
+The ACL does not contain the address.
+
+
+<pre><code><b>const</b> <a href="ACL.md#0x1_ACL_ENOT_CONTAIN">ENOT_CONTAIN</a>: u64 = 1;
+</code></pre>
+
+
+
+<a name="0x1_ACL_empty"></a>
+
+## Function `empty`
+
+Return an empty ACL.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_empty">empty</a>(): <a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_empty">empty</a>(): <a href="ACL.md#0x1_ACL">ACL</a> {
+    <a href="ACL.md#0x1_ACL">ACL</a>{ list: <a href="_empty">Vector::empty</a>&lt;address&gt;() }
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ACL_add"></a>
+
+## Function `add`
+
+Add the address to the ACL.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_add">add</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: address)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_add">add</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL">ACL</a>, addr: address) {
+    <b>assert</b>!(!<a href="_contains">Vector::contains</a>(&<b>mut</b> acl.list, &addr), <a href="_invalid_argument">Errors::invalid_argument</a>(<a href="ACL.md#0x1_ACL_ECONTAIN">ECONTAIN</a>));
+    <a href="_push_back">Vector::push_back</a>(&<b>mut</b> acl.list, addr);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ACL_remove"></a>
+
+## Function `remove`
+
+Remove the address from the ACL.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_remove">remove</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: address)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_remove">remove</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL">ACL</a>, addr: address) {
+    <b>let</b> (found, index) = <a href="_index_of">Vector::index_of</a>(&<b>mut</b> acl.list, &addr);
+    <b>assert</b>!(found, <a href="_invalid_argument">Errors::invalid_argument</a>(<a href="ACL.md#0x1_ACL_ENOT_CONTAIN">ENOT_CONTAIN</a>));
+    <a href="_remove">Vector::remove</a>(&<b>mut</b> acl.list, index);
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ACL_contains"></a>
+
+## Function `contains`
+
+Return true iff the ACL contains the address.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_contains">contains</a>(acl: &<a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: address): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_contains">contains</a>(acl: &<a href="ACL.md#0x1_ACL">ACL</a>, addr: address): bool {
+    <a href="_contains">Vector::contains</a>(&acl.list, &addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_ACL_assert_contains"></a>
+
+## Function `assert_contains`
+
+assert! that the ACL has the address.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_assert_contains">assert_contains</a>(acl: &<a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: address)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_assert_contains">assert_contains</a>(acl: &<a href="ACL.md#0x1_ACL">ACL</a>, addr: address) {
+    <b>assert</b>!(<a href="ACL.md#0x1_ACL_contains">contains</a>(acl, addr), <a href="_invalid_argument">Errors::invalid_argument</a>(<a href="ACL.md#0x1_ACL_ENOT_CONTAIN">ENOT_CONTAIN</a>));
+}
+</code></pre>
+
+
+
+</details>

--- a/language/move-stdlib/nursery/docs/Role.md
+++ b/language/move-stdlib/nursery/docs/Role.md
@@ -1,0 +1,166 @@
+
+<a name="0x1_Role"></a>
+
+# Module `0x1::Role`
+
+A generic module for role-based access control (RBAC).
+
+
+-  [Resource `Role`](#0x1_Role_Role)
+-  [Constants](#@Constants_0)
+-  [Function `assign_role`](#0x1_Role_assign_role)
+-  [Function `revoke_role`](#0x1_Role_revoke_role)
+-  [Function `has_role`](#0x1_Role_has_role)
+-  [Function `assert_has_role`](#0x1_Role_assert_has_role)
+
+
+<pre><code><b>use</b> <a href="">0x1::Errors</a>;
+<b>use</b> <a href="">0x1::Signer</a>;
+</code></pre>
+
+
+
+<a name="0x1_Role_Role"></a>
+
+## Resource `Role`
+
+
+
+<pre><code><b>struct</b> <a href="Role.md#0x1_Role">Role</a>&lt;Type&gt; has key
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a name="@Constants_0"></a>
+
+## Constants
+
+
+<a name="0x1_Role_EROLE"></a>
+
+
+
+<pre><code><b>const</b> <a href="Role.md#0x1_Role_EROLE">EROLE</a>: u64 = 0;
+</code></pre>
+
+
+
+<a name="0x1_Role_assign_role"></a>
+
+## Function `assign_role`
+
+Assign the role to the account. The caller must pass a witness, so is
+expected to be a function of the module that defines <code>Type</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_assign_role">assign_role</a>&lt;Type&gt;(<b>to</b>: &signer, _witness: &Type)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_assign_role">assign_role</a>&lt;Type&gt;(<b>to</b>: &signer, _witness: &Type) {
+    <b>assert</b>!(!<a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(<a href="_address_of">Signer::address_of</a>(<b>to</b>)), <a href="_already_published">Errors::already_published</a>(<a href="Role.md#0x1_Role_EROLE">EROLE</a>));
+    move_to&lt;<a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;&gt;(<b>to</b>, <a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;{});
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Role_revoke_role"></a>
+
+## Function `revoke_role`
+
+Revoke the role from the account. The caller must pass a witness, so is
+expected to be a function of the module that defines <code>Type</code>.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_revoke_role">revoke_role</a>&lt;Type&gt;(from: &signer, _witness: &Type)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_revoke_role">revoke_role</a>&lt;Type&gt;(from: &signer, _witness: &Type) <b>acquires</b> <a href="Role.md#0x1_Role">Role</a> {
+    <b>assert</b>!(<a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(<a href="_address_of">Signer::address_of</a>(from)), <a href="_not_published">Errors::not_published</a>(<a href="Role.md#0x1_Role_EROLE">EROLE</a>));
+    <b>let</b> <a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;{} = move_from&lt;<a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;&gt;(<a href="_address_of">Signer::address_of</a>(from));
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Role_has_role"></a>
+
+## Function `has_role`
+
+Return true iff the address has the role.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(addr: address): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(addr: address): bool {
+    <b>exists</b>&lt;<a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;&gt;(addr)
+}
+</code></pre>
+
+
+
+</details>
+
+<a name="0x1_Role_assert_has_role"></a>
+
+## Function `assert_has_role`
+
+assert! that the account has the role.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_assert_has_role">assert_has_role</a>&lt;Type&gt;(account: &signer)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_assert_has_role">assert_has_role</a>&lt;Type&gt;(account: &signer) {
+    <b>assert</b>!(<a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(<a href="_address_of">Signer::address_of</a>(account)), <a href="_not_published">Errors::not_published</a>(<a href="Role.md#0x1_Role_EROLE">EROLE</a>));
+}
+</code></pre>
+
+
+
+</details>

--- a/language/move-stdlib/nursery/sources/ACL.move
+++ b/language/move-stdlib/nursery/sources/ACL.move
@@ -1,0 +1,46 @@
+/// Access control list (ACL) module. An ACL is a list of account addresses who
+/// have the access permission to a certain object.
+/// This module uses a `vector` to represent the list, but can be refactored to
+/// use a "set" instead when it's available in the language in the future.
+
+module Std::ACL {
+    use Std::Vector;
+    use Std::Errors;
+
+    /// The ACL already contains the address.
+    const ECONTAIN: u64 = 0;
+    /// The ACL does not contain the address.
+    const ENOT_CONTAIN: u64 = 1;
+
+    struct ACL has store, drop, copy {
+        list: vector<address>
+    }
+
+    /// Return an empty ACL.
+    public fun empty(): ACL {
+        ACL{ list: Vector::empty<address>() }
+    }
+
+    /// Add the address to the ACL.
+    public fun add(acl: &mut ACL, addr: address) {
+        assert!(!Vector::contains(&mut acl.list, &addr), Errors::invalid_argument(ECONTAIN));
+        Vector::push_back(&mut acl.list, addr);
+    }
+
+    /// Remove the address from the ACL.
+    public fun remove(acl: &mut ACL, addr: address) {
+        let (found, index) = Vector::index_of(&mut acl.list, &addr);
+        assert!(found, Errors::invalid_argument(ENOT_CONTAIN));
+        Vector::remove(&mut acl.list, index);
+    }
+
+    /// Return true iff the ACL contains the address.
+    public fun contains(acl: &ACL, addr: address): bool {
+        Vector::contains(&acl.list, &addr)
+    }
+
+    /// assert! that the ACL has the address.
+    public fun assert_contains(acl: &ACL, addr: address) {
+        assert!(contains(acl, addr), Errors::invalid_argument(ENOT_CONTAIN));
+    }
+}

--- a/language/move-stdlib/nursery/sources/Role.move
+++ b/language/move-stdlib/nursery/sources/Role.move
@@ -1,0 +1,34 @@
+/// A generic module for role-based access control (RBAC).
+
+module Std::Role {
+    use Std::Errors;
+    use Std::Signer;
+
+    const EROLE: u64 = 0;
+
+    struct Role<phantom Type> has key {}
+
+    /// Assign the role to the account. The caller must pass a witness, so is
+    /// expected to be a function of the module that defines `Type`.
+    public fun assign_role<Type>(to: &signer, _witness: &Type) {
+        assert!(!has_role<Type>(Signer::address_of(to)), Errors::already_published(EROLE));
+        move_to<Role<Type>>(to, Role<Type>{});
+    }
+
+    /// Revoke the role from the account. The caller must pass a witness, so is
+    /// expected to be a function of the module that defines `Type`.
+    public fun revoke_role<Type>(from: &signer, _witness: &Type) acquires Role {
+        assert!(has_role<Type>(Signer::address_of(from)), Errors::not_published(EROLE));
+        let Role<Type>{} = move_from<Role<Type>>(Signer::address_of(from));
+    }
+
+    /// Return true iff the address has the role.
+    public fun has_role<Type>(addr: address): bool {
+        exists<Role<Type>>(addr)
+    }
+
+    /// assert! that the account has the role.
+    public fun assert_has_role<Type>(account: &signer) {
+        assert!(has_role<Type>(Signer::address_of(account)), Errors::not_published(EROLE));
+    }
+}

--- a/language/move-stdlib/nursery/tests/ACLTests.move
+++ b/language/move-stdlib/nursery/tests/ACLTests.move
@@ -1,0 +1,60 @@
+#[test_only]
+module Std::ACLTests {
+    use Std::ACL;
+    use Std::Signer;
+    use Std::Vector;
+    use Std::UnitTest;
+
+    struct Data has key {
+        value: u64,
+        write_acl: ACL::ACL
+    }
+
+    #[test]
+    fun test_success() acquires Data {
+        let (alice, bob) = create_two_signers();
+        let acl = ACL::empty();
+        ACL::add(&mut acl, Signer::address_of(&alice));
+        move_to(&alice, Data {value: 0, write_acl: acl});
+
+        let alice_data = borrow_global_mut<Data>(Signer::address_of(&alice));
+        ACL::add(&mut alice_data.write_acl, Signer::address_of(&bob));
+        ACL::remove(&mut alice_data.write_acl, Signer::address_of(&bob));
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 7)]
+    fun test_add_failure() acquires Data {
+        let (alice, bob) = create_two_signers();
+        let acl = ACL::empty();
+        ACL::add(&mut acl, Signer::address_of(&alice));
+        move_to(&alice, Data {value: 0, write_acl: acl});
+
+        let alice_data = borrow_global_mut<Data>(Signer::address_of(&alice));
+        ACL::add(&mut alice_data.write_acl, Signer::address_of(&bob));
+        ACL::add(&mut alice_data.write_acl, Signer::address_of(&bob));
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 263)]
+    fun test_remove_failure() acquires Data {
+        let (alice, bob) = create_two_signers();
+        let acl = ACL::empty();
+        ACL::add(&mut acl, Signer::address_of(&alice));
+        move_to(&alice, Data {value: 0, write_acl: acl});
+
+        let alice_data = borrow_global_mut<Data>(Signer::address_of(&alice));
+        ACL::remove(&mut alice_data.write_acl, Signer::address_of(&bob));
+    }
+
+    #[test_only]
+    fun create_signer(): signer {
+        Vector::pop_back(&mut UnitTest::create_signers_for_testing(1))
+    }
+
+    #[test_only]
+    fun create_two_signers(): (signer, signer) {
+        let signers = &mut UnitTest::create_signers_for_testing(2);
+        (Vector::pop_back(signers), Vector::pop_back(signers))
+    }
+}

--- a/language/move-stdlib/nursery/tests/RoleTests.move
+++ b/language/move-stdlib/nursery/tests/RoleTests.move
@@ -1,0 +1,48 @@
+#[test_only]
+module Std::RoleTests {
+    use Std::Role;
+    use Std::Vector;
+    use Std::UnitTest;
+
+    struct Developer has drop {}
+    struct User has drop {}
+    struct Admin has drop {}
+
+    #[test]
+    fun test_success() {
+        let (alice, bob) = create_two_signers();
+        Role::assign_role<Developer>(&alice, &Developer{});
+        Role::assign_role<User>(&alice, &User{});
+        Role::assign_role<Admin>(&bob, &Admin{});
+
+        Role::revoke_role<Developer>(&alice, &Developer{});
+        Role::revoke_role<User>(&alice, &User{});
+        Role::revoke_role<Admin>(&bob, &Admin{});
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 6)]
+    fun test_assign_failure() {
+        let alice = create_signer();
+        Role::assign_role<Developer>(&alice, &Developer{});
+        Role::assign_role<Developer>(&alice, &Developer{});
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 5)]
+    fun test_revoke_failure() {
+        let alice = create_signer();
+        Role::revoke_role<Developer>(&alice, &Developer{});
+    }
+
+    #[test_only]
+    fun create_signer(): signer {
+        Vector::pop_back(&mut UnitTest::create_signers_for_testing(1))
+    }
+
+    #[test_only]
+    fun create_two_signers(): (signer, signer) {
+        let signers = &mut UnitTest::create_signers_for_testing(2);
+        (Vector::pop_back(signers), Vector::pop_back(signers))
+    }
+}


### PR DESCRIPTION
A generic module to support the role-based access control is missing in move-stdlib. The `Roles` module in the Diem Framework is specific to the DPN, so may not be reusable for other networks or applications. This PR adds a generic role module to support the role-based access control. This PR also add a module for "access control list" which provides a lightweight way for access control. These modules have minimal features. More features can be added laster as needed. 

This PR:
- Added the Role module which is a generic module for role-based access control
  (RBAC).

- Added the ACL module which is a module that defines the access control list (ACL)

- Added tests for both modules

## Motivation

To provide the stdlib modules for access control

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test

