### PR TITLE
[network/mempool] Add Network mock framework for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2252,6 +2252,7 @@ dependencies = [
  "channel",
  "diem-config",
  "diem-crypto",
+ "diem-id-generator",
  "diem-infallible",
  "diem-logger",
  "diem-metrics",

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -52,6 +52,7 @@ enum_dispatch = "0.3.5"
 proptest = "1.0.0"
 
 diem-config = { path = "../config", features = ["fuzzing"] }
+diem-id-generator = { path = "../common/id-generator" }
 network = { path = "../network", features = ["fuzzing"] }
 storage-interface = { path = "../storage/storage-interface", features = ["fuzzing"] }
 

--- a/mempool/src/tests/integration_tests.rs
+++ b/mempool/src/tests/integration_tests.rs
@@ -1,0 +1,186 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::tests::test_framework::{test_transactions, MempoolTestFramework};
+use diem_config::{
+    config::PeerRole,
+    network_id::{NetworkId, PeerNetworkId},
+};
+use diem_types::PeerId;
+use futures::executor::block_on;
+use netcore::transport::ConnectionOrigin;
+use network::{
+    testutils::{
+        builder::TestFrameworkBuilder,
+        test_framework::TestFramework,
+        test_node::{mock_conn_metadata, ApplicationNode, NodeId, TestNode},
+    },
+    ProtocolId,
+};
+
+#[test]
+fn single_node_test() {
+    let mut test_framework: MempoolTestFramework =
+        TestFrameworkBuilder::new(1).add_validator(0).build();
+    let mut node = test_framework.take_node(NodeId::validator(0));
+    let network_id = NetworkId::Validator;
+    let other_peer_network_id = PeerNetworkId::new(network_id, PeerId::random());
+    let other_metadata = mock_conn_metadata(
+        other_peer_network_id,
+        PeerRole::Validator,
+        ConnectionOrigin::Outbound,
+        Some(&[ProtocolId::MempoolDirectSend]),
+    );
+    let future = async move {
+        let all_txns = test_transactions(0, 3);
+        let all_txns = all_txns.as_slice();
+        let inbound_handle = node.get_inbound_handle(network_id);
+        node.assert_txns_not_in_mempool(&all_txns[0..1]);
+        node.add_txns_via_client(&all_txns[0..1]).await;
+
+        // After we connect, we should try to send messages to it
+        inbound_handle.connect(
+            node.peer_network_id(network_id).peer_id(),
+            network_id,
+            other_metadata,
+        );
+
+        // Respond and at this point, txn will have shown up
+        node.verify_broadcast_and_ack(other_peer_network_id, &all_txns[0..1])
+            .await;
+
+        // Now submit another txn and check
+        node.add_txns_via_client(&all_txns[1..2]).await;
+        node.assert_txns_in_mempool(&all_txns[0..2]);
+        node.verify_broadcast_and_ack(other_peer_network_id, &all_txns[1..2])
+            .await;
+
+        // Let's also send it an incoming request with more txns and respond with an ack (DirectSend)
+        node.send_message(
+            ProtocolId::MempoolDirectSend,
+            other_peer_network_id,
+            &all_txns[2..3],
+        )
+        .await;
+        node.assert_txns_in_mempool(&all_txns[0..3]);
+        node.commit_txns(&all_txns[0..3]);
+        node.assert_txns_not_in_mempool(&all_txns[0..3]);
+    };
+    block_on(future);
+}
+
+/// Tests if the node is a VFN, and it's getting forwarded messages from a PFN.  It should forward
+/// messages to the upstream VAL.  Upstream and downstream nodes are mocked.
+#[test]
+fn vfn_middle_man_test() {
+    let mut test_framework: MempoolTestFramework = TestFrameworkBuilder::new(1).add_vfn(0).build();
+    let mut node = test_framework.take_node(NodeId::vfn(0));
+    let validator_peer_network_id = PeerNetworkId::new(NetworkId::Vfn, PeerId::random());
+    let validator_metadata = mock_conn_metadata(
+        validator_peer_network_id,
+        PeerRole::Validator,
+        ConnectionOrigin::Outbound,
+        Some(&[ProtocolId::MempoolDirectSend]),
+    );
+
+    let fn_peer_network_id = PeerNetworkId::new(NetworkId::Vfn, PeerId::random());
+    let fn_metadata = mock_conn_metadata(
+        fn_peer_network_id,
+        PeerRole::Unknown,
+        ConnectionOrigin::Inbound,
+        Some(&[ProtocolId::MempoolDirectSend]),
+    );
+
+    let future = async move {
+        let test_txns = test_transactions(0, 2);
+        let inbound_handle = node.get_inbound_handle(NetworkId::Vfn);
+        // Connect upstream Validator and downstream FN
+        inbound_handle.connect(
+            node.peer_network_id(NetworkId::Vfn).peer_id(),
+            NetworkId::Vfn,
+            validator_metadata,
+        );
+        let inbound_handle = node.get_inbound_handle(NetworkId::Public);
+        inbound_handle.connect(
+            node.peer_network_id(NetworkId::Public).peer_id(),
+            NetworkId::Public,
+            fn_metadata,
+        );
+
+        // Incoming transactions should be accepted
+        node.send_message(
+            ProtocolId::MempoolDirectSend,
+            fn_peer_network_id,
+            &test_txns,
+        )
+        .await;
+        node.assert_txns_in_mempool(&test_txns);
+
+        // And they should be forwarded upstream
+        node.verify_broadcast_and_ack(validator_peer_network_id, &test_txns)
+            .await;
+    };
+    block_on(future);
+}
+
+/// Tests if the node is a VFN, and it's getting forwarded messages from a PFN.  It should forward
+/// messages to the upstream VAL.  Upstream and downstream nodes also are running nodes.
+#[test]
+fn fn_to_val_test() {
+    let mut test_framework: MempoolTestFramework = TestFrameworkBuilder::new(1)
+        .add_validator(0)
+        .add_vfn(0)
+        .add_pfn(0)
+        .build();
+
+    let mut val = test_framework.take_node(NodeId::validator(0));
+    let mut vfn = test_framework.take_node(NodeId::vfn(0));
+    let mut pfn = test_framework.take_node(NodeId::pfn(0));
+    let pfn_txns = test_transactions(0, 3);
+    let vfn_txns = pfn_txns.clone();
+    let val_txns = pfn_txns.clone();
+
+    let pfn_vfn_network = pfn.find_common_network(&vfn).unwrap();
+    let vfn_metadata = vfn.conn_metadata(
+        pfn_vfn_network,
+        ConnectionOrigin::Outbound,
+        Some(&[ProtocolId::MempoolDirectSend]),
+    );
+    let vfn_val_network = vfn.find_common_network(&val).unwrap();
+    let val_metadata = val.conn_metadata(
+        vfn_val_network,
+        ConnectionOrigin::Outbound,
+        Some(&[ProtocolId::MempoolDirectSend]),
+    );
+
+    // NOTE: Always return node at end, or it will be dropped and channels closed
+    let pfn_future = async move {
+        pfn.connect(pfn_vfn_network, vfn_metadata);
+        pfn.add_txns_via_client(&pfn_txns).await;
+        pfn.assert_txns_in_mempool(&pfn_txns);
+        // Forward to VFN
+        pfn.send_next_network_msg(pfn_vfn_network).await;
+        pfn
+    };
+
+    let vfn_future = async move {
+        vfn.connect(vfn_val_network, val_metadata);
+
+        // Respond to PFN
+        vfn.send_next_network_msg(pfn_vfn_network).await;
+        vfn.assert_txns_in_mempool(&vfn_txns);
+
+        // Forward to VAL
+        vfn.send_next_network_msg(vfn_val_network).await;
+        vfn
+    };
+
+    let val_future = async move {
+        // Respond to VFN
+        val.send_next_network_msg(vfn_val_network).await;
+        val.assert_txns_in_mempool(&val_txns);
+        val
+    };
+
+    let _ = block_on(futures::future::join3(pfn_future, vfn_future, val_future));
+}

--- a/mempool/src/tests/mod.rs
+++ b/mempool/src/tests/mod.rs
@@ -6,6 +6,8 @@ mod common;
 #[cfg(test)]
 mod core_mempool_test;
 #[cfg(test)]
+mod integration_tests;
+#[cfg(test)]
 mod multi_node_test;
 #[cfg(test)]
 mod node;
@@ -15,3 +17,5 @@ mod shared_mempool_test;
 pub mod fuzzing;
 #[cfg(any(feature = "fuzzing", test))]
 pub mod mocks;
+#[cfg(test)]
+mod test_framework;

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -1,0 +1,546 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    core_mempool::CoreMempool,
+    network::{MempoolNetworkEvents, MempoolNetworkSender, MempoolSyncMsg},
+    shared_mempool::start_shared_mempool,
+    tests::common::TestTransaction,
+    ConsensusRequest, MempoolClientRequest, MempoolClientSender,
+};
+use diem_config::{
+    config::NodeConfig,
+    network_id::{NetworkId, PeerNetworkId},
+};
+use diem_id_generator::{IdGenerator, U32IdGenerator};
+use diem_infallible::{Mutex, RwLock};
+use diem_types::{
+    account_address::AccountAddress, mempool_status::MempoolStatusCode,
+    on_chain_config::ON_CHAIN_CONFIG_REGISTRY, transaction::SignedTransaction,
+};
+use event_notifications::EventSubscriptionService;
+use futures::{channel::oneshot, SinkExt};
+use mempool_notifications::MempoolNotifier;
+use network::{
+    application::storage::PeerMetadataStorage,
+    peer_manager::{PeerManagerNotification, PeerManagerRequest},
+    protocols::{direct_send::Message, rpc::InboundRpcRequest},
+    testutils::{
+        test_framework::{setup_node_networks, TestFramework},
+        test_node::{
+            ApplicationNetworkHandle, ApplicationNode, InboundNetworkHandle, NodeId, NodeType,
+            OutboundMessageReceiver, TestNode,
+        },
+    },
+    ProtocolId,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
+use storage_interface::{mock::MockDbReaderWriter, DbReaderWriter};
+use tokio::runtime::Runtime;
+use tokio_stream::StreamExt;
+use vm_validator::mocks::mock_vm_validator::MockVMValidator;
+
+/// An inbound sender for notifications from consensus
+pub type MempoolConsensusSender = futures::channel::mpsc::Sender<ConsensusRequest>;
+
+/// An individual mempool node that runs in it's own runtime.
+///
+/// TODO: Add ability to mock StateSync updates to remove transactions
+/// TODO: Add ability to reject transactions via Consensus
+pub struct MempoolNode {
+    /// The [`CoreMempool`] storage of the node
+    pub mempool: Arc<Mutex<CoreMempool>>,
+    /// A generator for [`MempoolSyncMsg`] request ids.
+    pub request_id_generator: U32IdGenerator,
+    /// This runtime has to be here to ensure that the channels don't close prematurely
+    _runtime: Arc<Runtime>,
+
+    // Mempool specific channels
+    /// Used for incoming JSON-RPC requests (e.g. adding new transactions)
+    pub mempool_client_sender: MempoolClientSender,
+    /// Used for Rejections notifications from consensus
+    pub mempool_consensus_sender: MempoolConsensusSender,
+    /// Used for StateSync commit notifications
+    pub mempool_notifications: MempoolNotifier,
+
+    // Networking specifics
+    node_id: NodeId,
+    peer_network_ids: HashMap<NetworkId, PeerNetworkId>,
+    peer_metadata_storage: Arc<PeerMetadataStorage>,
+
+    inbound_handles: HashMap<NetworkId, InboundNetworkHandle>,
+    outbound_handles: HashMap<NetworkId, OutboundMessageReceiver>,
+    other_inbound_handles: HashMap<PeerNetworkId, InboundNetworkHandle>,
+}
+
+impl std::fmt::Display for MempoolNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.node_id)
+    }
+}
+
+impl ApplicationNode for MempoolNode {
+    fn node_id(&self) -> NodeId {
+        self.node_id
+    }
+
+    fn default_protocols(&self) -> &[ProtocolId] {
+        &[ProtocolId::MempoolDirectSend]
+    }
+
+    fn get_inbound_handle(&self, network_id: NetworkId) -> InboundNetworkHandle {
+        self.inbound_handles
+            .get(&network_id)
+            .unwrap_or_else(|| panic!("Must have inbound handle for network {}", network_id))
+            .clone()
+    }
+
+    fn add_inbound_handle_for_peer(
+        &mut self,
+        peer_network_id: PeerNetworkId,
+        handle: InboundNetworkHandle,
+    ) {
+        if self
+            .other_inbound_handles
+            .insert(peer_network_id, handle)
+            .is_some()
+        {
+            panic!(
+                "Double added handle for {} on {}",
+                peer_network_id, self.node_id
+            )
+        }
+    }
+
+    fn get_inbound_handle_for_peer(&self, peer_network_id: PeerNetworkId) -> InboundNetworkHandle {
+        self.other_inbound_handles
+            .get(&peer_network_id)
+            .expect("Must have inbound handle for other peer")
+            .clone()
+    }
+
+    fn get_outbound_handle(&mut self, network_id: NetworkId) -> &mut OutboundMessageReceiver {
+        self.outbound_handles.get_mut(&network_id).unwrap()
+    }
+
+    fn get_peer_metadata_storage(&self) -> &PeerMetadataStorage {
+        &self.peer_metadata_storage
+    }
+
+    fn peer_network_ids(&self) -> &HashMap<NetworkId, PeerNetworkId> {
+        &self.peer_network_ids
+    }
+}
+
+impl MempoolNode {
+    /// Queues transactions for sending on a node, uses client
+    pub async fn add_txns_via_client(&mut self, txns: &[TestTransaction]) {
+        for txn in sign_transactions(txns) {
+            let (sender, receiver) = oneshot::channel();
+
+            self.mempool_client_sender
+                .send(MempoolClientRequest::SubmitTransaction(txn, sender))
+                .await
+                .unwrap();
+            let status = receiver.await.unwrap().unwrap();
+            assert_eq!(status.0.code, MempoolStatusCode::Accepted)
+        }
+    }
+
+    /// Commits transactions and removes them from the local mempool, stops them from being broadcasted later
+    pub fn commit_txns(&self, txns: &[TestTransaction]) {
+        if NodeType::Validator == self.node_id.node_type {
+            let mut mempool = self.mempool.lock();
+            for txn in txns.iter() {
+                mempool.remove_transaction(
+                    &TestTransaction::get_address(txn.address),
+                    txn.sequence_number,
+                    false,
+                );
+            }
+        } else {
+            panic!("Can't commit transactions on anything but a validator");
+        }
+    }
+
+    pub fn assert_txns_in_mempool(&self, txns: &[TestTransaction]) {
+        if let Err((actual, expected)) =
+            self.assert_condition_on_mempool_txns(txns, block_only_contains_transactions)
+        {
+            panic!(
+                "Expected to contain test transactions {:?}, but got {:?}",
+                expected, actual
+            );
+        }
+    }
+
+    pub fn assert_txns_not_in_mempool(&self, txns: &[TestTransaction]) {
+        if let Err((actual, expected)) = self.assert_condition_on_mempool_txns(txns, {
+            |actual, expected| !block_contains_any_transaction(actual, expected)
+        }) {
+            panic!(
+                "Expected to not contain test transactions {:?}, but got {:?}",
+                expected, actual
+            );
+        }
+    }
+
+    fn assert_condition_on_mempool_txns<
+        Condition: FnOnce(&[SignedTransaction], &[TestTransaction]) -> bool,
+    >(
+        &self,
+        txns: &[TestTransaction],
+        condition: Condition,
+    ) -> Result<(), (Vec<(AccountAddress, u64)>, Vec<(AccountAddress, u64)>)> {
+        let block = self.mempool.lock().get_block(100, HashSet::new());
+        if !condition(&block, txns) {
+            let actual: Vec<_> = block
+                .iter()
+                .map(|txn| (txn.sender(), txn.sequence_number()))
+                .collect();
+            let expected: Vec<_> = txns
+                .iter()
+                .map(|txn| {
+                    (
+                        TestTransaction::get_address(txn.address),
+                        txn.sequence_number,
+                    )
+                })
+                .collect();
+            Err((actual, expected))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub async fn send_message(
+        &mut self,
+        protocol_id: ProtocolId,
+        remote_peer_network_id: PeerNetworkId,
+        txns: &[TestTransaction],
+    ) {
+        let network_id = remote_peer_network_id.network_id();
+        let remote_peer_id = remote_peer_network_id.peer_id();
+        let inbound_handle = self.get_inbound_handle(network_id);
+        let request_id = self.request_id_generator.next();
+        let request_id = bcs::to_bytes(&request_id).unwrap();
+
+        let msg = MempoolSyncMsg::BroadcastTransactionsRequest {
+            request_id: request_id.clone(),
+            transactions: sign_transactions(txns),
+        };
+        let data = protocol_id.to_bytes(&msg).unwrap().into();
+        let (notif, maybe_receiver) = match protocol_id {
+            ProtocolId::MempoolDirectSend => (
+                PeerManagerNotification::RecvMessage(
+                    remote_peer_id,
+                    Message {
+                        protocol_id,
+                        mdata: data,
+                    },
+                ),
+                None,
+            ),
+            ProtocolId::MempoolRpc => {
+                let (res_tx, res_rx) = oneshot::channel();
+                let notif = PeerManagerNotification::RecvRpc(
+                    remote_peer_id,
+                    InboundRpcRequest {
+                        protocol_id,
+                        data,
+                        res_tx,
+                    },
+                );
+                (notif, Some(res_rx))
+            }
+            _ => panic!("Invalid protocol"),
+        };
+        inbound_handle
+            .inbound_message_sender
+            .push((remote_peer_id, protocol_id), notif)
+            .unwrap();
+
+        let response: MempoolSyncMsg = if let Some(res_rx) = maybe_receiver {
+            let response = res_rx.await.unwrap().unwrap();
+            protocol_id.from_bytes(&response).unwrap()
+        } else {
+            match self.get_outbound_handle(network_id).next().await.unwrap() {
+                PeerManagerRequest::SendDirectSend(peer_id, msg) => {
+                    assert_eq!(peer_id, remote_peer_id);
+                    msg.protocol_id.from_bytes(&msg.mdata).unwrap()
+                }
+                _ => panic!("Should not be getting an RPC response"),
+            }
+        };
+        if let MempoolSyncMsg::BroadcastTransactionsResponse {
+            request_id: response_request_id,
+            retry,
+            backoff,
+        } = response
+        {
+            assert_eq!(response_request_id, request_id);
+            assert!(!retry);
+            assert!(!backoff);
+        } else {
+            panic!("Expected a response!");
+        }
+    }
+
+    pub async fn verify_broadcast_and_ack(
+        &mut self,
+        expected_peer_network_id: PeerNetworkId,
+        expected_txns: &[TestTransaction],
+    ) {
+        let network_id = expected_peer_network_id.network_id();
+        let expected_peer_id = expected_peer_network_id.peer_id();
+        let inbound_handle = self.get_inbound_handle(network_id);
+        let message = self.get_next_network_msg(network_id).await;
+        let (peer_id, protocol_id, data, maybe_rpc_sender) = match message {
+            PeerManagerRequest::SendRpc(peer_id, msg) => {
+                (peer_id, msg.protocol_id, msg.data, Some(msg.res_tx))
+            }
+            PeerManagerRequest::SendDirectSend(peer_id, msg) => {
+                (peer_id, msg.protocol_id, msg.mdata, None)
+            }
+        };
+        assert_eq!(peer_id, expected_peer_id);
+        let request_id = match bcs::from_bytes(&data).unwrap() {
+            MempoolSyncMsg::BroadcastTransactionsRequest {
+                request_id,
+                transactions,
+            } => {
+                if !block_only_contains_transactions(&transactions, expected_txns) {
+                    let txns: Vec<_> = transactions
+                        .iter()
+                        .map(|txn| (txn.sender(), txn.sequence_number()))
+                        .collect();
+                    let expected_txns: Vec<_> = expected_txns
+                        .iter()
+                        .map(|txn| {
+                            (
+                                TestTransaction::get_address(txn.address),
+                                txn.sequence_number,
+                            )
+                        })
+                        .collect();
+
+                    panic!(
+                        "Request doesn't match. Actual: {:?} Expected: {:?}",
+                        txns, expected_txns
+                    );
+                }
+                request_id
+            }
+            MempoolSyncMsg::BroadcastTransactionsResponse { .. } => {
+                panic!("We aren't supposed to be getting as response here");
+            }
+        };
+        let response = MempoolSyncMsg::BroadcastTransactionsResponse {
+            request_id,
+            retry: false,
+            backoff: false,
+        };
+        let bytes = protocol_id.to_bytes(&response).unwrap();
+
+        if let Some(rpc_sender) = maybe_rpc_sender {
+            let _ = rpc_sender.send(Ok(bytes.into())).unwrap();
+        } else {
+            let notif = PeerManagerNotification::RecvMessage(
+                peer_id,
+                Message {
+                    protocol_id,
+                    mdata: bytes.into(),
+                },
+            );
+            inbound_handle
+                .inbound_message_sender
+                .push((peer_id, protocol_id), notif)
+                .unwrap();
+        }
+    }
+}
+
+impl TestNode for MempoolNode {}
+
+/// A [`TestFramework`] for [`MempoolNode`]s to test Mempool in a single and multi-node mock network
+/// environment.
+pub struct MempoolTestFramework {
+    pub nodes: HashMap<NodeId, MempoolNode>,
+}
+
+impl TestFramework<MempoolNode> for MempoolTestFramework {
+    fn new(nodes: HashMap<NodeId, MempoolNode>) -> Self {
+        Self { nodes }
+    }
+
+    fn build_node(
+        node_id: NodeId,
+        config: NodeConfig,
+        peer_network_ids: &[PeerNetworkId],
+    ) -> MempoolNode {
+        // Collect mappings of network_id to peer_network_id
+        let mut network_ids = Vec::new();
+        let mut network_id_mapping = HashMap::new();
+        for peer_network_id in peer_network_ids {
+            let network_id = peer_network_id.network_id();
+            assert!(
+                !network_id_mapping.contains_key(&network_id),
+                "Duplicate network id for node"
+            );
+            network_ids.push(network_id);
+            network_id_mapping.insert(network_id, *peer_network_id);
+        }
+        let runtime = node_runtime(node_id);
+
+        let (application_handles, inbound_handles, outbound_handles, peer_metadata_storage) =
+            setup_node_networks(&network_ids);
+        let (mempool_client_sender, mempool_consensus_sender, mempool_notifications, mempool) =
+            setup_mempool(
+                config,
+                application_handles,
+                peer_metadata_storage.clone(),
+                &runtime,
+            );
+
+        MempoolNode {
+            node_id,
+            peer_network_ids: network_id_mapping,
+            mempool,
+            _runtime: runtime,
+            mempool_client_sender,
+            mempool_consensus_sender,
+            mempool_notifications,
+            inbound_handles,
+            outbound_handles,
+            other_inbound_handles: HashMap::new(),
+            peer_metadata_storage,
+            request_id_generator: U32IdGenerator::new(),
+        }
+    }
+
+    fn take_node(&mut self, node_id: NodeId) -> MempoolNode {
+        self.nodes.remove(&node_id).expect("Node must exist")
+    }
+}
+
+/// Creates a full [`SharedMempool`] and mocks all of the database information.
+///
+/// This hooks in the [`ApplicationNetworkHandle`]s into mempool so that the requests make it all
+/// the way to the [`SharedMempool`]
+fn setup_mempool(
+    config: NodeConfig,
+    network_handles: Vec<ApplicationNetworkHandle<MempoolNetworkSender, MempoolNetworkEvents>>,
+    peer_metadata_storage: Arc<PeerMetadataStorage>,
+    runtime: &Runtime,
+) -> (
+    MempoolClientSender,
+    MempoolConsensusSender,
+    MempoolNotifier,
+    Arc<Mutex<CoreMempool>>,
+) {
+    let (sender, _subscriber) = futures::channel::mpsc::unbounded();
+    let (ac_endpoint_sender, ac_endpoint_receiver) = mpsc_channel();
+    let (consensus_sender, consensus_events) = mpsc_channel();
+    let (mempool_notifier, mempool_listener) =
+        mempool_notifications::new_mempool_notifier_listener_pair();
+
+    let mempool = Arc::new(Mutex::new(CoreMempool::new(&config)));
+    let vm_validator = Arc::new(RwLock::new(MockVMValidator));
+    let db_rw = Arc::new(RwLock::new(DbReaderWriter::new(MockDbReaderWriter)));
+    let db_ro = Arc::new(MockDbReaderWriter);
+
+    let mut event_subscriber = EventSubscriptionService::new(ON_CHAIN_CONFIG_REGISTRY, db_rw);
+    let reconfig_event_subscriber = event_subscriber.subscribe_to_reconfigurations().unwrap();
+
+    start_shared_mempool(
+        runtime.handle(),
+        &config,
+        mempool.clone(),
+        network_handles,
+        ac_endpoint_receiver,
+        consensus_events,
+        mempool_listener,
+        reconfig_event_subscriber,
+        db_ro,
+        vm_validator,
+        vec![sender],
+        peer_metadata_storage,
+    );
+
+    (
+        ac_endpoint_sender,
+        consensus_sender,
+        mempool_notifier,
+        mempool,
+    )
+}
+
+/// Builds a runtime for each node
+fn node_runtime(node_id: NodeId) -> Arc<Runtime> {
+    Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .thread_name(format!("node-{:?}", node_id))
+            .enable_all()
+            .build()
+            .expect("[test-framework] failed to create runtime"),
+    )
+}
+
+fn mpsc_channel<T>() -> (
+    futures::channel::mpsc::Sender<T>,
+    futures::channel::mpsc::Receiver<T>,
+) {
+    futures::channel::mpsc::channel(1_024)
+}
+
+/// Creates a single [`TestTransaction`] with the given `seq_num`.
+pub fn test_transaction(seq_num: u64) -> TestTransaction {
+    TestTransaction::new(1, seq_num, 1)
+}
+
+/// Create test transactions from `start`(inclusive) to `end` (exclusive)
+pub fn test_transactions(start: u64, end: u64) -> Vec<TestTransaction> {
+    let mut txns = vec![];
+    for seq_num in start..end {
+        txns.push(test_transaction(seq_num))
+    }
+    txns
+}
+
+/// Tells us if a [`SignedTransaction`] block contains only the [`TestTransaction`]s
+pub fn block_only_contains_transactions(
+    block: &[SignedTransaction],
+    txns: &[TestTransaction],
+) -> bool {
+    txns.iter()
+        .all(|txn| block_contains_transaction(block, txn))
+        && block.len() == txns.len()
+}
+
+/// Tells us if a [`SignedTransaction`] block contains any of the [`TestTransaction`]s
+pub fn block_contains_any_transaction(
+    block: &[SignedTransaction],
+    txns: &[TestTransaction],
+) -> bool {
+    txns.iter()
+        .any(|txn| block_contains_transaction(block, txn))
+        && block.len() == txns.len()
+}
+
+/// Tells us if a [`SignedTransaction`] block contains the [`TestTransaction`]
+fn block_contains_transaction(block: &[SignedTransaction], txn: &TestTransaction) -> bool {
+    block.iter().any(|signed_txn| {
+        signed_txn.sequence_number() == txn.sequence_number
+            && signed_txn.sender() == TestTransaction::get_address(txn.address)
+    })
+}
+
+/// Signs [`TestTransaction`]s with a max gas amount
+pub fn sign_transactions(txns: &[TestTransaction]) -> Vec<SignedTransaction> {
+    txns.iter()
+        .map(|txn| txn.make_signed_transaction_with_max_gas_amount(5))
+        .collect()
+}

--- a/network/src/testutils/builder.rs
+++ b/network/src/testutils/builder.rs
@@ -1,0 +1,166 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::testutils::{
+    test_framework::TestFramework,
+    test_node::{NodeId, NodeType, TestNode},
+};
+use diem_config::{
+    config::NodeConfig,
+    network_id::{NetworkId, PeerNetworkId},
+};
+use rand::{rngs::StdRng, SeedableRng};
+use std::{collections::HashMap, marker::PhantomData};
+
+/// A builder for a [`TestFramework`] implementation.
+///
+/// This handles making sure that nodes are unique, and that they have the channels attached
+/// to each other to send messages between each other.
+///
+pub struct TestFrameworkBuilder<Framework: TestFramework<Node>, Node: TestNode> {
+    /// Owners are a simple stand in for actual [`AccountAddress`] uniqueness in the network.
+    /// An `owner` can have 1 of each [`NodeType`] of `Node`. This simplifies linking
+    /// [`NodeType::Validator`] and [`NodeType::ValidatorFullNode`] later, as well as keeps
+    /// a unique identifier for each node as [`NodeId`].
+    owners: u32,
+    /// The unique mapping of `Node` to ensure no duplicates.
+    nodes: HashMap<NodeId, Node>,
+    /// Random generator for randomness in keys and [`PeerId`]s. Hardcoded to remove non-determinism.
+    rng: StdRng,
+    _framework_marker: PhantomData<Framework>,
+}
+
+impl<Framework: TestFramework<Node>, Node: TestNode> TestFrameworkBuilder<Framework, Node> {
+    /// Create a new [`TestFrameworkBuilder`], ensuring that there is a fixed number of `owners`.
+    pub fn new(owners: u32) -> Self {
+        Self {
+            owners,
+            nodes: HashMap::new(),
+            rng: StdRng::from_seed([0u8; 32]),
+            _framework_marker: PhantomData::default(),
+        }
+    }
+
+    /// Builds the [`TestFramework`]
+    pub fn build(self) -> Framework {
+        TestFramework::new(self.nodes)
+    }
+
+    /// Adds a [`TestNode`] of [`NodeType::Validator`]
+    pub fn add_validator(mut self, owner: u32) -> Self {
+        let config = NodeConfig::random_with_template(
+            owner,
+            &NodeConfig::default_for_validator(),
+            &mut self.rng,
+        );
+        let peer_id = config
+            .validator_network
+            .as_ref()
+            .expect("Validator must have a validator network")
+            .peer_id();
+
+        self.add_node(
+            owner,
+            NodeType::Validator,
+            config,
+            &[
+                PeerNetworkId::new(NetworkId::Validator, peer_id),
+                PeerNetworkId::new(NetworkId::Vfn, peer_id),
+            ],
+        )
+    }
+
+    /// Adds a [`TestNode`] of [`NodeType::ValidatorFullNode`]
+    pub fn add_vfn(mut self, owner: u32) -> Self {
+        let config = NodeConfig::random_with_template(
+            owner,
+            &NodeConfig::default_for_validator_full_node(),
+            &mut self.rng,
+        );
+        let peer_id = config
+            .full_node_networks
+            .iter()
+            .find(|network| network.network_id == NetworkId::Public)
+            .expect("Vfn must have a public network")
+            .peer_id();
+
+        self.add_node(
+            owner,
+            NodeType::ValidatorFullNode,
+            config,
+            &[
+                PeerNetworkId::new(NetworkId::Vfn, peer_id),
+                PeerNetworkId::new(NetworkId::Public, peer_id),
+            ],
+        )
+    }
+
+    /// Adds a [`TestNode`] of [`NodeType::PublicFullNode`]
+    pub fn add_pfn(mut self, owner: u32) -> Self {
+        let config = NodeConfig::random_with_template(
+            owner,
+            &NodeConfig::default_for_public_full_node(),
+            &mut self.rng,
+        );
+        let peer_id = config
+            .full_node_networks
+            .iter()
+            .find(|network| network.network_id == NetworkId::Public)
+            .expect("Pfn must have a public network")
+            .peer_id();
+
+        self.add_node(
+            owner,
+            NodeType::PublicFullNode,
+            config,
+            &[PeerNetworkId::new(NetworkId::Public, peer_id)],
+        )
+    }
+
+    /// Add a node to the network, ensuring that it doesn't already exist
+    fn add_node(
+        mut self,
+        owner: u32,
+        node_type: NodeType,
+        config: NodeConfig,
+        peer_network_ids: &[PeerNetworkId],
+    ) -> Self {
+        assert!(owner < self.owners);
+
+        let node_id = NodeId { owner, node_type };
+        assert!(!self.nodes.contains_key(&node_id));
+
+        let mut node = Framework::build_node(node_id, config, peer_network_ids);
+
+        // Add node's sender to every possible node that it could be connected to.
+        for (other_node_id, other_node) in self.nodes.iter_mut() {
+            if let Some(network_id) = other_node.find_common_network(&node) {
+                // The VFN network only goes between the same owner, skip it if it doesn't match
+                if network_id == NetworkId::Vfn && owner != other_node_id.owner {
+                    continue;
+                }
+
+                // Add the inbound handle for the new node to the other node
+                add_inbound_peer_handle_to_node(network_id, other_node, &node);
+
+                // Add the inbound handle for the other node to the new node
+                add_inbound_peer_handle_to_node(network_id, &mut node, other_node);
+            }
+        }
+
+        self.nodes.insert(node_id, node);
+        self
+    }
+}
+
+/// Adds `receiving_node`'s peer_handle to the `sending_node`
+fn add_inbound_peer_handle_to_node<Node: TestNode>(
+    network_id: NetworkId,
+    sending_node: &mut Node,
+    receiving_node: &Node,
+) {
+    sending_node.add_inbound_handle_for_peer(
+        receiving_node.peer_network_id(network_id),
+        receiving_node.get_inbound_handle(network_id),
+    );
+}

--- a/network/src/testutils/mod.rs
+++ b/network/src/testutils/mod.rs
@@ -1,4 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod builder;
 pub mod fake_socket;
+pub mod test_framework;
+pub mod test_node;

--- a/network/src/testutils/test_framework.rs
+++ b/network/src/testutils/test_framework.rs
@@ -1,0 +1,106 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    application::storage::PeerMetadataStorage,
+    peer_manager::{ConnectionRequestSender, PeerManagerRequestSender},
+    protocols::network::{NewNetworkEvents, NewNetworkSender},
+    testutils::test_node::{
+        ApplicationNetworkHandle, ApplicationNode, InboundNetworkHandle, NodeId,
+        OutboundMessageReceiver,
+    },
+};
+use channel::message_queues::QueueStyle;
+use diem_config::{
+    config::NodeConfig,
+    network_id::{NetworkId, PeerNetworkId},
+};
+use std::{collections::HashMap, hash::Hash, sync::Arc, vec::Vec};
+
+/// A trait describing a test framework for a specific application
+///
+/// This is essentially an abstract implementation, to get around how rust handles traits
+/// there are functions to get required variables in the implementation.
+///
+pub trait TestFramework<Node: ApplicationNode + Sync> {
+    /// Constructor for the [`TestFramework`]
+    fn new(nodes: HashMap<NodeId, Node>) -> Self;
+
+    /// A constructor for `Node` specific to the application
+    fn build_node(node_id: NodeId, config: NodeConfig, peer_network_ids: &[PeerNetworkId]) -> Node;
+
+    /// In order to have separate tasks, we have to pull these out of the framework
+    fn take_node(&mut self, node_id: NodeId) -> Node;
+}
+
+/// Setup the multiple networks built for a specific node
+pub fn setup_node_networks<NetworkSender: NewNetworkSender, NetworkEvents: NewNetworkEvents>(
+    network_ids: &[NetworkId],
+) -> (
+    Vec<ApplicationNetworkHandle<NetworkSender, NetworkEvents>>,
+    HashMap<NetworkId, InboundNetworkHandle>,
+    HashMap<NetworkId, OutboundMessageReceiver>,
+    Arc<PeerMetadataStorage>,
+) {
+    let mut application_handles = Vec::new();
+    let mut inbound_handles = HashMap::new();
+    let mut outbound_handles = HashMap::new();
+
+    let peer_metadata_storage = PeerMetadataStorage::new(network_ids);
+
+    // Build each individual network
+    for network_id in network_ids {
+        let (application_handle, inbound_handle, outbound_handle) =
+            setup_network(*network_id, peer_metadata_storage.clone());
+        application_handles.push(application_handle);
+        inbound_handles.insert(*network_id, inbound_handle);
+        outbound_handles.insert(*network_id, outbound_handle);
+    }
+
+    (
+        application_handles,
+        inbound_handles,
+        outbound_handles,
+        peer_metadata_storage,
+    )
+}
+
+/// Builds all the channels used for networking
+fn setup_network<NetworkSender: NewNetworkSender, NetworkEvents: NewNetworkEvents>(
+    network_id: NetworkId,
+    peer_metadata_storage: Arc<PeerMetadataStorage>,
+) -> (
+    ApplicationNetworkHandle<NetworkSender, NetworkEvents>,
+    InboundNetworkHandle,
+    OutboundMessageReceiver,
+) {
+    let (reqs_inbound_sender, reqs_inbound_receiver) = diem_channel();
+    let (reqs_outbound_sender, reqs_outbound_receiver) = diem_channel();
+    let (connection_outbound_sender, _connection_outbound_receiver) = diem_channel();
+    let (connection_inbound_sender, connection_inbound_receiver) =
+        crate::peer_manager::conn_notifs_channel::new();
+    let network_sender = NetworkSender::new(
+        PeerManagerRequestSender::new(reqs_outbound_sender),
+        ConnectionRequestSender::new(connection_outbound_sender),
+    );
+    let network_events = NetworkEvents::new(reqs_inbound_receiver, connection_inbound_receiver);
+
+    (
+        (network_id, network_sender, network_events),
+        InboundNetworkHandle {
+            inbound_message_sender: reqs_inbound_sender,
+            connection_update_sender: connection_inbound_sender,
+            peer_metadata_storage,
+        },
+        reqs_outbound_receiver,
+    )
+}
+
+/// A generic FIFO diem channel
+fn diem_channel<K: Eq + Hash + Clone, T>() -> (
+    channel::diem_channel::Sender<K, T>,
+    channel::diem_channel::Receiver<K, T>,
+) {
+    static MAX_QUEUE_SIZE: usize = 8;
+    channel::diem_channel::new(QueueStyle::FIFO, MAX_QUEUE_SIZE, None)
+}

