### PR TITLE
[shuffle] node uses a seed rng for clean reruns

### DIFF
--- a/shuffle/cli/src/node.rs
+++ b/shuffle/cli/src/node.rs
@@ -4,6 +4,7 @@
 use crate::shared::get_shuffle_dir;
 use anyhow::Result;
 use diem_types::on_chain_config::VMPublishingOption;
+use rand::SeedableRng;
 use std::fs;
 
 pub fn handle() -> Result<()> {
@@ -15,12 +16,16 @@ pub fn handle() -> Result<()> {
         println!("Accessing node config in {}", shuffle_dir.display());
     }
     let publishing_option = VMPublishingOption::open();
+
+    // prepare a deterministic generator so that recreated test environments
+    // have the same waypoints, configurations, etc
+    let rng = rand::rngs::StdRng::seed_from_u64(0);
     diem_node::load_test_environment(
         Some(shuffle_dir.join("nodeconfig")),
         false,
         Some(publishing_option),
         diem_framework_releases::current_module_blobs().to_vec(),
-        rand::rngs::OsRng,
+        rng,
     );
     Ok(())
 }


### PR DESCRIPTION

## Motivation

Restarting `shuffle node` would change the resulting waypoints, and other configurations, breaking future txns. This allows for consistent waypoints, allowing reruns.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo test -p shuffle

