### PR TITLE
[api] optimizing openapi specificatoin for client code generation

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -7,22 +7,59 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.1.0
+  contact:
+    name: The Diem Core Contributors
+    url: https://github.com/diem/diem
 tags:
-  - name: info
-    description: API for getting the latest ledger information.
-  - name: accounts
-    description: API for getting account resources, modules / events.
+  - name: general
+    description: General information
   - name: transactions
-    description: API for getting, creating, and submitting transactions.
+    description: Access to transactions
+  - name: accounts
+    description: Access to account resources and modules
   - name: events
-    description: API for getting events.
+    description: Access to events
+  - name: transaction_model
+    x-displayName: Transaction
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/Transaction"/>
+  - name: account_resource_model
+    x-displayName: AccountResource
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/MoveResource"/>
+  - name: account_module_model
+    x-displayName: AccountModule
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/MoveModuleBytecode"/>
+  - name: event_model
+    x-displayName: Event
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/Event"/>
+  - name: move_value_model
+    x-displayName: MoveValue
+    description: |
+      <SchemaDefinition schemaRef="#/components/schemas/MoveValue"/>
+x-tagGroups:
+  - name: API
+    tags:
+      - general
+      - transactions
+      - accounts
+      - events
+  - name: Models
+    tags:
+      - transaction_model
+      - account_resource_model
+      - account_module_model
+      - event_model
+      - move_value_model
 paths:
   /:
     get:
-      summary: Get the latest ledger information.
+      summary: Ledger information
       operationId: get_ledger_info
       tags:
-        - info
+        - general
       responses:
         "200":
           description: Returns the latest ledger information.
@@ -36,26 +73,26 @@ paths:
           $ref: '#/components/responses/500'
   /spec.html:
     get:
-      summary: API specification document.
+      summary: API document
       operationId: get_spec_html
       tags:
-        - info
+        - general
       responses:
         "200":
           description: Returns OpenAPI specification html document.
         "400":
-          $ref: '#/components/responses/400'
+          description: Bad Request
   /openapi.yaml:
     get:
-      summary: OpenAPI YAML specification.
+      summary: OpenAPI specification
       operationId: get_spec_yaml
       tags:
-        - info
+        - general
       responses:
         "200":
           description: Returns OpenAPI specification YAML document.
         "400":
-          $ref: '#/components/responses/400'
+          description: Bad Request
   /accounts/{address}/resources:
     get:
       summary: Get account resources
@@ -366,7 +403,7 @@ paths:
           $ref: '#/components/responses/500'
   /accounts/{address}/events/{event_handle_struct}/{field_name}:
     get:
-      summary: Get events by event handle.
+      summary: Get events by event handle
       operationId: get_account_events
       description: >-
         This API extracts event key from the account resource identified
@@ -374,7 +411,6 @@ paths:
         events identified by the event key.
       tags:
         - events
-        - accounts
       parameters:
         - $ref: '#/components/parameters/AccountAddress'
         - name: event_handle_struct

--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -20,7 +20,7 @@ paths:
   /:
     get:
       summary: Get the latest ledger information.
-      operationId: get-ledger-info
+      operationId: get_ledger_info
       tags:
         - info
       responses:
@@ -37,7 +37,7 @@ paths:
   /spec.html:
     get:
       summary: API specification document.
-      operationId: get-spec-html
+      operationId: get_spec_html
       tags:
         - info
       responses:
@@ -48,7 +48,7 @@ paths:
   /openapi.yaml:
     get:
       summary: OpenAPI YAML specification.
-      operationId: get-spec-yaml
+      operationId: get_spec_yaml
       tags:
         - info
       responses:
@@ -59,7 +59,7 @@ paths:
   /accounts/{address}/resources:
     get:
       summary: Get account resources
-      operationId: get-account-resources
+      operationId: get_account_resources
       tags:
         - accounts
       parameters:
@@ -82,7 +82,7 @@ paths:
   /accounts/{address}/modules:
     get:
       summary: Get account modules
-      operationId: get-account-modules
+      operationId: get_account_modules
       tags:
         - accounts
       parameters:
@@ -105,7 +105,7 @@ paths:
   /ledger/{ledger_version}/accounts/{address}/resources:
     get:
       summary: Get account resources by ledger version
-      operationId: get-account-resources-by-version
+      operationId: get_account_resources_by_version
       description: >-
         This API returns account resources for a specific ledger version (AKA transaction version).
 
@@ -146,7 +146,7 @@ paths:
 
 
         When the data is pruned, server responds 404.
-      operationId: get-account-modules-by-version
+      operationId: get_account_modules_by_version
       tags:
         - accounts
       parameters:
@@ -171,7 +171,7 @@ paths:
   /transactions:
     get:
       summary: Get transactions
-      operationId: get-transactions
+      operationId: get_transactions
       tags:
         - transactions
       parameters:
@@ -192,7 +192,7 @@ paths:
           $ref: '#/components/responses/500'
     post:
       summary: Submit transaction
-      operationId: submit-transaction
+      operationId: submit_transaction
       description: >-
         **Submit transaction using JSON without additional tools**
 
