### PR TITLE
[api] api spec test job

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -35,6 +35,7 @@ jobs:
       test-non-rust-lint: ${{ steps.non-rust-lint-changes.outputs.changes-found }}
       test-docker-compose: ${{ steps.docker-compose-changes.outputs.changes-found }}
       test-test-coverage: ${{ steps.test-coverage.outputs.changes-found }}
+      test-api-spec: ${{ steps.test-api-spec.outputs.changes-found }}
     steps:
       - uses: actions/checkout@v2.4.0
         with:
@@ -140,6 +141,11 @@ jobs:
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
           pattern: '^rust.toolchain\|^x.toml\|^devtools\|^.github\|common/logger'
+      - id: test-api-spec
+        name: find api changes.
+        uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
+        with:
+          pattern: '^api'
 
   dev-setup-sh-test:
     runs-on: ubuntu-20.04-xl
@@ -930,6 +936,21 @@ jobs:
         uses: ./.github/actions/early-terminator
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
+
+  api_spec_test:
+    name: API specification test
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: ${{ needs.prepare.outputs.test-api-spec == 'true' }}
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - name: Use Node.js 14
+        uses: actions/setup-node@v2.4.0
+        with:
+          node-version: '14'
+      - name:
+        working-directory: api
+        run: make test
 
   # Compile (but don't run) the benchmarks, to insulate against bit rot
   build-benchmarks:

--- a/api/Makefile
+++ b/api/Makefile
@@ -1,0 +1,18 @@
+# Copyright (c) The Diem Core Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+test: clean lint test-code-gen clean
+
+lint:
+	npx @redocly/openapi-cli lint doc/openapi.yaml --skip-rule no-empty-servers
+
+test-code-gen:
+	npx @openapitools/openapi-generator-cli version-manager set 5.2.1
+	npx @openapitools/openapi-generator-cli generate -g rust -i doc/openapi.yaml -o /tmp/diem_api_client --package-name diem_api_client
+	cd /tmp/diem_api_client && cargo build
+
+clean:
+	rm -rf /tmp/diem_api_client
+	rm -rf openapitools.json
+
+.PHONY: test lint test-code-gen clean

--- a/scripts/api_lint.sh
+++ b/scripts/api_lint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Copyright (c) The Diem Core Contributors
-# SPDX-License-Identifier: Apache-2.0
-
-set -e
-
-npx @redocly/openapi-cli lint api/doc/openapi.yaml --skip-rule no-empty-servers


### PR DESCRIPTION
#9193 add a new build job for running api specification lint task and a simple test of rust code generation.

Intent to create a new job instead of mixing with non-rust-lint, because we will need add more specification test later.

Removed scripts/api_lint.sh, change to add Makefile to api directory, later will add more specification test tasks, it is easier to be maintained by a Makefile