### PR TITLE
[shuffle] shuffle transactions --raw

### DIFF
--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -41,8 +41,13 @@ pub async fn main() -> Result<()> {
             &normalized_key_path(key_path)?,
             &normalized_address(address)?,
         ),
-        Subcommand::Transactions { network, tail } => {
-            transactions::handle(normalized_network(network.as_str())?, should_tail(tail)).await
+        Subcommand::Transactions { network, tail, raw } => {
+            transactions::handle(
+                normalized_network(network.as_str())?,
+                unwrap_nested_boolean_option(tail),
+                unwrap_nested_boolean_option(raw),
+            )
+            .await
         }
     }
 }
@@ -101,6 +106,13 @@ pub enum Subcommand {
         #[structopt(short, long)]
         network: String,
 
+        #[structopt(
+            short,
+            long,
+            help = "Writes out transactions without pretty formatting"
+        )]
+        raw: Option<Option<bool>>,
+
         #[structopt(short, help = "Blocks and streams future transactions as they happen")]
         tail: Option<Option<bool>>,
     },
@@ -157,8 +169,8 @@ fn normalized_network(network: &str) -> Result<Url> {
     }
 }
 
-fn should_tail(tail_flag: Option<Option<bool>>) -> bool {
-    match tail_flag {
+fn unwrap_nested_boolean_option(option: Option<Option<bool>>) -> bool {
+    match option {
         Some(Some(val)) => val,
         Some(_val) => true,
         None => false,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We want shuffle transactions to print all transactions in the pretty format for easy readability. If the user wants the transaction to be printed out in one line however, we also want to give them the flexibility to do so by using the --raw flag. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

When I run cargo run -p shuffle -- transactions -n 127.0.0.1:8081, I get this output:

![image](https://user-images.githubusercontent.com/55404786/140164484-95921da9-6e00-43c9-b7af-78e0487a79d7.png)

When I run cargo run -p shuffle -- transactions -n 127.0.0.1:8081 --raw, I get this output:

<img width="1750" alt="Screen Shot 2021-11-03 at 10 50 13 AM" src="https://user-images.githubusercontent.com/55404786/140164709-a3f5cd2a-e280-4cdf-8e06-75c6cde65d20.png">

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
