### PR TITLE
[shuffle] shuffle test with e2e, unit test, and all subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7745,6 +7745,7 @@ dependencies = [
  "hex",
  "include_dir",
  "move-binary-format",
+ "move-cli",
  "move-lang",
  "move-package",
  "once_cell",

--- a/shuffle/cli/Cargo.toml
+++ b/shuffle/cli/Cargo.toml
@@ -38,6 +38,7 @@ diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
 generate-key = { path = "../../config/generate-key" }
 move-lang = { path = "../../language/move-lang" }
+move-cli = { path = "../../language/tools/move-cli" }
 move-package = { path = "../../language/tools/move-package" }
 move-binary-format = { path = "../../language/move-binary-format" }
 shuffle-custom-node = { path = "../genesis" }

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -334,6 +334,13 @@ fn generate_transaction_builders(pkg_path: &Path, target_dir: &Path) -> Result<(
     Ok(())
 }
 
+pub fn normalized_project_path(project_path: Option<PathBuf>) -> Result<PathBuf> {
+    match project_path {
+        Some(path) => Ok(path),
+        None => get_shuffle_project_path(&std::env::current_dir()?),
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{generate_typescript_libraries, get_shuffle_project_path};

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -5,17 +5,27 @@ use crate::{
     account, deploy,
     shared::{self, MAIN_PKG_PATH},
 };
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use diem_config::config::{NodeConfig, DEFAULT_PORT};
 use diem_crypto::PrivateKey;
 use diem_sdk::{
-    client::BlockingClient, transaction_builder::TransactionFactory, types::LocalAccount,
+    client::{AccountAddress, BlockingClient},
+    transaction_builder::TransactionFactory,
+    types::LocalAccount,
 };
 use diem_types::{chain_id::ChainId, transaction::authenticator::AuthenticationKey};
+use move_cli::package::cli;
+use move_package::BuildConfig;
 use shared::Home;
-use std::{collections::HashMap, path::Path, process::Command};
+use std::{
+    collections::HashMap,
+    panic,
+    path::{Path, PathBuf},
+    process::Command,
+};
+use structopt::StructOpt;
 
-pub fn handle(project_path: &Path) -> Result<()> {
+pub fn run_e2e_tests(project_path: &Path) -> Result<()> {
     let _config = shared::read_config(project_path)?;
     shared::generate_typescript_libraries(project_path)?;
     let home = Home::new(shared::get_home_path().as_path())?;
@@ -27,14 +37,21 @@ pub fn handle(project_path: &Path) -> Result<()> {
         )
     })?;
     let json_rpc_url = format!("http://0.0.0.0:{}", config.json_rpc.address.port());
-    println!("Connecting to {}...", json_rpc_url);
-    let client = BlockingClient::new(json_rpc_url);
+    let network = json_rpc_url.as_str();
+    println!("Connecting to {}...", network);
+    let client = BlockingClient::new(network);
     let factory = TransactionFactory::new(ChainId::test());
 
     let mut new_account = create_test_account(&client, &home, &factory)?;
     create_receiver_account(&client, &home, &factory)?;
     send_module_transaction(&client, &mut new_account, project_path, &factory)?;
-    run_deno_test(project_path, &config)
+    run_deno_test(
+        project_path,
+        &config,
+        network,
+        home.get_test_key_path(),
+        new_account.address(),
+    )
 }
 
 // Set up a new test account
@@ -93,7 +110,13 @@ fn send_module_transaction(
 }
 
 // Run shuffle test using deno
-fn run_deno_test(project_path: &Path, config: &NodeConfig) -> Result<()> {
+fn run_deno_test(
+    project_path: &Path,
+    config: &NodeConfig,
+    network: &str,
+    key_path: &Path,
+    sender_address: AccountAddress,
+) -> Result<()> {
     let tests_path_string = project_path
         .join("e2e")
         .as_path()
@@ -110,12 +133,20 @@ fn run_deno_test(project_path: &Path, config: &NodeConfig) -> Result<()> {
         shared::get_shuffle_dir().to_str().unwrap().to_string(),
     );
 
+    filtered_envs.insert(String::from("SENDER_ADDRESS"), sender_address.to_string());
+    filtered_envs.insert(
+        String::from("PRIVATE_KEY_PATH"),
+        key_path.to_string_lossy().to_string(),
+    );
+
+    filtered_envs.insert(String::from("SHUFFLE_NETWORK"), network.to_string());
+
     Command::new("deno")
         .args([
             "test",
             "--unstable",
             tests_path_string.as_str(),
-            "--allow-env=PROJECT_PATH,SHUFFLE_HOME",
+            "--allow-env=PROJECT_PATH,SHUFFLE_HOME,SHUFFLE_NETWORK,PRIVATE_KEY_PATH,SENDER_ADDRESS",
             "--allow-read",
             format!(
                 "--allow-net=:{},:{}",
@@ -129,4 +160,86 @@ fn run_deno_test(project_path: &Path, config: &NodeConfig) -> Result<()> {
         .expect("deno failed to start, is it installed? brew install deno")
         .wait()?;
     Ok(())
+}
+
+fn run_move_unit_tests(project_path: &Path) -> Result<()> {
+    let unit_test_cmd = cli::PackageCommand::UnitTest {
+        // Setting to default values with exception of report_storage_on_error
+        // to get more information about a failed test
+        instruction_execution_bound: 5000,
+        filter: None,
+        list: false,
+        num_threads: 8,
+        report_statistics: false,
+        report_storage_on_error: true,
+        check_stackless_vm: false,
+        verbose_mode: false,
+    };
+
+    panic::set_hook(Box::new(|_info| {
+        // Allows us to return the error below instead of panic!
+        // todo: Remove all panic catching after @tzakian PR lands
+    }));
+
+    let result = panic::catch_unwind(|| {
+        cli::handle_package_commands(
+            &Some(project_path.join(MAIN_PKG_PATH)),
+            generate_build_config_for_testing()?,
+            &unit_test_cmd,
+        )
+    });
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(_) => Err(anyhow!("Run move package build in the main folder of the project directory, then rerun shuffle test [subcommand]")),
+    }
+}
+
+fn generate_build_config_for_testing() -> Result<BuildConfig> {
+    Ok(BuildConfig {
+        dev_mode: true,
+        test_mode: true,
+        generate_docs: false,
+        generate_abis: true,
+        install_dir: None,
+    })
+}
+
+#[derive(Debug, StructOpt)]
+pub enum TestCommand {
+    #[structopt(about = "Runs end to end test in shuffle")]
+    E2e {
+        #[structopt(short, long)]
+        project_path: Option<PathBuf>,
+    },
+
+    #[structopt(about = "Runs move move unit tests in project folder")]
+    Unit {
+        #[structopt(short, long)]
+        project_path: Option<PathBuf>,
+    },
+
+    #[structopt(
+        about = "Runs both end to end test in shuffle and move move unit tests in project folder"
+    )]
+    All {
+        #[structopt(short, long)]
+        project_path: Option<PathBuf>,
+    },
+}
+
+pub fn handle(cmd: TestCommand) -> Result<()> {
+    match cmd {
+        TestCommand::E2e { project_path } => {
+            run_e2e_tests(shared::normalized_project_path(project_path)?.as_path())
+        }
+        TestCommand::Unit { project_path } => {
+            run_move_unit_tests(shared::normalized_project_path(project_path)?.as_path())
+        }
+        TestCommand::All { project_path } => {
+            let normalized_path = shared::normalized_project_path(project_path)?;
+            run_move_unit_tests(normalized_path.as_path())?;
+            run_e2e_tests(normalized_path.as_path())
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR achieves the ability to allow users to run the move unit tests they've written using shuffle. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

This code runs `move package test` in the main folder of the project folder. To test if my code works, I need to make sure that my code prints the same output as `move package test` does.

To do this I first wrote a quick test in one of my move modules:

![image](https://user-images.githubusercontent.com/55404786/140196305-3ac06791-631b-407a-810c-34ee25af7b3d.png)

Then I ran `move package test` in my terminal to see what the output would be: 

![image](https://user-images.githubusercontent.com/55404786/140196394-9e4f1986-3e00-4c1a-b8e2-63db3a88559b.png)

Then I ran `cargo run -p shuffle -- test unit -p /Users/avinash00/a` to see if I'd get the same output:

![image](https://user-images.githubusercontent.com/55404786/140196814-3cc54cfd-35ae-499a-8434-e1e6d48e794c.png)

Notice how the output of the shuffle command matches the move package test command.

## Related PRs

There is currently a bug when a user runs move package test twice in their directory. This PR, #9491, will fix this bug. 

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
