### PR TITLE
[move] Bump VS Code test timeout

### DIFF
--- a/language/move-analyzer/editors/code/tests/index.ts
+++ b/language/move-analyzer/editors/code/tests/index.ts
@@ -17,6 +17,9 @@ export async function run(): Promise<void> {
     const suite = new Mocha({
         ui: 'tdd',
         color: true,
+        // The default timeout of 2000 miliseconds can sometimes be too quick, since the extension
+        // tests need to launch VS Code first.
+        timeout: 5000,
     });
 
     const testsRoot = path.resolve(__dirname, '..');


### PR DESCRIPTION
The GitHub action to test the move-analyzer VS Code extension (the language server client) would sometimes timeout. When run locally, the tests spend most of their time booting up an instance of VS Code. Bump the timeout up 2.5x, on the assumption that this is also why the GitHub action is taking a while.