### PR TITLE
[State Sync] Support a read-only mode for state sync v1.

### DIFF
--- a/state-sync/state-sync-v1/src/bootstrapper.rs
+++ b/state-sync/state-sync-v1/src/bootstrapper.rs
@@ -55,6 +55,7 @@ impl StateSyncBootstrapper {
             node_config,
             waypoint,
             executor_proxy,
+            false,
         )
     }
 
@@ -69,6 +70,7 @@ impl StateSyncBootstrapper {
         node_config: &NodeConfig,
         waypoint: Waypoint,
         executor_proxy: E,
+        read_only_mode: bool,
     ) -> Self {
         let (coordinator_sender, coordinator_receiver) = mpsc::unbounded();
         let initial_state = executor_proxy
@@ -88,6 +90,7 @@ impl StateSyncBootstrapper {
             waypoint,
             executor_proxy,
             initial_state,
+            read_only_mode,
         )
         .expect("[State Sync] Unable to create state sync coordinator!");
         runtime.spawn(coordinator.start(network));

--- a/state-sync/state-sync-v1/src/error.rs
+++ b/state-sync/state-sync-v1/src/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     OldSyncRequestVersion(Version, Version),
     #[error("Processed an invalid chunk! Failed to apply the chunk: {0}")]
     ProcessInvalidChunk(String),
+    #[error("State sync is operating in read-only mode! Error: {0}")]
+    ReadOnlyMode(String),
     #[error(
         "Received a chunk for an outdated request from peer {0}. Known version: {1}, received: {2}"
     )]

--- a/state-sync/state-sync-v1/src/shared_components.rs
+++ b/state-sync/state-sync-v1/src/shared_components.rs
@@ -114,7 +114,7 @@ pub(crate) mod test_utils {
         node_config: NodeConfig,
         waypoint: Waypoint,
     ) -> StateSyncCoordinator<ExecutorProxy, MempoolNotifier> {
-        create_state_sync_coordinator_for_tests(node_config, waypoint)
+        create_state_sync_coordinator_for_tests(node_config, waypoint, false)
     }
 
     pub(crate) fn create_validator_coordinator(
@@ -122,7 +122,7 @@ pub(crate) mod test_utils {
         let mut node_config = NodeConfig::default();
         node_config.base.role = RoleType::Validator;
 
-        create_state_sync_coordinator_for_tests(node_config, Waypoint::default())
+        create_state_sync_coordinator_for_tests(node_config, Waypoint::default(), false)
     }
 
     #[cfg(test)]
@@ -131,12 +131,22 @@ pub(crate) mod test_utils {
         let mut node_config = NodeConfig::default();
         node_config.base.role = RoleType::FullNode;
 
-        create_state_sync_coordinator_for_tests(node_config, Waypoint::default())
+        create_state_sync_coordinator_for_tests(node_config, Waypoint::default(), false)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn create_read_only_coordinator(
+    ) -> StateSyncCoordinator<ExecutorProxy, MempoolNotifier> {
+        let mut node_config = NodeConfig::default();
+        node_config.base.role = RoleType::Validator;
+
+        create_state_sync_coordinator_for_tests(node_config, Waypoint::default(), true)
     }
 
     fn create_state_sync_coordinator_for_tests(
         node_config: NodeConfig,
         waypoint: Waypoint,
+        read_only_mode: bool,
     ) -> StateSyncCoordinator<ExecutorProxy, MempoolNotifier> {
         // Generate a genesis change set
         let (genesis, _) = vm_genesis::test_genesis_change_set_and_validators(Some(1));
@@ -188,6 +198,7 @@ pub(crate) mod test_utils {
             waypoint,
             executor_proxy,
             initial_state,
+            read_only_mode,
         )
         .unwrap()
     }

--- a/state-sync/state-sync-v1/tests/test_harness.rs
+++ b/state-sync/state-sync-v1/tests/test_harness.rs
@@ -276,6 +276,7 @@ impl StateSyncEnvironment {
             60_000,
             120_000,
             mock_network,
+            false,
         );
     }
 
@@ -288,6 +289,7 @@ impl StateSyncEnvironment {
         timeout_ms: u64,
         multicast_timeout_ms: u64,
         mock_network: bool,
+        read_only_mode: bool,
     ) {
         let (config, network_id) = setup_state_sync_config(role, timeout_ms, multicast_timeout_ms);
         let network_handles = self.setup_network_handles(index, &role, mock_network, network_id);
@@ -323,6 +325,7 @@ impl StateSyncEnvironment {
             &config,
             waypoint,
             MockExecutorProxy::new(handler, storage_proxy.clone()),
+            read_only_mode,
         );
         peer.client = Some(bootstrapper.create_client());
         peer.consensus_notifier = Some(consensus_notifier);


### PR DESCRIPTION
## Motivation

This PR extends state sync v1 to support a read-only mode, a mode in which state sync will respond to chunk requests from peers (to enable them to synchronize), but will not actively request data in order to synchronize itself. This is required to support the case where state sync v2 is synchronizing the node, and state sync v1 is only enabled to support backward compatibility. 

Note: most of the new code is just tests to ensure that things work as expected 😄 

The PR offers the following commits:
1. Add a read-only mode to state sync v1 and add some simple unit/integration tests.
2. Add the ability to disable read-only mode, in the case that state sync v1 is read-only and the node is unable to make progress with state sync v2.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New unit and integration tests have been added for the additional functionality.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906