### PR TITLE
[move-prover] use ghost types for uninstantiated global invariants

### DIFF
--- a/language/move-prover/bytecode/src/global_invariant_analysis.rs
+++ b/language/move-prover/bytecode/src/global_invariant_analysis.rs
@@ -8,7 +8,7 @@ use crate::{
     function_target_pipeline::{
         FunctionTargetProcessor, FunctionTargetsHolder, FunctionVariant, VerificationFlavor,
     },
-    stackless_bytecode::{BorrowNode, Bytecode, Operation},
+    stackless_bytecode::{BorrowNode, Bytecode, Operation, PropKind},
     usage_analysis,
     verification_analysis::{is_invariant_suspendable, InvariantAnalysisData},
 };
@@ -16,7 +16,7 @@ use crate::{
 use move_binary_format::file_format::CodeOffset;
 use move_model::{
     ast::ConditionKind,
-    model::{FunctionEnv, GlobalEnv, GlobalId, QualifiedInstId, StructId},
+    model::{FunId, FunctionEnv, GlobalEnv, GlobalId, QualifiedId, QualifiedInstId, StructId},
     ty::{Type, TypeDisplayContext, TypeInstantiationDerivation, TypeUnificationAdapter, Variance},
 };
 
@@ -32,6 +32,14 @@ pub struct PerBytecodeRelevance {
     /// associated value is a set of `inst_inv` (instantiation of invariant type parameters) that
     /// are applicable to the concrete function instance `F<inst_fun>`.
     pub insts: BTreeMap<Vec<Type>, BTreeSet<Vec<Type>>>,
+}
+
+impl PerBytecodeRelevance {
+    fn merge(&mut self, other: PerBytecodeRelevance) {
+        for (fun_inst, inv_insts) in other.insts {
+            self.insts.entry(fun_inst).or_default().extend(inv_insts);
+        }
+    }
 }
 
 /// A named struct for holding the information on how invariants are relevant to a function.
@@ -246,67 +254,11 @@ impl PerFunctionRelevance {
             .get(&fid)
             .expect("Invariant applicability not available");
 
-        let mem_analysis = usage_analysis::get_memory_usage(target);
-
         let fun_type_params = target.get_type_parameters();
         let fun_type_params_arity = fun_type_params.len();
 
-        // collect invariant applicability and instantiation information for entrypoint assumptions
-        //
-        // NOTE: why do we use the `InvariantRelevance::accessed` set instead of other sets?
-        //
-        // - The reason we choose `accessed` over `direct_accessed` is that sometimes we need to
-        //   assume invariants that are applicable to callees only and not applicable to the caller.
-        //   The reason is that if we inline a callee function, proving properties about the inlined
-        //   function might require assumptions about the memories it touches (e.g., proving the
-        //   `borrow_global_mut<R>(addr)` does not abort with the invariant that resource `R` must
-        //   exist under account `addr` after operation has started).
-        //
-        //   It does not hurt (in terms of soundness or completeness of the proofs) to assume extra
-        //   invariants in the `accessed` set even when these assumptions are not actually used in
-        //   proofs of any asserts. We might re-consider this when performance (due to too many
-        //   assumptions added to the proof system) becomes an issue.
-        //
-        // - The reason we choose `direct_accessed` over `direct_modified` is that we may need
-        //   assumptions from global invariants to prove properties in the code.
-        //
-        //   For example, we may have an `invariant exists<A>(0x1) ==> exists<B>(0x1);` while in
-        //   the code, we have `if (exists<A>(0x1)) { borrow_global<B>(0x1); }`. With the global
-        //   invariant, we know that the `borrow_global` won't abort. But we won't be able to prove
-        //   this property without the global invariant.
-        let entrypoint_invariants: BTreeSet<_> = inv_applicability
-            .accessed
-            .iter()
-            .filter_map(|&inv_id| {
-                let inv = env.get_global_invariant(inv_id).unwrap();
-                // update invariants should not be assumed at function entrypoint.
-                matches!(inv.kind, ConditionKind::GlobalInvariant(..)).then(|| inv_id)
-            })
-            .collect();
-        let entrypoint_assumptions = Self::calculate_invariant_relevance(
-            env,
-            mem_analysis.accessed.all.iter(),
-            &entrypoint_invariants,
-            fun_type_params_arity,
-        );
-
-        // if this function defers invariant checking on return, filter out invariants that are
-        // suspended in body.
-        //
-        // NOTE: why do we use the `InvariantRelevance::direct_modified` set instead of other sets?
-        //
-        // First, be reminded that in the rest of this function, we aim to find which invariants
-        // should be *asserted* at each bytecode instruction. Therefore, if a bytecode instruction
-        // only reads some memory but never modifies one, we don't need to assert the invariant.
-        // This rules out the `direct_accessed` and `accessed` sets.
-        //
-        // Second, similar to the reason why we choose `direct_accessed` set over `accessed` for
-        // invariants that constitute entrypoint assumptions, we choose `direct_modified` over
-        // `modified` is that we don't want to assert invariants that are applicable to callees
-        // only and not applicable to the caller. The reason is still: if a suspendable invariant is
-        // delegated to the caller, that invariant will appear in the `direct_modified` set on the
-        // caller side.
-        let (inv_related_return, inv_related_normal): (BTreeSet<_>, BTreeSet<_>) =
+        let inv_ro = &inv_applicability.accessed;
+        let (inv_rw_return, inv_rw_normal): (BTreeSet<_>, BTreeSet<_>) =
             if check_suspendable_inv_on_return {
                 inv_applicability
                     .direct_modified
@@ -320,123 +272,117 @@ impl PerFunctionRelevance {
         // collect invariant applicability and instantiation information per bytecode, i.e.,
         // - which invariants should be instrumented after each instruction and
         // - per each invariant applicable, how to instantiate them.
+        let mut entrypoint_assumptions = BTreeMap::new();
         let mut per_bytecode_assertions = BTreeMap::new();
-        let mut mem_related_on_return = BTreeSet::new();
-        let mut exitpoint_assertions = None;
+        let mut exitpoint_assertions = BTreeMap::new();
 
         for (code_offset, bc) in target.data.code.iter().enumerate() {
             let code_offset = code_offset as CodeOffset;
 
-            // collect memory modified in operations
-            let mem_related = match bc {
+            // collect memory accessed/modified in operations
+            let (mem_ro, mem_rw) = match bc {
                 Call(_, _, oper, _, _) => match oper {
-                    Function(mid, fid, inst) | OpaqueCallEnd(mid, fid, inst) => {
+                    Function(mid, fid, inst) => {
                         let callee_fid = mid.qualified(*fid);
-
-                        // shortcut the call if the callee does not delegate invariant checking.
-                        //
-                        // NOTE: in this case, memories modified by the callee are NOT back
-                        // propagated to the caller in the `verification_analysis.rs`, which means,
-                        // the `InvariantRelevance::direct_modified` set for the caller does NOT
-                        // necessarily cover invariants that are related to the callee.
-                        if !inv_analysis.fun_set_with_no_inv_check.contains(&callee_fid) {
-                            continue;
-                        }
-
-                        let callee_env = env.get_function(callee_fid);
-                        let callee_target =
-                            targets.get_target(&callee_env, &FunctionVariant::Baseline);
-                        let callee_usage = usage_analysis::get_memory_usage(&callee_target);
-
-                        // NOTE: it is important to include *ALL* memories modified by the callee
-                        // instead of just the direct ones --- if a function `F` delegates
-                        // suspendable invariant checking to its caller, all the functions that `F`
-                        // calls will not check suspendable invariants anymore.
-                        callee_usage.modified.get_all_inst(inst)
+                        get_callee_memory_usage_for_invariant_instrumentation(
+                            env, targets, callee_fid, inst,
+                        )
+                    }
+                    OpaqueCallBegin(mid, fid, inst) => {
+                        let callee_fid = mid.qualified(*fid);
+                        let (mem_ro, _) = get_callee_memory_usage_for_invariant_instrumentation(
+                            env, targets, callee_fid, inst,
+                        );
+                        (mem_ro, BTreeSet::new())
+                    }
+                    OpaqueCallEnd(mid, fid, inst) => {
+                        let callee_fid = mid.qualified(*fid);
+                        let (_, mem_rw) = get_callee_memory_usage_for_invariant_instrumentation(
+                            env, targets, callee_fid, inst,
+                        );
+                        (BTreeSet::new(), mem_rw)
                     }
 
                     MoveTo(mid, sid, inst) | MoveFrom(mid, sid, inst) => {
                         let mem = mid.qualified_inst(*sid, inst.to_owned());
-                        std::iter::once(mem).collect()
+                        (BTreeSet::new(), std::iter::once(mem).collect())
                     }
-                    WriteBack(GlobalRoot(mem), _) => std::iter::once(mem.clone()).collect(),
+                    WriteBack(GlobalRoot(mem), _) => {
+                        (BTreeSet::new(), std::iter::once(mem.clone()).collect())
+                    }
+
+                    Exists(mid, sid, inst) | GetGlobal(mid, sid, inst) => {
+                        let mem = mid.qualified_inst(*sid, inst.to_owned());
+                        (std::iter::once(mem).collect(), BTreeSet::new())
+                    }
 
                     // shortcut other operations
                     _ => continue,
                 },
 
-                Ret(..) if check_suspendable_inv_on_return => {
-                    std::mem::take(&mut mem_related_on_return)
-                }
+                Prop(_, PropKind::Assert, exp) | Prop(_, PropKind::Assume, exp) => (
+                    exp.used_memory(env)
+                        .into_iter()
+                        .map(|(usage, _)| usage)
+                        .collect(),
+                    BTreeSet::new(),
+                ),
 
                 // shortcut other bytecodes
                 _ => continue,
             };
 
-            // mark whether we are processing a return instruction
-            let is_return = matches!(bc, Ret(..));
-
-            // select the related invariants based on whether this bytecode instruction is a return
-            let inv_related = if is_return {
-                &inv_related_return
-            } else {
-                &inv_related_normal
-            };
-
-            // collect instantiation information
-            let relevance = Self::calculate_invariant_relevance(
+            // collect instantiation information (step 1)
+            // - entrypoint assumptions arised from memories that are read-only from the bytecode
+            let relevance_ro = Self::calculate_invariant_relevance(
                 env,
-                mem_related.iter(),
-                inv_related,
+                mem_ro.iter(),
+                inv_ro,
                 fun_type_params_arity,
             );
 
-            if is_return {
-                // capture invariants asserted before return
-                if exitpoint_assertions.is_some() {
-                    panic!("Expect at most one return instruction in the function body");
-                }
-                exitpoint_assertions = Some(relevance);
-            } else {
-                // capture invariants asserted after the bytecode
-                per_bytecode_assertions.insert(code_offset, relevance);
+            // collect instantiation information (step 2)
+            // - invariants that need to be assumed and asserted for read-write operations
+            let relevance_rw_normal = Self::calculate_invariant_relevance(
+                env,
+                mem_rw.iter(),
+                &inv_rw_normal,
+                fun_type_params_arity,
+            );
+            let relevance_rw_return = Self::calculate_invariant_relevance(
+                env,
+                mem_rw.iter(),
+                &inv_rw_return,
+                fun_type_params_arity,
+            );
 
-                // save the related memories for return point if the function defers that
-                if check_suspendable_inv_on_return {
-                    mem_related_on_return.extend(mem_related);
+            // entrypoint assumptions are about both the ro invariants and rw invariants, and
+            // regardless of whether they are checked in-place or deferred to the exit point.
+            for (inv_id, inv_rel) in relevance_ro
+                .iter()
+                .chain(relevance_rw_normal.iter())
+                .chain(relevance_rw_return.iter())
+            {
+                let inv = env.get_global_invariant(*inv_id).unwrap();
+                if matches!(inv.kind, ConditionKind::GlobalInvariantUpdate(..)) {
+                    // update invariants should not be assumed at function entrypoint
+                    continue;
                 }
+                entrypoint_assumptions
+                    .entry(*inv_id)
+                    .or_insert_with(PerBytecodeRelevance::default)
+                    .merge(inv_rel.clone());
             }
-        }
 
-        // sanity check: the deferred memory is indeed consumed by a return instruction, UNLESS
-        // the deferred memory do not touch anything that is checked in any suspendable invariant.
-        if !mem_related_on_return.is_empty() {
-            let mut deferred_invs = vec![];
-            'error_check: for inv_id in inv_related_return {
-                let inv = env.get_global_invariant(inv_id).unwrap();
-                for inv_mem in &inv.mem_usage {
-                    let inv_ty = inv_mem.to_type();
-                    for rel_mem in &mem_related_on_return {
-                        let rel_ty = rel_mem.to_type();
-                        let adapter =
-                            TypeUnificationAdapter::new_pair(&rel_ty, &inv_ty, true, true);
-                        if adapter.unify(Variance::Allow, false).is_none() {
-                            deferred_invs.push(inv_id);
-                            continue 'error_check;
-                        }
-                    }
-                }
-            }
-            if !deferred_invs.is_empty() {
-                env.error(
-                    &target.get_loc(),
-                    &format!(
-                        "Function `{}` defers the checking of {} suspendable invariants to the \
-                        return point, but the function never returns",
-                        target.func_env.get_full_name_str(),
-                        deferred_invs.len(),
-                    ),
-                );
+            // normal rw invariants are asserted in-place, right after the bytecode
+            per_bytecode_assertions.insert(code_offset, relevance_rw_normal);
+
+            // exitpoint assertions are only about the rw invariants deferred to the exit point.
+            for (inv_id, inv_rel) in relevance_rw_return {
+                exitpoint_assertions
+                    .entry(inv_id)
+                    .or_insert_with(PerBytecodeRelevance::default)
+                    .merge(inv_rel);
             }
         }
 
@@ -444,7 +390,7 @@ impl PerFunctionRelevance {
         Self {
             entrypoint_assumptions,
             per_bytecode_assertions,
-            exitpoint_assertions: exitpoint_assertions.unwrap_or_default(),
+            exitpoint_assertions,
         }
     }
 
@@ -546,5 +492,38 @@ impl PerFunctionRelevance {
         }
 
         result
+    }
+}
+
+fn get_callee_memory_usage_for_invariant_instrumentation(
+    env: &GlobalEnv,
+    targets: &FunctionTargetsHolder,
+    callee_fid: QualifiedId<FunId>,
+    callee_inst: &[Type],
+) -> (
+    BTreeSet<QualifiedInstId<StructId>>, // memory constitute to entry-point assumptions
+    BTreeSet<QualifiedInstId<StructId>>, // memory constitute to in-line or exit-point assertions
+) {
+    let inv_analysis = env
+        .get_extension::<InvariantAnalysisData>()
+        .expect("Verification analysis not performed");
+
+    let callee_env = env.get_function(callee_fid);
+    let callee_target = targets.get_target(&callee_env, &FunctionVariant::Baseline);
+    let callee_usage = usage_analysis::get_memory_usage(&callee_target);
+
+    // NOTE: it is important to include *ALL* memories accessed/modified by the callee
+    // instead of just the direct ones. Reasons include:
+    // - if a function `F` delegates suspendable invariant checking to its caller,
+    //   all the functions that `F` calls will not check suspendable invariants anymore.
+    // - if a function `F` is inlined, then all its callee might be inlined as well and
+    //   it is important to assume the invariants for them.
+    let all_accessed = callee_usage.accessed.get_all_inst(callee_inst);
+    if inv_analysis.fun_set_with_no_inv_check.contains(&callee_fid) {
+        let mem_rw = callee_usage.modified.get_all_inst(callee_inst);
+        let mem_ro = all_accessed.difference(&mem_rw).cloned().collect();
+        (mem_ro, mem_rw)
+    } else {
+        (all_accessed, BTreeSet::new())
     }
 }

--- a/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
+++ b/language/move-prover/bytecode/src/global_invariant_instrumentation_v2.rs
@@ -145,7 +145,7 @@ impl Analyzer {
         let mut func_insts = BTreeSet::new();
 
         let fun_mems = &usage_analysis::get_memory_usage(target).accessed.all;
-        let fun_arity = target.get_type_parameters().len();
+        let fun_arity = target.get_type_parameter_count();
         for inv_mem in &invariant.mem_usage {
             for fun_mem in fun_mems.iter() {
                 if inv_mem.module_id != fun_mem.module_id || inv_mem.id != fun_mem.id {

--- a/language/move-prover/bytecode/src/mono_analysis.rs
+++ b/language/move-prover/bytecode/src/mono_analysis.rs
@@ -275,8 +275,7 @@ impl<'a> Analyzer<'a> {
         // Analyze instantiations (when this function is a verification target)
         if self.inst_opt.is_none() {
             // collect information
-            let fun_type_params = target.get_type_parameters();
-            let fun_type_params_arity = fun_type_params.len();
+            let fun_type_params_arity = target.get_type_parameter_count();
             let usage_state = UsageProcessor::analyze(self.targets, target.func_env, target.data);
 
             // collect instantiations

--- a/language/move-prover/bytecode/tests/global_invariant_analysis/mutual_inst.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_analysis/mutual_inst.exp
@@ -397,6 +397,8 @@ A::good: [
       ]
     ]
   }
+  2: S::publish_x_y<u64, bool>($t0, $t2, $t3) on_abort goto L2 with $t4 {}
+  5: S::publish_x_y<u64, bool>($t1, $t5, $t6) on_abort goto L2 with $t4 {}
   exitpoint {}
 ]
 

--- a/language/move-prover/bytecode/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
@@ -96,12 +96,14 @@ Demo::f1: [
       ]
     ]
   }
+  0: $t1 := exists<Demo::S1<bool>>($t0) {}
   10: write_back[Demo::S1<bool>@]($t3) {
     assert @0 = [
       <> -> [
       ]
     ]
   }
+  12: $t6 := exists<Demo::S1<u64>>($t0) {}
   22: write_back[Demo::S1<u64>@]($t8) {
     assert @0 = [
       <> -> [

--- a/language/move-prover/bytecode/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
+++ b/language/move-prover/bytecode/tests/global_invariant_analysis/uninst_type_param_in_inv.exp
@@ -93,6 +93,8 @@ Demo::f1: [
   entrypoint {
     assume @0 = [
       <> -> [
+        <bool, #0>
+        <u64, #1>
       ]
     ]
   }
@@ -100,6 +102,7 @@ Demo::f1: [
   10: write_back[Demo::S1<bool>@]($t3) {
     assert @0 = [
       <> -> [
+        <bool, #0>
       ]
     ]
   }
@@ -107,6 +110,7 @@ Demo::f1: [
   22: write_back[Demo::S1<u64>@]($t8) {
     assert @0 = [
       <> -> [
+        <u64, #1>
       ]
     ]
   }

--- a/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.exp
+++ b/language/move-prover/bytecode/tests/verification_analysis/inv_suspension.exp
@@ -96,14 +96,14 @@ invariant applicability: [
   InvRelevance::outer_T: {
     accessed: [@0*, @1*]
     modified: [@0*, @1*]
-    directly accessed: [@0*, @1*]
-    directly modified: [@0*, @1*]
+    directly accessed: [@1*]
+    directly modified: [@1*]
   }
   InvRelevance::outer_bool: {
     accessed: [@0*]
     modified: [@0*]
-    directly accessed: [@0*]
-    directly modified: [@0*]
+    directly accessed: []
+    directly modified: []
   }
   InvRelevance::outer_u64: {
     accessed: [@1*]

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -818,7 +818,7 @@ impl<'env> Evaluator<'env> {
         // convert type args
         let callee_inst = env.get_node_instantiation(node_id);
         if cfg!(debug_assertions) {
-            let callee_ty_params = callee_target.get_type_parameters();
+            let callee_ty_params = callee_target.func_env.get_type_parameters();
             assert_eq!(decl.type_params.len(), callee_ty_params.len());
             assert_eq!(decl.type_params.len(), callee_inst.len());
         }

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -2173,7 +2173,7 @@ impl<'env> FunctionContext<'env> {
 
         // check and convert type arguments
         if cfg!(debug_assertions) {
-            let callee_ty_params = callee_target.get_type_parameters();
+            let callee_ty_params = callee_target.func_env.get_type_parameters();
             // TODO (mengxu) verify type constraints
             assert_eq!(callee_ty_params.len(), ty_args.len());
         }

--- a/language/move-prover/tests/sources/functional/uninst_global_invariant.exp
+++ b/language/move-prover/tests/sources/functional/uninst_global_invariant.exp
@@ -1,0 +1,11 @@
+Move prover returns: exiting with boogie verification errors
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/uninst_global_invariant.move:33:9
+   │
+33 │         invariant<T> exists<S2<T>>(@0x42) ==> exists<S1>(@0x42);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/uninst_global_invariant.move:11: test2
+   =         account = <redacted>
+   =     at tests/sources/functional/uninst_global_invariant.move:12: test2
+   =     at tests/sources/functional/uninst_global_invariant.move:33

--- a/language/move-prover/tests/sources/functional/uninst_global_invariant.move
+++ b/language/move-prover/tests/sources/functional/uninst_global_invariant.move
@@ -1,17 +1,35 @@
 module 0x42::Test {
-    struct S1 has key, store {}
+    struct S1 has key, store, drop { v: u64 }
 
-    struct S2<T: store> has key, store { t: T }
+    struct S2<T: store + drop> has key, store, drop { t: T }
 
-    fun foo(account: signer) {
-        move_to(&account, S1 {});
+    fun test1(account: signer) {
+        move_to(&account, S1 { v: 0 });
+        // invariant is related here and verifies
+    }
+
+    fun test2(account: address) acquires S1 {
+        move_from<S1>(account);
+        // invariant is related here and does not verify
+    }
+
+    fun test3(account: address) acquires S1 {
+        let s1 = borrow_global_mut<S1>(account);
+        *&mut s1.v = 0;
+        // invariant is related here and verifies
+    }
+
+    fun test4(account: address) acquires S1 {
+        let s1 = borrow_global_mut<S1>(account);
+        *&mut s1.v = 0;
+        // invariant is related here and verifies
+
+        let s1 = borrow_global_mut<S1>(account);
+        *&mut s1.v = 1;
+        // invariant is related here and verifies
     }
 
     spec module {
-        invariant<T> exists<S1>(@0x42) ==> exists<S2<T>>(@0x42);
-
-        // When applying invariant I to function foo, we cannot
-        // find a valid instantiation for the type parameter `T`.
-        // therefore, this global invariant cannot be checked.
+        invariant<T> exists<S2<T>>(@0x42) ==> exists<S1>(@0x42);
     }
 }


### PR DESCRIPTION
Not all type parameters in a generic global invariant can be instantiated when
instrumenting the invariant to a function. in #9545, we give warning on those
invariants but that is not enough, as these invariants are still silently considered
as verified. But in reality, these invariants may or may not hold. As shown in the
test case `uninst_global_invariant.move`.

Following is an illustration of the problem:

```move
// function
fun incr_counter(account: &signer): u64 acquires BallotCounter {
  let addr = Signer::address_of(account);
  let counter = &mut borrow_global_mut<BallotCounter>(addr).counter;
  let count = *counter;
  *counter = *counter + 1;
  ^^^^^^^^^^^^^^^^^^^^^^^^
                          -- invariant is applicable here, but we
                          -- can’t find a proper instantiation for
                          -- the `Proposal` type parameter.
  count
}

// invariant
invariant<Proposal> forall ballot_address: address
  where exists<Ballots<Proposal>>(ballot_address):
    exists<BallotCounter>(ballot_address);
```

The solution is to automatically add a ghost type parameter to the
list of function type parameters. And the ghost type parameter is only
used to instantiate the invariant and is not used in the Move code.

```move
fun incr_counter<T>(account: &signer): u64 acquires BallotCounter {
                ^^^
                   -- this is a ghost type parameter and is not used
                   -- in the body of `incr_counter` in the Move code.
  
  // instrumented entry-point assumption
  assume forall ballot_address: address
    where exists<Ballots<T>>(ballot_address):
      exists<BallotCounter>(ballot_address);

  let addr = Signer::address_of(account);
  let counter = &mut borrow_global_mut<BallotCounter>(addr).counter;
  let count = *counter;
  *counter = *counter + 1;
  ^^^^^^^^^^^^^^^^^^^^^^^^
                          -- the invariant can be instrumented here by
                          -- instantiation invariant<Proposal = T> 
  
  // instrumented check
  assert forall ballot_address: address
    where exists<Ballots<T>>(ballot_address):
      exists<BallotCounter>(ballot_address);
  count
}
```

This solution is implemented in this PR.

## Motivation

Fix a hole in the generic invariant implementation

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

- CI
- The whole diem framework still verifies despite there are uninstantiated invariants in them.
- Test cases are updated