@@ -262,7 +262,7 @@ paths:
           1. Create hash message bytes: "DIEM::Transaction" bytes + BCS bytes of [Transaction](https://diem.github.io/diem/diem_types/transaction/enum.Transaction.html).
           2. Apply hash algorithm `SHA3-256` to the hash message bytes.
           3. Hex-encode the hash bytes with `0x` prefix.
-      operationId: get-transaction
+      operationId: get_transaction
       tags:
         - transactions
       parameters:
@@ -304,7 +304,7 @@ paths:
 
           1. Client first needs to HEX decode the `message` into bytes.
           2. Then sign the bytes to create signature.
-      operationId: create-signing-message
+      operationId: create_signing_message
       tags:
         - transactions
       requestBody:
@@ -336,7 +336,7 @@ paths:
   /events/{event_key}:
     get:
       summary: Get events by event key
-      operationId: get-events
+      operationId: get_events
       tags:
         - events
       parameters:
@@ -367,7 +367,7 @@ paths:
   /accounts/{address}/events/{event_handle_struct}/{field_name}:
     get:
       summary: Get events by event handle.
-      operationId: get-account-events
+      operationId: get_account_events
       description: >-
         This API extracts event key from the account resource identified
         by the `event_handle_struct` and `field_name`, then returns

--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -495,6 +495,7 @@ components:
 
 
         Different with `Address` type, hex-encoded bytes should not trim any zeros.
+      example: "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1"
     TimestampSec:
       type: string
       format: uint64
@@ -604,7 +605,7 @@ components:
           1. Empty chars should be ignored when comparing 2 struct tag ids.
           2. When used in an URL path, should be encoded by url-encoding (AKA percent-encoding).
       example: >-
-        0x1::DiemAccount::Balance<0x1::XUS::XUS>
+        0x1::XUS::XUS
     MoveTypeId:
       type: string
       pattern: '^(bool|u8|u64|u128|address|signer|vector<.+>|0x[0-9a-zA-Z:_<>]+|^&(mut )?.+$|T\d+)$'
@@ -869,6 +870,7 @@ components:
           $ref: '#/components/schemas/Uint64'
         gas_currency_code:
           type: string
+          example: "XDX"
         expiration_timestamp_secs:
           $ref: '#/components/schemas/TimestampSec'
         payload:
@@ -907,6 +909,7 @@ components:
       properties:
         type:
           type: string
+          example: "pending_transaction"
         hash:
           $ref: '#/components/schemas/HexEncodedBytes'
     PendingTransaction:
@@ -962,6 +965,7 @@ components:
       properties:
         type:
           type: string
+          example: "user_transaction"
         events:
           type: array
           items:
@@ -984,6 +988,7 @@ components:
       properties:
         type:
           type: string
+          example: "block_metadata_transaction"
         id:
           $ref: '#/components/schemas/HexEncodedBytes'
         round:
@@ -1009,6 +1014,7 @@ components:
       properties:
         type:
           type: string
+          example: "genesis_transaction"
         payload:
           $ref: '#/components/schemas/WriteSetPayload'
         events:
@@ -1043,22 +1049,32 @@ components:
       properties:
         type:
           type: string
+          example: script_function_payload
         module:
           type: string
+          example: 0x1::PaymentScripts
           description: Module identifier / name, case sensitive
         function:
           type: string
+          example: peer_to_peer_with_metadata
           description: Script function name, case sensitive.
         type_arguments:
           type: array
           description: Generic type arguments required by the script function.
           items:
             $ref: '#/components/schemas/MoveTypeTagId'
+          example:
+            - "0x1::XDX::XDX"
         arguments:
           type: array
           description: The script function arguments.
           items:
             $ref: '#/components/schemas/MoveValue'
+          example:
+            - "0x1668f6be25668c1a17cd8caf6b8d2f25"
+            - "2021000000"
+            - "0x"
+            - "0x"
     ScriptPayload:
       type: object
       required:
@@ -1069,6 +1085,7 @@ components:
       properties:
         type:
           type: string
+          example: script_payload
         code:
           $ref: '#/components/schemas/MoveScriptBytecode'
         type_arguments:
@@ -1087,6 +1104,7 @@ components:
       properties:
         type:
           type: string
+          example: move_module_bytecode_payload
         bytecode:
           $ref: '#/components/schemas/HexEncodedBytes'
         abi:
@@ -1099,6 +1117,7 @@ components:
       properties:
         type:
           type: string
+          example: write_set_payload
         write_set:
           $ref: '#/components/schemas/WriteSet'
     WriteSet:
@@ -1119,6 +1138,7 @@ components:
       properties:
         type:
           type: string
+          example: script_write_set
         execute_as:
           $ref: '#/components/schemas/Address'
         script:
@@ -1132,6 +1152,7 @@ components:
       properties:
         type:
           type: string
+          example: direct_write_set
         changes:
           type: array
           items:
@@ -1162,6 +1183,7 @@ components:
       properties:
         type:
           type: string
+          example: delete_module
         address:
           $ref: '#/components/schemas/Address'
         module:
@@ -1176,6 +1198,7 @@ components:
       properties:
         type:
           type: string
+          example: delete_resource
         address:
           $ref: '#/components/schemas/Address'
         resource:
@@ -1190,6 +1213,7 @@ components:
       properties:
         type:
           type: string
+          example: write_module
         address:
           $ref: '#/components/schemas/Address'
         data:
@@ -1204,6 +1228,7 @@ components:
       properties:
         type:
           type: string
+          example: write_resource
         address:
           $ref: '#/components/schemas/Address'
         data:
@@ -1238,28 +1263,50 @@ components:
       type: string
       format: uint64
       description: Unsiged int64 type value
+      example: "0"
     MoveValue:
-      oneOf:
-        - type: string
-          description: >-
-            Move `uint64`, `uint128` or `address` type value.
+      description: >-
+        Move `bool` type value is serialized into `boolean`.
 
 
-            Move `address` type value is hex-encoded 16 bytes Diem account address;
-            it is prefixed with `0x` and leading zeros are trimmed.
-        - type: boolean
-          description: >-
-            Move `bool` type value
-        - type: integer
-          description: >-
-            Move `u8` type value
-        - type: array
-          items:
-            $ref: '#/components/schemas/MoveValue'
-        - type: object
-          description: >-
-            Move struct value; the property name is serialized from Move struct field name
-            and the property value is serialized from struct field value(`MoveValue`).
+        Move `u8` type value is serialized into `integer`.
+
+
+        Move `u64` and `u128` type value is serialized into `string`.
+
+
+        Move `address` type value(16 bytes Diem account address) is serialized into
+        hex-encoded string, which is prefixed with `0x` and leading zeros are trimmed.
+
+
+        For example:
+          * `0x1`
+          * `0x1668f6be25668c1a17cd8caf6b8d2f25`
+
+
+        Move `vector` type value is serialized into `array`, except `vector<u8>` which is
+        serialized into hex-encoded string with `0x` prefix.
+
+
+        For example:
+          * `vector<u64>{255, 255}` => `["255", "255"]`
+          * `vector<u8>{255, 255}` => `0xffff`
+
+
+        Move `struct` type value is serialized into `object` that looks like this:
+
+          ```json
+          {
+            field1_name: field1_value,
+            field2_name: field2_value,
+            ......
+          }
+          ```
+
+        For example:
+          `{ "created": "0xa550c18", "role_id": "0" }`
+
+      example: "3344000000"
     Event:
       type: object
       required:
@@ -1282,9 +1329,16 @@ components:
         sequence_number:
           $ref: '#/components/schemas/EventSequenceNumber'
         type:
-          $ref: '#/components/schemas/MoveTypeTagId'
+          allOf:
+            - $ref: '#/components/schemas/MoveTypeTagId'
+            - example: >-
+                0x1::DiemAccount::CreateAccountEvent
         data:
-          $ref: '#/components/schemas/MoveValue'
+          allOf:
+            - $ref: '#/components/schemas/MoveValue'
+            - example:
+                created: "0xa550c18"
+                role_id: "0"
     TransactionSignature:
       oneOf:
         - $ref: '#/components/schemas/Ed25519Signature'
@@ -1308,6 +1362,7 @@ components:
       properties:
         type:
           type: string
+          example: ed25519_signature
         public_key:
           $ref: '#/components/schemas/HexEncodedBytes'
         signature:
@@ -1325,6 +1380,7 @@ components:
       properties:
         type:
           type: string
+          example: multi_ed25519_signature
         public_keys:
           type: array
           description: all public keys of the sender account
@@ -1352,6 +1408,7 @@ components:
       properties:
         type:
           type: string
+          example: multi_agent_signature
         sender:
           $ref: '#/components/schemas/AccountSignature'
         secondary_signer_addresses:

--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -30,6 +30,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LedgerInfo'
+        "400":
+          $ref: '#/components/responses/400'
         "500":
           $ref: '#/components/responses/500'
   /spec.html:
@@ -41,6 +43,8 @@ paths:
       responses:
         "200":
           description: Returns OpenAPI specification html document.
+        "400":
+          $ref: '#/components/responses/400'
   /openapi.yaml:
     get:
       summary: OpenAPI YAML specification.
@@ -50,6 +54,8 @@ paths:
       responses:
         "200":
           description: Returns OpenAPI specification YAML document.
+        "400":
+          $ref: '#/components/responses/400'
   /accounts/{address}/resources:
     get:
       summary: Get account resources
@@ -216,9 +222,7 @@ paths:
         content:
           application/json:
             schema:
-              allOf:
-                - $ref: '#/components/schemas/UserTransactionRequest'
-                - $ref: '#/components/schemas/UserTransactionSignature'
+              $ref: '#/components/schemas/SubmitTransactionRequest'
           application/vnd.bcs+signed_transaction:
             schema:
               type: string
@@ -265,8 +269,12 @@ paths:
         - name: txn_hash_or_version
           in: path
           required: true
+          description: >-
+            * Transaction hash should be hex-encoded bytes string with `0x` prefix.
+
+            * Transaction version is an `uint64` number.
           schema:
-            $ref: '#/components/schemas/TransactionHashOrVersion'
+            type: string
       responses:
         "200":
           description: >-
@@ -274,9 +282,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                  - $ref: '#/components/schemas/PendingTransaction'
-                  - $ref: '#/components/schemas/OnChainTransaction'
+                $ref: '#/components/schemas/Transaction'
         "400":
           $ref: '#/components/responses/400'
         "404":
@@ -375,7 +381,7 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/MoveStructTagID'
+            $ref: '#/components/schemas/MoveStructTagId'
           example: 0x1::DiemAccount::DiemAccount
         - name: field_name
           in: path
@@ -408,7 +414,7 @@ components:
       in: path
       required: true
       schema:
-        $ref: '#/components/schemas/address'
+        $ref: '#/components/schemas/Address'
     LedgerVersion:
       name: ledger_version
       in: path
@@ -468,7 +474,7 @@ components:
           type: string
         diem_ledger_version:
           $ref: '#/components/schemas/LedgerVersion'
-    address:
+    Address:
       type: string
       format: address
       description: >-
@@ -488,7 +494,7 @@ components:
         two hex digits per byte.
 
 
-        Different with `address` type, hex-encoded bytes should not trim any zeros.
+        Different with `Address` type, hex-encoded bytes should not trim any zeros.
     TimestampSec:
       type: string
       format: uint64
@@ -507,13 +513,6 @@ components:
       example: "52635485"
       description: >-
         The version of the latest transaction in the ledger.
-    TransactionHashOrVersion:
-      description: >-
-        Transaction hash should be hex-encoded bytes string.
-        Transaction version should be an unsigned int64.
-      anyOf:
-        - $ref: '#/components/schemas/HexEncodedBytes'
-        - $ref: '#/components/schemas/u64'
     EventKey:
       type: string
       format: hex
@@ -562,51 +561,124 @@ components:
         - value
       properties:
         type:
-          $ref: '#/components/schemas/MoveStructTagID'
+          $ref: '#/components/schemas/MoveStructTagId'
         value:
           type: "object"
           description: >-
-            Account resource data value, deserialized from Move data, field name map to field value, use `type` field information to decode.
-    MoveTypeTagID:
-      oneOf:
-        - $ref: '#/components/schemas/MovePrimitiveTypeID'
-        - $ref: '#/components/schemas/MoveVectorTypeID'
-        - $ref: '#/components/schemas/MoveStructTagID'
-    MoveTypeID:
-      oneOf:
-        - $ref: '#/components/schemas/MovePrimitiveTypeID'
-        - $ref: '#/components/schemas/MoveVectorTypeID'
-        - $ref: '#/components/schemas/MoveStructTagID'
-        - $ref: '#/components/schemas/MoveReferenceTypeID'
-        - $ref: '#/components/schemas/MoveGenericTypeID'
-    MovePrimitiveTypeID:
+            Account resource data value, deserialized from Move data.
+            The sibling property `type` is the Move struct type tag identifier for the value.
+
+
+            The property name is from Move struct field name, and property value is the
+            Move struct field value.
+    MoveTypeTagId:
       type: string
-      format: move_type
-      enum:
-        - bool
-        - u8
-        - u64
-        - u128
-        - address
-        - signer
-    MoveVectorTypeID:
-      type: string
-      format: move_type
-      pattern: '^vector<.+>$'
+      pattern: '^(bool|u8|u64|u128|address|signer|vector<.+>|0x[0-9a-zA-Z:_<>]+)$'
       description: >-
-        String representation of an on-chain Move vector: `vector<{non-reference MoveTypeID}>`
+        String representation of an on-chain Move type tag that is exposed in transaction payload.
+
+        Values:
+          - bool
+          - u8
+          - u64
+          - u128
+          - address
+          - signer
+          - vector: `vector<{non-reference MoveTypeId}>`
+          - struct: `{address}::{module_name}::{struct_name}::<{generic types}>`
 
 
-        Examples:
+        Vector type value examples:
           * `vector<u8>`
           * `vector<vector<u64>>`
           * `vector<0x1::DiemAccount::Balance<0x1::XDX::XDX>>`
 
 
-        See [doc](https://diem.github.io/move/vector.html) for more details.
-      example:
-        - "vector<u8>"
-    MoveStructTagID:
+        Struct type value examples:
+          * `0x1::Diem::Diem<0x1::XDX::XDX>`
+          * `0x1::Abc::Abc<vector<u8>, vector<u64>>`
+          * `0x1::DiemAccount::AccountOperationsCapability`
+
+
+        Note:
+          1. Empty chars should be ignored when comparing 2 struct tag ids.
+          2. When used in an URL path, should be encoded by url-encoding (AKA percent-encoding).
+      example: >-
+        0x1::DiemAccount::Balance<0x1::XUS::XUS>
+    MoveTypeId:
+      type: string
+      pattern: '^(bool|u8|u64|u128|address|signer|vector<.+>|0x[0-9a-zA-Z:_<>]+|^&(mut )?.+$|T\d+)$'
+      description: >-
+        String representation of an on-chain Move type identifier defined by the Move language.
+
+
+        Values:
+          - bool
+          - u8
+          - u64
+          - u128
+          - address
+          - signer
+          - vector: `vector<{non-reference MoveTypeId}>`
+          - struct: `{address}::{module_name}::{struct_name}::<{generic types}>`
+          - reference: immutable `&` and mutable `&mut` references.
+          - generic_type_parameter: it is always start with `T` and following an index number,
+            which is the position of the generic type parameter in the `struct` or
+            `function` generic type parameters definition.
+
+
+        Vector type value examples:
+          * `vector<u8>`
+          * `vector<vector<u64>>`
+          * `vector<0x1::DiemAccount::Balance<0x1::XDX::XDX>>`
+
+
+        Struct type value examples:
+          * `0x1::Diem::Diem<0x1::XDX::XDX>`
+          * `0x1::Abc::Abc<vector<u8>, vector<u64>>`
+          * `0x1::DiemAccount::AccountOperationsCapability`
+
+
+        Reference type value examples:
+          * `&signer`
+          * `&mut address`
+          * `&mut vector<u8>`
+
+
+        Generic type parameter value example, the following is `0x1::TransactionFee::TransactionFee` JSON representation:
+
+            {
+                "name": "TransactionFee",
+                "is_native": false,
+                "abilities": ["key"],
+                "generic_type_params": [
+                    {"constraints": [], "is_phantom": true}
+                ],
+                "fields": [
+                    { "name": "balance", "type": "0x1::Diem::Diem<T0>" },
+                    { "name": "preburn", "type": "0x1::Diem::Preburn<T0>" }
+                ]
+            }
+
+        It's Move source code:
+
+            module DiemFramework::TransactionFee {
+                struct TransactionFee<phantom CoinType> has key {
+                    balance: Diem<CoinType>,
+                    preburn: Preburn<CoinType>,
+                }
+            }
+
+        The `T0` in the above JSON representation is the generic type place holder for
+        the `CoinType` in the Move source code.
+
+
+        Note:
+          1. Empty chars should be ignored when comparing 2 struct tag ids.
+          2. When used in an URL path, should be encoded by url-encoding (AKA percent-encoding).
+      example: >-
+        &mut 0x1::DiemAccount::Balance<0x1::XUS::XUS>
+    MoveStructTagId:
       type: string
       format: move_type
       pattern: '^0x[0-9a-zA-Z:_<>]+$'
@@ -633,63 +705,6 @@ components:
         See [doc](https://diem.github.io/move/structs-and-resources.html) for more details.
       example:
         - "0x1::DiemAccount::DiemAccount"
-    MoveReferenceTypeID:
-      type: string
-      format: move_type
-      pattern: '^&(mut )?.+$'
-      description: >-
-        A reference type string representation.
-
-
-        Move has two types of references: immutable `&` and mutable `&mut`.
-        For example:
-          * `&signer`
-          * `&mut address`
-          * `&mut vector<u8>`
-
-
-        See [doc](https://diem.github.io/move/references.html) for more details.
-      example: >-
-        &signer
-    MoveGenericTypeID:
-      type: string
-      format: move_type
-      pattern: '^T\d+$'
-      description: >-
-        A generic type parameter type string representation.
-
-
-        It is always start with `T` and following an index number, which
-        is the position of the generic type parameter in the `struct` or
-        `function` generic type parameters definition.
-
-
-        For example, the following is `0x1::TransactionFee::TransactionFee` JSON representation:
-
-            {
-                "name": "TransactionFee",
-                "is_native": false,
-                "abilities": ["key"],
-                "generic_type_params": [
-                    {"constraints": [], "is_phantom": true}
-                ],
-                "fields": [
-                    { "name": "balance", "type": "0x1::Diem::Diem<T0>" },
-                    { "name": "preburn", "type": "0x1::Diem::Preburn<T0>" }
-                ]
-            }
-
-        It's Move source code:
-
-            module DiemFramework::TransactionFee {
-                struct TransactionFee<phantom CoinType> has key {
-                    balance: Diem<CoinType>,
-                    preburn: Preburn<CoinType>,
-                }
-            }
-
-        The `T0` in the above JSON representation is the generic type place holder for
-        the `CoinType` in the Move source code.
     MoveModuleBytecode:
       type: object
       required:
@@ -701,6 +716,8 @@ components:
           $ref: '#/components/schemas/MoveModule'
     MoveModule:
       type: object
+      description: >-
+        JSON format of Move module interface definition.
       required:
         - address
         - name
@@ -709,7 +726,7 @@ components:
         - structs
       properties:
         address:
-          $ref: '#/components/schemas/address'
+          $ref: '#/components/schemas/Address'
         name:
           type: string
           example: "Diem"
@@ -769,7 +786,7 @@ components:
         name:
           type: string
         type:
-          $ref: '#/components/schemas/MoveTypeID'
+          $ref: '#/components/schemas/MoveTypeId'
     MoveFunction:
       type: object
       required:
@@ -786,7 +803,6 @@ components:
           type: string
           enum:
             - public
-            - private
             - script
             - friend
         generic_type_params:
@@ -803,11 +819,11 @@ components:
         params:
           type: array
           items:
-            $ref: '#/components/schemas/MoveTypeID'
+            $ref: '#/components/schemas/MoveTypeId'
         return:
           type: array
           items:
-            $ref: '#/components/schemas/MoveTypeID'
+            $ref: '#/components/schemas/MoveTypeId'
     MoveAbility:
       type: string
       enum:
@@ -827,7 +843,7 @@ components:
         - name
       properties:
         address:
-          $ref: '#/components/schemas/address'
+          $ref: '#/components/schemas/Address'
         name:
           type: string
           description: Module identifier / name
@@ -844,13 +860,13 @@ components:
         - payload
       properties:
         sender:
-          $ref: '#/components/schemas/address'
+          $ref: '#/components/schemas/Address'
         sequence_number:
-          $ref: '#/components/schemas/u64'
+          $ref: '#/components/schemas/Uint64'
         max_gas_amount:
-          $ref: '#/components/schemas/u64'
+          $ref: '#/components/schemas/Uint64'
         gas_unit_price:
-          $ref: '#/components/schemas/u64'
+          $ref: '#/components/schemas/Uint64'
         gas_currency_code:
           type: string
         expiration_timestamp_secs:
@@ -862,31 +878,52 @@ components:
       required:
         - signature
       description: >-
-        This schema is used for merging with `UserTransactionRequest`
-        to append `signature` field when it is required.
+        This schema is used for appending `signature` field to another schema.
       properties:
         signature:
           $ref: '#/components/schemas/TransactionSignature'
-    PendingTransaction:
+    Transaction:
+      oneOf:
+        - $ref: '#/components/schemas/PendingTransaction'
+        - $ref: '#/components/schemas/GenesisTransaction'
+        - $ref: '#/components/schemas/UserTransaction'
+        - $ref: '#/components/schemas/BlockMetadataTransaction'
+      discriminator:
+        propertyName: type
+        mapping:
+          pending_transaction: '#/components/schemas/PendingTransaction'
+          genesis_transaction: '#/components/schemas/GenesisTransaction'
+          user_transaction: '#/components/schemas/UserTransaction'
+          block_metadata_transaction: '#/components/schemas/BlockMetadataTransaction'
+    SubmitTransactionRequest:
       allOf:
-        - type: object
-          required:
-            - type
-            - hash
-          properties:
-            type:
-              type: string
-              enum:
-                - pending_transaction
-            hash:
-              $ref: '#/components/schemas/HexEncodedBytes'
         - $ref: '#/components/schemas/UserTransactionRequest'
         - $ref: '#/components/schemas/UserTransactionSignature'
+    PendingTransactionProperties:
+      type: object
+      required:
+        - type
+        - hash
+      properties:
+        type:
+          type: string
+        hash:
+          $ref: '#/components/schemas/HexEncodedBytes'
+    PendingTransaction:
+      allOf:
+        - $ref: '#/components/schemas/PendingTransactionProperties'
+        - $ref: '#/components/schemas/SubmitTransactionRequest'
     OnChainTransaction:
       oneOf:
         - $ref: '#/components/schemas/GenesisTransaction'
         - $ref: '#/components/schemas/UserTransaction'
         - $ref: '#/components/schemas/BlockMetadataTransaction'
+      discriminator:
+        propertyName: type
+        mapping:
+          genesis_transaction: '#/components/schemas/GenesisTransaction'
+          user_transaction: '#/components/schemas/UserTransaction'
+          block_metadata_transaction: '#/components/schemas/BlockMetadataTransaction'
     OnChainTransactionInfo:
       type: object
       required:
@@ -899,7 +936,7 @@ components:
         - vm_status
       properties:
         version:
-          $ref: '#/components/schemas/u64'
+          $ref: '#/components/schemas/Uint64'
         hash:
           $ref: '#/components/schemas/HexEncodedBytes'
         state_root_hash:
@@ -907,75 +944,80 @@ components:
         event_root_hash:
           $ref: '#/components/schemas/HexEncodedBytes'
         gas_used:
-          $ref: '#/components/schemas/u64'
+          $ref: '#/components/schemas/Uint64'
         success:
           type: boolean
+          description: >-
+            Transaction execution result (success: true, failure: false).
+            See `vm_status` for human readable error message from Diem VM.
         vm_status:
           type: string
+          description: >-
+            Human readable transaction execution result message from Diem VM.
+    UserTransactionProperties:
+      type: object
+      required:
+        - type
+        - events
+      properties:
+        type:
+          type: string
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/Event'
     UserTransaction:
       allOf:
-        - type: object
-          required:
-            - type
-            - events
-          properties:
-            type:
-              type: string
-              enum:
-                - user_transaction
-            events:
-              type: array
-              items:
-                $ref: '#/components/schemas/Event'
+        - $ref: '#/components/schemas/UserTransactionProperties'
         - $ref: '#/components/schemas/UserTransactionRequest'
         - $ref: '#/components/schemas/UserTransactionSignature'
         - $ref: '#/components/schemas/OnChainTransactionInfo'
+    BlockMetadataTransactionProperties:
+      type: object
+      required:
+        - type
+        - id
+        - round
+        - previous_block_votes
+        - proposer
+        - timestamp
+      properties:
+        type:
+          type: string
+        id:
+          $ref: '#/components/schemas/HexEncodedBytes'
+        round:
+          $ref: '#/components/schemas/Uint64'
+        previous_block_votes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+        proposer:
+          $ref: '#/components/schemas/Address'
+        timestamp:
+          $ref: '#/components/schemas/TimestampUsec'
     BlockMetadataTransaction:
       allOf:
-        - type: object
-          required:
-            - type
-            - id
-            - round
-            - previous_block_votes
-            - proposer
-            - timestamp
-          properties:
-            type:
-              type: string
-              enum:
-                - block_metadata_transaction
-            id:
-              $ref: '#/components/schemas/HexEncodedBytes'
-            round:
-              $ref: '#/components/schemas/u64'
-            previous_block_votes:
-              type: array
-              items:
-                $ref: '#/components/schemas/address'
-            proposer:
-              $ref: '#/components/schemas/address'
-            timestamp:
-              $ref: '#/components/schemas/TimestampUsec'
+        - $ref: '#/components/schemas/BlockMetadataTransactionProperties'
         - $ref: '#/components/schemas/OnChainTransactionInfo'
+    GenesisTransactionProperties:
+      type: object
+      required:
+        - type
+        - payload
+        - events
+      properties:
+        type:
+          type: string
+        payload:
+          $ref: '#/components/schemas/WriteSetPayload'
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/Event'
     GenesisTransaction:
       allOf:
-        - type: object
-          required:
-            - type
-            - payload
-            - events
-          properties:
-            type:
-              type: string
-              enum:
-                - genesis_transaction
-            payload:
-              $ref: '#/components/schemas/WriteSetPayload'
-            events:
-              type: array
-              items:
-                $ref: '#/components/schemas/Event'
+        - $ref: '#/components/schemas/GenesisTransactionProperties'
         - $ref: '#/components/schemas/OnChainTransactionInfo'
     TransactionPayload:
       oneOf:
@@ -983,6 +1025,13 @@ components:
         - $ref: '#/components/schemas/ScriptPayload'
         - $ref: '#/components/schemas/MoveModuleBytecodePayload'
         - $ref: '#/components/schemas/WriteSetPayload'
+      discriminator:
+        propertyName: type
+        mapping:
+          script_function_payload: '#/components/schemas/ScriptFunctionPayload'
+          script_payload: '#/components/schemas/ScriptPayload'
+          move_module_bytecode_payload: '#/components/schemas/MoveModuleBytecodePayload'
+          write_set_payload: '#/components/schemas/WriteSetPayload'
     ScriptFunctionPayload:
       type: object
       required:
@@ -994,8 +1043,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - script_function_payload
         module:
           type: string
           description: Module identifier / name, case sensitive
@@ -1006,7 +1053,7 @@ components:
           type: array
           description: Generic type arguments required by the script function.
           items:
-            $ref: '#/components/schemas/MoveTypeTagID'
+            $ref: '#/components/schemas/MoveTypeTagId'
         arguments:
           type: array
           description: The script function arguments.
@@ -1022,14 +1069,12 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - script_payload
         code:
           $ref: '#/components/schemas/MoveScriptBytecode'
         type_arguments:
           type: array
           items:
-            $ref: '#/components/schemas/MoveTypeTagID'
+            $ref: '#/components/schemas/MoveTypeTagId'
         arguments:
           type: array
           items:
@@ -1042,8 +1087,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - module_payload
         bytecode:
           $ref: '#/components/schemas/HexEncodedBytes'
         abi:
@@ -1056,14 +1099,17 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - write_set_payload
         write_set:
           $ref: '#/components/schemas/WriteSet'
     WriteSet:
       oneOf:
         - $ref: '#/components/schemas/ScriptWriteSet'
         - $ref: '#/components/schemas/DirectWriteSet'
+      discriminator:
+        propertyName: type
+        mapping:
+          script_write_set: '#/components/schemas/ScriptWriteSet'
+          direct_write_set: '#/components/schemas/DirectWriteSet'
     ScriptWriteSet:
       type: object
       required:
@@ -1073,10 +1119,8 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - script_write_set
         execute_as:
-          $ref: '#/components/schemas/address'
+          $ref: '#/components/schemas/Address'
         script:
           $ref: '#/components/schemas/Script'
     DirectWriteSet:
@@ -1088,8 +1132,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - direct_write_set
         changes:
           type: array
           items:
@@ -1104,6 +1146,13 @@ components:
         - $ref: '#/components/schemas/DeleteResource'
         - $ref: '#/components/schemas/WriteModule'
         - $ref: '#/components/schemas/WriteResource'
+      discriminator:
+        propertyName: type
+        mapping:
+          delete_module: '#/components/schemas/DeleteModule'
+          delete_resource: '#/components/schemas/DeleteResource'
+          write_module: '#/components/schemas/WriteModule'
+          write_resource: '#/components/schemas/WriteResource'
     DeleteModule:
       type: object
       required:
@@ -1113,10 +1162,8 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - delete_module
         address:
-          $ref: '#/components/schemas/address'
+          $ref: '#/components/schemas/Address'
         module:
           $ref: '#/components/schemas/MoveModuleId'
     DeleteResource:
@@ -1129,12 +1176,10 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - delete_resource
         address:
-          $ref: '#/components/schemas/address'
+          $ref: '#/components/schemas/Address'
         resource:
-          $ref: '#/components/schemas/MoveStructTagID'
+          $ref: '#/components/schemas/MoveStructTagId'
     WriteModule:
       type: object
       description: Write move module
@@ -1145,10 +1190,8 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - write_module
         address:
-          $ref: '#/components/schemas/address'
+          $ref: '#/components/schemas/Address'
         data:
           $ref: '#/components/schemas/MoveModuleBytecode'
     WriteResource:
@@ -1161,10 +1204,8 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - write_resource
         address:
-          $ref: '#/components/schemas/address'
+          $ref: '#/components/schemas/Address'
         data:
           $ref: '#/components/schemas/MoveResource'
     Script:
@@ -1179,7 +1220,7 @@ components:
         type_arguments:
           type: array
           items:
-            $ref: '#/components/schemas/MoveTypeTagID'
+            $ref: '#/components/schemas/MoveTypeTagId'
         arguments:
           type: array
           items:
@@ -1193,37 +1234,32 @@ components:
           $ref: '#/components/schemas/HexEncodedBytes'
         abi:
           $ref: '#/components/schemas/MoveFunction'
-    bool:
-      type: boolean
-      description: Move `bool` type value
-    u8:
-      type: integer
-      description: Unsiged int8 type value
-    u64:
+    Uint64:
       type: string
       format: uint64
       description: Unsiged int64 type value
-    u128:
-      type: string
-      format: uint128
-      description: Unsiged int128 type value
-    vector:
-      type: array
-      items:
-        $ref: '#/components/schemas/MoveValue'
-    struct:
-      type: object
-      description: Move struct value, object properties map to struct field name and value
-      additionalProperties: true
     MoveValue:
       oneOf:
-        - $ref: '#/components/schemas/bool'
-        - $ref: '#/components/schemas/u8'
-        - $ref: '#/components/schemas/u64'
-        - $ref: '#/components/schemas/u128'
-        - $ref: '#/components/schemas/address'
-        - $ref: '#/components/schemas/vector'
-        - $ref: '#/components/schemas/struct'
+        - type: string
+          description: >-
+            Move `uint64`, `uint128` or `address` type value.
+
+
+            Move `address` type value is hex-encoded 16 bytes Diem account address;
+            it is prefixed with `0x` and leading zeros are trimmed.
+        - type: boolean
+          description: >-
+            Move `bool` type value
+        - type: integer
+          description: >-
+            Move `u8` type value
+        - type: array
+          items:
+            $ref: '#/components/schemas/MoveValue'
+        - type: object
+          description: >-
+            Move struct value; the property name is serialized from Move struct field name
+            and the property value is serialized from struct field value(`MoveValue`).
     Event:
       type: object
       required:
@@ -1246,7 +1282,7 @@ components:
         sequence_number:
           $ref: '#/components/schemas/EventSequenceNumber'
         type:
-          $ref: '#/components/schemas/MoveTypeTagID'
+          $ref: '#/components/schemas/MoveTypeTagId'
         data:
           $ref: '#/components/schemas/MoveValue'
     TransactionSignature:
@@ -1254,6 +1290,12 @@ components:
         - $ref: '#/components/schemas/Ed25519Signature'
         - $ref: '#/components/schemas/MultiEd25519Signature'
         - $ref: '#/components/schemas/MultiAgentSignature'
+      discriminator:
+        propertyName: type
+        mapping:
+          ed25519_signature: '#/components/schemas/Ed25519Signature'
+          multi_ed25519_signature: '#/components/schemas/MultiEd25519Signature'
+          multi_agent_signature: '#/components/schemas/MultiAgentSignature'
     Ed25519Signature:
       type: object
       description: >-
@@ -1266,8 +1308,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - ed25519_signature
         public_key:
           $ref: '#/components/schemas/HexEncodedBytes'
         signature:
@@ -1285,8 +1325,6 @@ components:
       properties:
         type:
           type: string
-          enum:
-            - multi_ed25519_signature
         public_keys:
           type: array
           description: all public keys of the sender account
@@ -1307,16 +1345,19 @@ components:
       description: >-
         Multi agent signature, please refer to TBD.
       required:
+        - type
         - sender
         - secondary_signer_addresses
         - secondary_signers
       properties:
+        type:
+          type: string
         sender:
           $ref: '#/components/schemas/AccountSignature'
         secondary_signer_addresses:
           type: array
           items:
-            $ref: '#/components/schemas/address'
+            $ref: '#/components/schemas/Address'
         secondary_signers:
           type: array
           items:
@@ -1325,3 +1366,8 @@ components:
       oneOf:
         - $ref: '#/components/schemas/Ed25519Signature'
         - $ref: '#/components/schemas/MultiEd25519Signature'
+      discriminator:
+        propertyName: type
+        mapping:
+          ed25519_signature: '#/components/schemas/Ed25519Signature'
+          multi_ed25519_signature: '#/components/schemas/MultiEd25519Signature'


### PR DESCRIPTION
#9193 

Optimizing the openapi specification for client code generation by (openapi-generator):
1. Removed some alias types, which are created for better doc rendered into HTML.
2. Removed `enum` definition for the `type` field, replaced with `discriminator` field for type has `oneOf`. Enum type generation has bug in rust language.
3. Always use camel case type name to ensure generated type / struct / class names are consistent.
4. Removed `visibility` enum value `private`, it is valid in Move, but we don't render private function.
5. Extract out XxxProperties type for the type has inline type definition (under `allOf`). This removes a type named XxxAllOf to be generated and generates `XxxProperties` instead.
6. update operationId fields to use underscore instead of hyphen, generated code will use operationId for method names, use underscore is more consistent with generated code. For languages prefer camel case, code generator will convert the format.
7. updated/added some field value examples