### PR TITLE
[State Sync] Add auto-termination of blocked streams, garbage collection and unit tests.

### DIFF
--- a/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
@@ -17,6 +17,7 @@ use std::fmt::{Debug, Formatter};
 pub type NotificationId = u64;
 
 /// A generic data client response enum.
+// TODO(joshlind): remove me!
 pub type DataClientResponse = Response<ResponsePayload>;
 
 /// A single data notification with an ID and data payload.

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
@@ -35,7 +35,7 @@ const DATA_STREAM_CHANNEL_SIZE: usize = 1000;
 const MAX_CONCURRENT_REQUESTS: u64 = 3;
 
 // Maximum number of retries for a single client request before the stream terminates
-const MAX_REQUEST_RETRY: u64 = 10;
+pub const MAX_REQUEST_RETRY: u64 = 10;
 
 /// A unique ID used to identify each stream.
 pub type DataStreamId = u64;

--- a/state-sync/state-sync-v2/data-streaming-service/src/stream_progress_tracker.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/stream_progress_tracker.rs
@@ -512,7 +512,7 @@ impl DataStreamTracker for ContinuousTransactionStreamTracker {
                         .event(LogEvent::Pending)
                         .message(&format!(
                             "Requested an epoch ending ledger info for epoch: {:?}",
-                            target_ledger_info.ledger_info().epoch()
+                            next_request_epoch
                         )))
                 );
                 self.end_of_epoch_requested = true;

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
@@ -5,4 +5,4 @@ mod data_stream;
 mod stream_progress_tracker;
 mod streaming_client;
 mod streaming_service;
-mod utils;
+pub mod utils;

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
@@ -5,4 +5,4 @@ mod data_stream;
 mod stream_progress_tracker;
 mod streaming_client;
 mod streaming_service;
-pub mod utils;
+mod utils;

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
@@ -9,7 +9,7 @@ use crate::{
         new_streaming_service_client_listener_pair, ContinuouslyStreamTransactionOutputsRequest,
         ContinuouslyStreamTransactionsRequest, DataStreamingClient, GetAllAccountsRequest,
         GetAllEpochEndingLedgerInfosRequest, GetAllTransactionOutputsRequest,
-        GetAllTransactionsRequest, PayloadFeedback, StreamRequest, StreamingServiceListener,
+        GetAllTransactionsRequest, NotificationFeedback, StreamRequest, StreamingServiceListener,
         TerminateStreamRequest,
     },
     tests::utils::initialize_logger,
