### PR TITLE
[shuffle] shuffle transactions --address

### DIFF
--- a/shuffle/cli/src/console.rs
+++ b/shuffle/cli/src/console.rs
@@ -3,6 +3,7 @@
 
 use crate::shared;
 use anyhow::Result;
+use diem_types::account_address::AccountAddress;
 use std::{collections::HashMap, path::Path, process::Command};
 
 /// Launches a Deno REPL for the shuffle project, generating transaction
@@ -11,7 +12,7 @@ pub fn handle(
     project_path: &Path,
     network: Option<String>,
     key_path: &Path,
-    sender_address: &str,
+    sender_address: AccountAddress,
 ) -> Result<()> {
     let config = shared::read_config(project_path)?;
     shared::generate_typescript_libraries(project_path)?;
@@ -49,7 +50,10 @@ pub fn handle(
         String::from("SHUFFLE_HOME"),
         shared::get_shuffle_dir().to_string_lossy().to_string(),
     );
-    filtered_envs.insert(String::from("SENDER_ADDRESS"), String::from(sender_address));
+    filtered_envs.insert(
+        String::from("SENDER_ADDRESS"),
+        sender_address.to_hex_literal(),
+    );
     filtered_envs.insert(
         String::from("PRIVATE_KEY_PATH"),
         key_path.to_string_lossy().to_string(),

--- a/shuffle/cli/src/transactions.rs
+++ b/shuffle/cli/src/transactions.rs
@@ -1,25 +1,19 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
-use crate::shared::{get_home_path, Home};
 use anyhow::{anyhow, Result};
 use diem_types::account_address::AccountAddress;
-use reqwest::{Client, Response};
+use reqwest::{Client, Response, StatusCode};
 use serde_json::Value;
-use std::{cmp::max, fs, io, io::Write, str::FromStr, thread, time};
+use std::{cmp::max, io, io::Write, thread, time};
 use url::Url;
 
 const DIEM_ACCOUNT_TYPE: &str = "0x1::DiemAccount::DiemAccount";
 
 // Will list the last 10 transactions and has the ability to block and stream future transactions.
-pub async fn handle(network: Url, tail: bool, raw: bool) -> Result<()> {
-    let home = Home::new(get_home_path().as_path())?;
-    let address_str = fs::read_to_string(home.get_latest_address_path())?;
-    let address = AccountAddress::from_str(address_str.as_str())?;
+pub async fn handle(network: Url, tail: bool, address: AccountAddress, raw: bool) -> Result<()> {
     let client = reqwest::Client::new();
-
     let account_seq_num = get_account_sequence_number(&client, &network, address).await?;
     let mut prev_seq_num = max(account_seq_num as i64 - 10, 0);
-
     let resp =
         get_account_transactions_response(&client, address, &network, prev_seq_num, 10).await?;
     let json_with_txns: serde_json::Value = serde_json::from_str(resp.text().await?.as_str())?;
@@ -94,7 +88,8 @@ async fn get_account_transactions_response(
     start: i64,
     limit: u64,
 ) -> Result<Response> {
-    let path = network.join(format!("accounts/{}/transactions", address).as_str())?;
+    let path =
+        network.join(format!("accounts/{}/transactions", address.to_hex_literal()).as_str())?;
     Ok(client
         .get(path.as_str())
         .query(&[("start", start.to_string().as_str())])
@@ -108,10 +103,21 @@ async fn get_account_sequence_number(
     network: &Url,
     address: AccountAddress,
 ) -> Result<u64> {
-    let path = network.join(format!("accounts/{}/resources", address.to_hex_literal()).as_str())?;
+    let path =
+        network.join(format!("accounts/{}/resources/", address.to_hex_literal()).as_str())?;
     let resp = client.get(path.as_str()).send().await?;
+    check_accounts_resources_response_status_code(&resp.status())?;
     let json: Vec<Value> = serde_json::from_str(resp.text().await?.as_str())?;
     parse_json_for_account_seq_num(json)
+}
+
+fn check_accounts_resources_response_status_code(status_code: &StatusCode) -> Result<()> {
+    match status_code == &StatusCode::from_u16(200)? {
+        true => Ok(()),
+        false => Err(anyhow!(
+            "Failed to get account resources with provided address"
+        )),
+    }
 }
 
 fn parse_txn_for_seq_num(last_txn: &Value) -> Result<i64> {
@@ -254,5 +260,19 @@ mod test {
         let txn = get_sample_txn();
         let seq_num = parse_txn_for_seq_num(&txn[0]).unwrap();
         assert_eq!(seq_num, 2);
+    }
+
+    #[test]
+    fn test_check_accounts_resources_response_status_code() {
+        assert_eq!(
+            check_accounts_resources_response_status_code(&StatusCode::from_u16(200).unwrap())
+                .is_err(),
+            false
+        );
+        assert_eq!(
+            check_accounts_resources_response_status_code(&StatusCode::from_u16(404).unwrap())
+                .is_err(),
+            true
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

We want the ability to capture transactions from a given address. This PR accomplishes that. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Run cargo -p shuffle -- transactions -n 127.0.0.1:8081 --address 0x24163AFCC6E33B0A9473852E18327FA9

<img width="1750" alt="Screen Shot 2021-11-03 at 12 54 02 PM" src="https://user-images.githubusercontent.com/55404786/140182960-7f15e525-ab0e-4dce-af6e-fa6f5767461f.png">


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
