### PR TITLE
[logging] improve the error log for mempool

### DIFF
--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -614,7 +614,7 @@ async fn test_post_transaction_rejected_by_mempool() {
         resp,
         json!({
           "code": 400,
-          "message": "transaction is rejected: InvalidUpdate - Failed to update gas price to 0"
+          "message": "transaction is rejected: InvalidUpdate - Transaction already in mempool"
         }),
     );
 }

--- a/json-rpc/integration-tests/src/lib.rs
+++ b/json-rpc/integration-tests/src/lib.rs
@@ -784,7 +784,7 @@ impl PublicUsageTest for MempoolValidationError {
             let resp = env.submit(&txn2);
             assert_eq!(
                 resp.error.expect("error").message,
-                "Server error: Mempool submission error: \"Failed to update gas price to 0\""
+                "Server error: Mempool submission error: \"Transaction already in mempool\""
                     .to_string(),
             );
         });

--- a/mempool/src/core_mempool/transaction_store.rs
+++ b/mempool/src/core_mempool/transaction_store.rs
@@ -140,9 +140,8 @@ impl TransactionStore {
                         self.index_remove(&txn);
                     }
                 } else {
-                    return MempoolStatus::new(MempoolStatusCode::InvalidUpdate).with_message(
-                        format!("Failed to update gas price to {}", txn.get_gas_price()),
-                    );
+                    return MempoolStatus::new(MempoolStatusCode::InvalidUpdate)
+                        .with_message("Transaction already in mempool".to_string());
                 }
             }
         }


### PR DESCRIPTION
#9466 
When submitting same txn to mempool, we got error says "Failed to update gas price to 0"

From Zekun:

> the error message makes no sense , i thought we updated it. it assume you submit the same txn is to update the gas price to make it higher priority. we should simply return message like txn already in mempool

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Once it reaches the logging line, it has already detected that this transaction appears in mempool so I am changing the logging message to say "Transaction already in mempool."

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Ran `cargo lint`, `clippy`, `fmt`. Runs with no errors.