@@ -202,10 +202,10 @@ fn test_terminate_stream() {
 
     // Note the request we expect to receive on the streaming service side
     let request_notification_id = 19478;
-    let payload_feedback = PayloadFeedback::InvalidPayloadData;
+    let notification_feedback = NotificationFeedback::InvalidPayloadData;
     let expected_request = StreamRequest::TerminateStream(TerminateStreamRequest {
         notification_id: request_notification_id,
-        payload_feedback: payload_feedback.clone(),
+        notification_feedback: notification_feedback.clone(),
     });
 
     // Spawn a new server thread to handle any feedback requests
@@ -214,7 +214,7 @@ fn test_terminate_stream() {
     // Provide payload feedback and verify no error is returned
     let result = block_on(
         streaming_service_client
-            .terminate_stream_with_feedback(request_notification_id, payload_feedback),
+            .terminate_stream_with_feedback(request_notification_id, notification_feedback),
     );
     assert_ok!(result);
 }

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
@@ -6,7 +6,7 @@ use crate::{
     data_stream::DataStreamListener,
     error::Error,
     streaming_client::{
-        new_streaming_service_client_listener_pair, DataStreamingClient, PayloadFeedback,
+        new_streaming_service_client_listener_pair, DataStreamingClient, NotificationFeedback,
         StreamingServiceClient,
     },
     streaming_service::DataStreamingService,
@@ -92,7 +92,7 @@ async fn test_notifications_accounts_multiple_streams() {
                     streaming_client
                         .terminate_stream_with_feedback(
                             data_notification.notification_id,
-                            PayloadFeedback::InvalidPayloadData,
+                            NotificationFeedback::InvalidPayloadData,
                         )
                         .await
                         .unwrap();
@@ -533,7 +533,7 @@ async fn test_terminate_stream() {
     let result = streaming_client
         .terminate_stream_with_feedback(
             data_notification.notification_id,
-            PayloadFeedback::InvalidPayloadData,
+            NotificationFeedback::InvalidPayloadData,
         )
         .await;
     assert_ok!(result);

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
@@ -133,7 +133,6 @@ async fn test_notifications_continuous_outputs() {
                     let ledger_info = ledger_info_with_sigs.ledger_info();
                     // Verify the epoch of the ledger info
                     assert_eq!(ledger_info.epoch(), next_expected_epoch);
-                    assert_eq!(ledger_info.epoch(), next_expected_epoch);
 
                     // Verify the output start version matches the expected version
                     let first_output_version = outputs_with_proofs.first_transaction_output_version;

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -48,7 +48,7 @@ pub const MIN_ADVERTISED_TRANSACTION_OUTPUT: u64 = 1000;
 pub const MAX_ADVERTISED_TRANSACTION_OUTPUT: u64 = 10000;
 
 /// Test timeout constant
-pub const MAX_NOTIFICATION_TIMEOUT_SECS: u64 = 5;
+pub const MAX_NOTIFICATION_TIMEOUT_SECS: u64 = 10;
 
 /// A simple mock of the Diem Data Client
 #[derive(Clone, Debug)]

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -194,20 +194,10 @@ impl DiemDataClient for MockDiemDataClient {
     ) -> Result<Response<TransactionListWithProof>, diem_data_client::Error> {
         self.emulate_network_latencies();
 
-        // Include events if required
-        let events = if include_events { Some(vec![]) } else { None };
+        let transaction_list_with_proof =
+            create_transaction_list_with_proof(start_version, end_version, include_events);
 
-        // Create the requested transactions
-        let mut transactions = vec![];
-        for _ in start_version..=end_version {
-            transactions.push(create_transaction());
-        }
-
-        // Create a transaction list with an empty proof
-        let mut transaction_list_with_proof = TransactionListWithProof::new_empty();
-        transaction_list_with_proof.first_transaction_version = Some(start_version);
-        transaction_list_with_proof.events = events;
-        transaction_list_with_proof.transactions = transactions;
+        // Return the transaction list with proofs
         Ok(create_data_client_response(transaction_list_with_proof))
     }
 
@@ -349,7 +339,7 @@ fn create_transaction_output() -> TransactionOutput {
 }
 
 /// Returns a random u64 with a value between 0 and `max_value` - 1 (inclusive).
-fn create_random_u64(max_value: u64) -> u64 {
+pub fn create_random_u64(max_value: u64) -> u64 {
     create_range_random_u64(0, max_value)
 }
 
@@ -388,4 +378,27 @@ pub async fn get_data_notification(
             "Timed out waiting for a data notification!".into(),
         ))
     }
+}
+
+pub fn create_transaction_list_with_proof(
+    start_version: u64,
+    end_version: u64,
+    include_events: bool,
+) -> TransactionListWithProof {
+    // Include events if required
+    let events = if include_events { Some(vec![]) } else { None };
+
+    // Create the requested transactions
+    let mut transactions = vec![];
+    for _ in start_version..=end_version {
+        transactions.push(create_transaction());
+    }
+
+    // Create a transaction list with an empty proof
+    let mut transaction_list_with_proof = TransactionListWithProof::new_empty();
+    transaction_list_with_proof.first_transaction_version = Some(start_version);
+    transaction_list_with_proof.events = events;
+    transaction_list_with_proof.transactions = transactions;
+
+    transaction_list_with_proof
 }

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -122,7 +122,7 @@ impl DiemDataClient for MockDiemDataClient {
         // Create a random set of optimal chunk sizes to emulate changing environments
         let optimal_chunk_sizes = OptimalChunkSizes {
             account_states_chunk_size: create_non_zero_random_u64(100),
-            epoch_chunk_size: create_non_zero_random_u64(100),
+            epoch_chunk_size: create_non_zero_random_u64(10),
             transaction_chunk_size: create_non_zero_random_u64(2000),
             transaction_output_chunk_size: create_non_zero_random_u64(100),
         };


### PR DESCRIPTION
## Motivation

This PR extends the data streaming service with: (i) auto-termination when data streams become blocked and are unable to make progress (i.e., data refetches continuously fail); (ii) garbage collection for long lived streams (i.e., reducing internal notification storage); and (iii) additional unit tests to verify termination and garbage collection functionality.

To achieve this, the PR offers the following commits:
1. Add auto terminate functionality for blocked streams. These are streams that are unable to make progress after a specified number of data refetches.
2. Add unit tests for blocked streams and auto-termination.
3. Add garbage collection support for long lived streams and a unit test to verify this behaviour.
4. Add new unit tests to verify stream termination and creation.
5. Support for abortion of spawned tasks owned by a stream that has been terminated. This reduces unnecessary CPU cycles.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New unit tests have been added.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906