### PR TITLE
shuffle node --genesis /path/to/move/package

### DIFF
--- a/shuffle/cli/src/account.rs
+++ b/shuffle/cli/src/account.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{get_home_path, send, Home};
+use crate::shared::{get_home_path, send_transaction, Home};
 use anyhow::{anyhow, Context, Result};
 use diem_config::config::NodeConfig;
 use diem_crypto::PrivateKey;
@@ -156,7 +156,7 @@ pub fn create_account_onchain(
                 false,
             ),
         ));
-        send(client, create_new_account_txn)?;
+        send_transaction(client, create_new_account_txn)?;
         println!("Successfully created account {}", new_account.address());
     }
     println!(

--- a/shuffle/cli/src/account.rs
+++ b/shuffle/cli/src/account.rs
@@ -43,10 +43,10 @@ pub fn handle(root: Option<PathBuf>) -> Result<()> {
         }
     }
 
-    let config = NodeConfig::load(&home.get_node_config_path()).with_context(|| {
+    let config = NodeConfig::load(&home.get_validator_config_path()).with_context(|| {
         format!(
             "Failed to load NodeConfig from file: {:?}",
-            home.get_node_config_path()
+            home.get_validator_config_path()
         )
     })?;
     let json_rpc_url = format!("http://0.0.0.0:{}", config.json_rpc.address.port());

--- a/shuffle/cli/src/deploy.rs
+++ b/shuffle/cli/src/deploy.rs
@@ -29,7 +29,8 @@ pub fn handle(project_path: &Path) -> Result<()> {
             "An account hasn't been created yet! Run shuffle account first."
         ));
     }
-    let compiled_package = shared::build_move_packages(project_path)?;
+    let compiled_package =
+        shared::build_move_package(project_path.join(shared::MAIN_PKG_PATH).as_ref())?;
     publish_packages_as_transaction(home.get_latest_key_path(), compiled_package)
 }
 