--- a/network/src/testutils/test_node.rs
+++ b/network/src/testutils/test_node.rs
@@ -1,0 +1,347 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    application::storage::PeerMetadataStorage,
+    peer_manager::{ConnectionNotification, PeerManagerNotification, PeerManagerRequest},
+    protocols::{direct_send::Message, rpc::InboundRpcRequest},
+    transport::ConnectionMetadata,
+    DisconnectReason, ProtocolId,
+};
+use async_trait::async_trait;
+use diem_config::{
+    config::{PeerRole, RoleType},
+    network_id::{NetworkContext, NetworkId, PeerNetworkId},
+};
+use diem_types::PeerId;
+use futures::StreamExt;
+use netcore::transport::ConnectionOrigin;
+use std::{collections::HashMap, sync::Arc};
+
+/// A sender to a node to mock an inbound network message from [`PeerManager`]
+pub type InboundMessageSender =
+    channel::diem_channel::Sender<(PeerId, ProtocolId), PeerManagerNotification>;
+
+/// A sender to a node to mock an inbound connection from [`PeerManager`]
+pub type ConnectionUpdateSender = crate::peer_manager::conn_notifs_channel::Sender;
+
+/// A receiver to get outbound network messages to [`PeerManager`]
+pub type OutboundMessageReceiver =
+    channel::diem_channel::Receiver<(PeerId, ProtocolId), PeerManagerRequest>;
+
+/// A connection handle describing the network for a node.
+///
+/// Use this to interact with the node
+#[derive(Clone)]
+pub struct InboundNetworkHandle {
+    /// To send new incoming network messages
+    pub inbound_message_sender: InboundMessageSender,
+    /// To send new incoming connections or disconnections
+    pub connection_update_sender: ConnectionUpdateSender,
+    /// To update the local state (normally done by peer manager)
+    pub peer_metadata_storage: Arc<PeerMetadataStorage>,
+}
+
+impl InboundNetworkHandle {
+    /// Push connection update, and update the local storage
+    pub fn connect(
+        &self,
+        self_peer_id: PeerId,
+        network_id: NetworkId,
+        conn_metadata: ConnectionMetadata,
+    ) {
+        // PeerManager pushes this data before it's received by events
+        self.peer_metadata_storage
+            .insert_connection(network_id, conn_metadata.clone());
+        self.connection_update_sender
+            .push(
+                conn_metadata.remote_peer_id,
+                ConnectionNotification::NewPeer(
+                    conn_metadata,
+                    // TODO will `RoleType` matter
+                    NetworkContext::new(RoleType::Validator, network_id, self_peer_id),
+                ),
+            )
+            .unwrap();
+    }
+
+    /// Push disconnect update, and update the local storage
+    pub fn disconnect(
+        &self,
+        self_peer_id: PeerId,
+        network_id: NetworkId,
+        conn_metadata: ConnectionMetadata,
+    ) {
+        // PeerManager pushes this data before it's received by events
+        self.peer_metadata_storage.remove(&PeerNetworkId::new(
+            network_id,
+            conn_metadata.remote_peer_id,
+        ));
+        self.connection_update_sender
+            .push(
+                conn_metadata.remote_peer_id,
+                ConnectionNotification::LostPeer(
+                    conn_metadata,
+                    // TODO will `RoleType` matter
+                    NetworkContext::new(RoleType::Validator, network_id, self_peer_id),
+                    DisconnectReason::ConnectionLost,
+                ),
+            )
+            .unwrap();
+    }
+}
+
+/// An application specific network handle
+pub type ApplicationNetworkHandle<Sender, Events> = (NetworkId, Sender, Events);
+
+/// A unique identifier of a node across the entire network
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct NodeId {
+    pub owner: u32,
+    pub node_type: NodeType,
+}
+
+impl NodeId {
+    pub fn validator(owner: u32) -> Self {
+        Self {
+            owner,
+            node_type: NodeType::Validator,
+        }
+    }
+
+    pub fn vfn(owner: u32) -> Self {
+        Self {
+            owner,
+            node_type: NodeType::ValidatorFullNode,
+        }
+    }
+
+    pub fn pfn(owner: u32) -> Self {
+        Self {
+            owner,
+            node_type: NodeType::PublicFullNode,
+        }
+    }
+
+    pub fn role(&self) -> RoleType {
+        match self.node_type {
+            NodeType::Validator => RoleType::Validator,
+            _ => RoleType::FullNode,
+        }
+    }
+
+    pub fn peer_role(&self) -> PeerRole {
+        match self.node_type {
+            NodeType::Validator => PeerRole::Validator,
+            NodeType::ValidatorFullNode => PeerRole::ValidatorFullNode,
+            NodeType::PublicFullNode => PeerRole::Unknown,
+        }
+    }
+}
+
+impl std::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{:?}", self.owner, self.node_type)
+    }
+}
+
+/// An enum defining the type of node
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum NodeType {
+    Validator,
+    ValidatorFullNode,
+    PublicFullNode,
+}
+
+/// A trait defining an application specific node with networking abstracted
+///
+/// This is built as an abstract implementation of networking around a node
+pub trait ApplicationNode {
+    fn node_id(&self) -> NodeId;
+
+    /// Default ['ProtocolId`]s to connect with
+    fn default_protocols(&self) -> &[ProtocolId];
+
+    /// For sending to this node. Generally should not be used after setup
+    fn get_inbound_handle(&self, network_id: NetworkId) -> InboundNetworkHandle;
+
+    /// For adding handles to other peers
+    fn add_inbound_handle_for_peer(
+        &mut self,
+        peer_network_id: PeerNetworkId,
+        handle: InboundNetworkHandle,
+    );
+
+    /// For sending to other nodes
+    fn get_inbound_handle_for_peer(&self, peer_network_id: PeerNetworkId) -> InboundNetworkHandle;
+
+    /// For receiving messages from other nodes
+    fn get_outbound_handle(&mut self, network_id: NetworkId) -> &mut OutboundMessageReceiver;
+
+    fn get_peer_metadata_storage(&self) -> &PeerMetadataStorage;
+
+    fn peer_network_ids(&self) -> &HashMap<NetworkId, PeerNetworkId>;
+}
+
+/// An extension trait for an `ApplicationNode` to run tests on.
+///
+/// Handles common implementation and helper functions
+#[async_trait]
+pub trait TestNode: ApplicationNode + Sync {
+    /// Retrieve the [`PeerNetworkId`] for a specific [`NetworkId`].
+    ///
+    /// There can only be one per network.
+    fn peer_network_id(&self, network_id: NetworkId) -> PeerNetworkId {
+        *self.peer_network_ids().get(&network_id).unwrap_or_else(|| {
+            panic!(
+                "Expected network {} to exist on node {}",
+                network_id,
+                self.node_id()
+            )
+        })
+    }
+
+    /// Retrieve all [`NetworkId`] for the node
+    fn network_ids(&self) -> Vec<NetworkId> {
+        self.peer_network_ids().keys().copied().collect()
+    }
+
+    /// Connects a node to another node.  The other's inbound handle must already be added.
+    fn connect(&self, network_id: NetworkId, metadata: ConnectionMetadata) {
+        assert_eq!(ConnectionOrigin::Outbound, metadata.origin);
+        let self_peer_id = self.peer_network_id(network_id).peer_id();
+        let self_metadata = self.conn_metadata(network_id, ConnectionOrigin::Inbound, None);
+        let remote_peer_id = metadata.remote_peer_id;
+
+        // Tell the other node it's good to send to the connected peer now
+        self.get_inbound_handle_for_peer(PeerNetworkId::new(network_id, remote_peer_id))
+            .connect(remote_peer_id, network_id, self_metadata);
+
+        // Then connect us
+        self.get_inbound_handle(network_id)
+            .connect(self_peer_id, network_id, metadata);
+    }
+
+    /// Disconnects a node from another node
+    fn disconnect(&self, network_id: NetworkId, metadata: ConnectionMetadata) {
+        let self_peer_id = self.peer_network_id(network_id).peer_id();
+        let self_metadata = self.conn_metadata(network_id, ConnectionOrigin::Inbound, None);
+        let remote_peer_id = metadata.remote_peer_id;
+
+        // Tell the other node it's disconnected
+        self.get_inbound_handle_for_peer(PeerNetworkId::new(network_id, remote_peer_id))
+            .disconnect(remote_peer_id, network_id, self_metadata);
+
+        // Then disconnect us
+        self.get_inbound_handle(network_id)
+            .disconnect(self_peer_id, network_id, metadata);
+    }
+
+    /// Find a common [`NetworkId`] between nodes based on [`NodeType`]
+    fn find_common_network(&self, other: &Self) -> Option<NetworkId> {
+        let self_node_type = self.node_id().node_type;
+        let other_node_type = other.node_id().node_type;
+        match self_node_type {
+            NodeType::Validator => match other_node_type {
+                NodeType::Validator => Some(NetworkId::Validator),
+                NodeType::ValidatorFullNode => Some(NetworkId::Vfn),
+                NodeType::PublicFullNode => None,
+            },
+            NodeType::ValidatorFullNode => match other_node_type {
+                NodeType::Validator => Some(NetworkId::Vfn),
+                _ => Some(NetworkId::Public),
+            },
+            NodeType::PublicFullNode => match other_node_type {
+                NodeType::Validator => None,
+                _ => Some(NetworkId::Public),
+            },
+        }
+    }
+
+    /// Build `ConnectionMetadata` for a connection on another node
+    fn conn_metadata(
+        &self,
+        network_id: NetworkId,
+        origin: ConnectionOrigin,
+        maybe_protocols: Option<&[ProtocolId]>,
+    ) -> ConnectionMetadata {
+        mock_conn_metadata(
+            self.peer_network_id(network_id),
+            self.node_id().peer_role(),
+            origin,
+            maybe_protocols.or_else(|| Some(self.default_protocols())),
+        )
+    }
+
+    /// Gets the next queued network message on `Node`'s network (`NetworkId`).  Doesn't propagate
+    /// to downstream node
+    async fn get_next_network_msg(&mut self, network_id: NetworkId) -> PeerManagerRequest {
+        self.get_outbound_handle(network_id)
+            .next()
+            .await
+            .expect("Expecting a message")
+    }
+
+    /// Sends the next queued network message on `Node`'s network (`NetworkId`)
+    async fn send_next_network_msg(&mut self, network_id: NetworkId) {
+        let request = self.get_next_network_msg(network_id).await;
+
+        let (remote_peer_id, protocol_id, data, maybe_rpc_info) = match request {
+            PeerManagerRequest::SendRpc(peer_id, msg) => (
+                peer_id,
+                msg.protocol_id,
+                msg.data,
+                Some((msg.timeout, msg.res_tx)),
+            ),
+            PeerManagerRequest::SendDirectSend(peer_id, msg) => {
+                (peer_id, msg.protocol_id, msg.mdata, None)
+            }
+        };
+
+        let sender_peer_network_id = self.peer_network_id(network_id);
+        let receiver_peer_network_id = PeerNetworkId::new(network_id, remote_peer_id);
+        let receiver_handle = self.get_inbound_handle_for_peer(receiver_peer_network_id);
+        let sender_peer_id = sender_peer_network_id.peer_id();
+
+        // TODO: Add timeout functionality
+        let peer_manager_notif = if let Some((_timeout, res_tx)) = maybe_rpc_info {
+            PeerManagerNotification::RecvRpc(
+                sender_peer_id,
+                InboundRpcRequest {
+                    protocol_id,
+                    data,
+                    res_tx,
+                },
+            )
+        } else {
+            PeerManagerNotification::RecvMessage(
+                sender_peer_id,
+                Message {
+                    protocol_id,
+                    mdata: data,
+                },
+            )
+        };
+        receiver_handle
+            .inbound_message_sender
+            .push((sender_peer_id, protocol_id), peer_manager_notif)
+            .unwrap();
+    }
+}
+
+/// Creates a [`ConnectionMetadata`].  Its [`ProtocolIdSet`] defaults to empty if `maybe_protocols` is `None`
+pub fn mock_conn_metadata(
+    peer_network_id: PeerNetworkId,
+    peer_role: PeerRole,
+    origin: ConnectionOrigin,
+    maybe_protocols: Option<&[ProtocolId]>,
+) -> ConnectionMetadata {
+    let mut metadata =
+        ConnectionMetadata::mock_with_role_and_origin(peer_network_id.peer_id(), peer_role, origin);
+    if let Some(protocol_ids) = maybe_protocols {
+        for protocol_id in protocol_ids {
+            metadata.application_protocols.insert(*protocol_id);
+        }
+    }
+    metadata
+}


### PR DESCRIPTION
## Motivation

The current mempool test framework was based off of events emitted at certain points in the code.  I found that these often could be moved and cause issues, or none at all.  However, this change make it based on the network events, which is more appropriate since those are the messages we are actually sending.  Additionally, this should alleviate a lot of the issues with the flaky tests we have, as now we're dependent on the actual network events, rather than hoping the order of actions come through correctly.

I needed this change to make the RPC testing simpler, since we were dependent on messages that could be sent either before or after and RPC call.

Now, this is a pretty big change, but I've ported over most of the tests from the original test framework.  The RPC mempool still isn't working, but I've gotten a few tests to succeed with this framework.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See tests added

## Related Issues
* https://github.com/diem/diem/issues/9421
* And others https://github.com/diem/diem/issues?q=is%3Aissue+is%3Aopen++flaky