--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -21,7 +21,7 @@ pub async fn main() -> Result<()> {
     let subcommand = Subcommand::from_args();
     match subcommand {
         Subcommand::New { blockchain, path } => new::handle(blockchain, path),
-        Subcommand::Node {} => node::handle(),
+        Subcommand::Node { genesis } => node::handle(genesis),
         Subcommand::Build { project_path } => {
             build::handle(&normalized_project_path(project_path)?)
         }
@@ -65,7 +65,10 @@ pub enum Subcommand {
         path: PathBuf,
     },
     #[structopt(about = "Runs a local devnet with prefunded accounts")]
-    Node {},
+    Node {
+        #[structopt(short, long, help = "Move package directory to be used for genesis")]
+        genesis: Option<String>,
+    },
     #[structopt(about = "Compiles the Move package and generates typescript files")]
     Build {
         #[structopt(short, long)]

--- a/shuffle/cli/src/node.rs
+++ b/shuffle/cli/src/node.rs
@@ -1,31 +1,105 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::get_shuffle_dir;
+use crate::{shared, shared::Home};
 use anyhow::Result;
-use diem_types::on_chain_config::VMPublishingOption;
-use rand::SeedableRng;
-use std::fs;
+use diem_config::config::NodeConfig;
+use diem_types::{chain_id::ChainId, on_chain_config::VMPublishingOption};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
-pub fn handle() -> Result<()> {
-    let shuffle_dir = get_shuffle_dir();
-    if !shuffle_dir.is_dir() {
-        println!("Creating node config in {}", shuffle_dir.display());
-        fs::create_dir_all(&shuffle_dir)?;
+pub fn handle(genesis: Option<String>) -> Result<()> {
+    let home = Home::new(shared::get_home_path().as_path())?;
+    if !home.get_shuffle_path().is_dir() {
+        println!(
+            "Creating node config in {}",
+            home.get_shuffle_path().display()
+        );
+
+        create_node(&home, genesis)
     } else {
-        println!("Accessing node config in {}", shuffle_dir.display());
-    }
-    let publishing_option = VMPublishingOption::open();
+        println!(
+            "Accessing node config in {}",
+            home.get_shuffle_path().display()
+        );
+        if genesis.is_some() {
+            return Err(
+                anyhow::anyhow!(
+                    "Unable to set genesis on an already created node. rm -rf ~/.shuffle to recreate node; you will lose state"
+                )
+            );
+        }
 
-    // prepare a deterministic generator so that recreated test environments
-    // have the same waypoints, configurations, etc
-    let rng = rand::rngs::StdRng::seed_from_u64(0);
+        start_node(&home)
+    }
+}
+
+fn create_node(home: &Home, genesis: Option<String>) -> Result<()> {
+    fs::create_dir_all(home.get_shuffle_path())?;
+
+    let publishing_option = VMPublishingOption::open();
+    let genesis_modules = genesis_modules_from_path(&genesis)?;
     diem_node::load_test_environment(
-        Some(shuffle_dir.join("nodeconfig")),
+        Some(PathBuf::from(home.get_node_config_path())),
         false,
         Some(publishing_option),
-        diem_framework_releases::current_module_blobs().to_vec(),
-        rng,
+        genesis_modules,
+        rand::rngs::OsRng,
     );
     Ok(())
+}
+
+fn start_node(home: &Home) -> Result<()> {
+    println!("\tLog file: {:?}", home.get_validator_log_path());
+    println!("\tConfig path: {:?}", home.get_validator_config_path());
+    println!("\tDiem root key path: {:?}", home.get_root_key_path());
+    println!("\tWaypoint: {}", home.read_genesis_waypoint()?);
+    // Configure json rpc to bind on 0.0.0.0
+    let mut config = NodeConfig::load(home.get_validator_config_path()).unwrap();
+    config.json_rpc.address = format!("0.0.0.0:{}", config.json_rpc.address.port())
+        .parse()
+        .unwrap();
+    println!("\tJSON-RPC endpoint: {}", config.json_rpc.address);
+    config.json_rpc.stream_rpc.enabled = true;
+    println!("\tStream-RPC enabled!");
+    config.api.enabled = true;
+    println!("\tREST API enabled!");
+    println!("\tREST API: {}", config.api.address);
+
+    println!(
+        "\tFullNode network: {}",
+        config.full_node_networks[0].listen_address
+    );
+    println!("\tChainId: {}", ChainId::test());
+    println!();
+    println!("Diem is running, press ctrl-c to exit");
+    println!();
+
+    diem_node::start(&config, Some(PathBuf::from(home.get_validator_log_path())));
+    Ok(())
+}
+
+fn genesis_modules_from_path(genesis: &Option<String>) -> Result<Vec<Vec<u8>>> {
+    let path = match genesis {
+        None => return Ok(diem_framework_releases::current_module_blobs().to_vec()),
+        Some(path_str) => Path::new(path_str),
+    };
+
+    println!("Using custom genesis: {}", path.display());
+    let mut genesis_modules: Vec<Vec<u8>> = Vec::new();
+    let compiled_package = shared::build_move_package(path)?;
+    for module in compiled_package
+        .transitive_compiled_modules()
+        .compute_dependency_graph()
+        .compute_topological_order()?
+    {
+        println!("Genesis Module: {}", module.self_id());
+        let mut binary = vec![];
+        module.serialize(&mut binary)?;
+        genesis_modules.push(binary);
+    }
+
+    Ok(genesis_modules)
 }

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -62,7 +62,10 @@ pub fn read_config(project_path: &Path) -> Result<Config> {
 }
 
 /// Send a transaction to the blockchain through the blocking client.
-pub fn send(client: &BlockingClient, tx: diem_types::transaction::SignedTransaction) -> Result<()> {
+pub fn send_transaction(
+    client: &BlockingClient,
+    tx: diem_types::transaction::SignedTransaction,
+) -> Result<()> {
     use diem_json_rpc_types::views::VMStatusView;
 
     client.submit(&tx)?;

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -69,13 +69,13 @@ pub fn send_transaction(
     use diem_json_rpc_types::views::VMStatusView;
 
     client.submit(&tx)?;
-    assert_eq!(
-        client
-            .wait_for_signed_transaction(&tx, Some(std::time::Duration::from_secs(60)), None)?
-            .into_inner()
-            .vm_status,
-        VMStatusView::Executed,
-    );
+    let status = client
+        .wait_for_signed_transaction(&tx, Some(std::time::Duration::from_secs(60)), None)?
+        .into_inner()
+        .vm_status;
+    if status != VMStatusView::Executed {
+        return Err(anyhow::anyhow!("transaction execution failed: {}", status));
+    }
     Ok(())
 }
 

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{account, deploy, shared};
+use crate::{
+    account, deploy,
+    shared::{self, MAIN_PKG_PATH},
+};
 use anyhow::{Context, Result};
 use diem_config::config::{NodeConfig, DEFAULT_PORT};
 use diem_crypto::PrivateKey;
@@ -17,10 +20,10 @@ pub fn handle(project_path: &Path) -> Result<()> {
     shared::generate_typescript_libraries(project_path)?;
     let home = Home::new(shared::get_home_path().as_path())?;
 
-    let config = NodeConfig::load(&home.get_node_config_path()).with_context(|| {
+    let config = NodeConfig::load(&home.get_validator_config_path()).with_context(|| {
         format!(
             "Failed to load NodeConfig from file: {:?}",
-            home.get_node_config_path()
+            home.get_validator_config_path()
         )
     })?;
     let json_rpc_url = format!("http://0.0.0.0:{}", config.json_rpc.address.port());
@@ -84,7 +87,7 @@ fn send_module_transaction(
         project_path.to_string_lossy().to_string()
     );
 
-    let compiled_package = shared::build_move_packages(project_path)?;
+    let compiled_package = shared::build_move_package(project_path.join(MAIN_PKG_PATH).as_ref())?;
     deploy::send_module_transaction(&compiled_package, client, new_account, factory)?;
     deploy::check_module_exists(client, new_account)
 }

--- a/shuffle/transaction-builder/Cargo.toml
+++ b/shuffle/transaction-builder/Cargo.toml
@@ -24,7 +24,6 @@ parking_lot = "0.11.1"
 [dev-dependencies]
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
-move-core-types = { path = "../../language/move-core/types" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 
 [features]


### PR DESCRIPTION
## Motivation

Diem Core Framework (DCF) developers work on .move files that are included in the genesis. This is a significantly different workflow to regular Move application developers in that
1. DCF devs are using the root mint.key to seed the genesis txn w move modules
2. This implies special privileges
3. DCF devs cannot be the default sender address of 0x241... on genesis writes

Adding the below flag will allow one to customize the genesis on creation of a new node:
<img width="1001" alt="CleanShot 2021-11-03 at 12 42 00@2x" src="https://user-images.githubusercontent.com/635121/140181302-ee948efc-8c11-4d02-a047-7b23477c29f2.png">
<img width="548" alt="CleanShot 2021-11-03 at 12 42 16@2x" src="https://user-images.githubusercontent.com/635121/140181341-b9f17b76-e6da-410b-b4c4-d38764788842.png">


Do note however that modifying the genesis after node creation is not yet supported, and will error out:

<img width="883" alt="CleanShot 2021-11-03 at 12 42 53@2x" src="https://user-images.githubusercontent.com/635121/140181423-e54c3794-6b0b-4d00-8418-ef606eaf4aff.png">


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cd shuffle && cargo test
