### PR TITLE
[transaction-builder-generator] Add Swift support

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -623,7 +623,7 @@ jobs:
           key: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: run codegen unit tests
         run: |
-          $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator -p shuffle --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
+          source $HOME/.profile && $pre_command && mkdir -p target/junit-reports && cargo nextest --jobs ${max_threads} --tries ${nextest_tries} --failure-output=immediate-final -p transaction-builder-generator -p shuffle --unit --changed-since "origin/$TARGET_BRANCH" --run-ignored=ignored-only --junit target/junit-reports/codegen-unit-test.xml
         env:
           TARGET_BRANCH: ${{ needs.prepare.outputs.changes-target-branch }}
       - name: upload codegen test results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7583,9 +7583,9 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.20.3"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97c2583aebdb8c0e72cefc41788c014d706175ae666c5ef4ae3518fdd9d70b1"
+checksum = "b5cf21ac6679c60495e22ed041e2c913740f0332597c6a64bbcba04dbcb39249"
 dependencies = [
  "bcs",
  "bincode",
@@ -9219,7 +9219,7 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f559b464de2e2bdabcac6a210d12e9b5a5973c251e102c44c585c71d51bd78e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "static_assertions",
 ]
 

--- a/crates/diem-documentation-tool/Cargo.toml
+++ b/crates/diem-documentation-tool/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2018"
 
 [dependencies]
 serde_yaml = "0.8.17"
-serde-reflection = "0.3.4"
-serde-generate = "0.20.2"
+serde-reflection = "0.3.5"
+serde-generate = "0.20.6"
 anyhow = "1.0.38"
 regex = "1.4.3"
 structopt = "0.3.21"

--- a/diem-move/transaction-builder-generator/Cargo.toml
+++ b/diem-move/transaction-builder-generator/Cargo.toml
@@ -15,13 +15,13 @@ heck = "0.3.2"
 regex = "1.4.3"
 structopt = "0.3.21"
 textwrap = "0.13.4"
-serde-reflection = "0.3.4"
-serde-generate = "0.20.2"
 serde_yaml = "0.8.17"
 
 diem-types = { path = "../../types" }
 diem-workspace-hack = { path = "../../crates/diem-workspace-hack" }
 move-core-types = { path = "../../language/move-core/types" }
+serde-reflection = "0.3.5"
+serde-generate = "0.20.6"
 bcs = "0.1.2"
 
 [dev-dependencies]

--- a/diem-move/transaction-builder-generator/README.md
+++ b/diem-move/transaction-builder-generator/README.md
@@ -43,6 +43,8 @@ The following languages are currently supported:
 
 * TypeScript / JavaScript
 
+* Swift (version 5.3)
+
 
 ## Quick Start
 
@@ -193,6 +195,52 @@ dotnet add Demo.csproj reference ../Diem/Types/Diem.Types.csproj
 dotnet add Demo.csproj reference ../Serde/Serde.csproj
 dotnet add Demo.csproj reference ../Bcs/Bcs.csproj
 dotnet run --project Demo.csproj
+```
+
+### Swift
+
+To install Swift source `Serde`, `Bcs`, `DiemTypes`, and `DiemStdlib` into a target directory `$DEST`, run:
+```bash
+target/debug/generate-transaction-builders \
+    --language swift \
+    --module-name DiemStdlib \
+    --with-diem-types "testsuite/generate-format/tests/staged/diem.yaml" \
+    --target-source-dir "$DEST" \
+    "language/diem-framework/DPN/releases/legacy" \
+    "language/diem-framework/DPN/releases/artifacts/current"
+```
+
+Next, you may copy the [Swift demo](examples/swift/main.swift), create the
+Swift package for the transaction builders, and execute the example with the
+following:
+
+```bash
+cp language/transaction-builder/generator/examples/swift/main.swift "$DEST/Sources/DiemStdlib"
+cd "$DEST"
+cat >Package.swift <<EOF
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "DiemStdlib",
+    targets: [
+        .target(
+            name: "Serde",
+            dependencies: []
+        ),
+        .target(
+            name: "DiemTypes",
+            dependencies: ["Serde"]
+        ),
+        .target(
+            name: "DiemStdlib",
+            dependencies: ["Serde", "DiemTypes"]
+        ),
+    ]
+)
+EOF
+swift run
 ```
 
 ## Adding Support for a New Language

--- a/diem-move/transaction-builder-generator/examples/swift/main.swift
+++ b/diem-move/transaction-builder-generator/examples/swift/main.swift
@@ -1,0 +1,78 @@
+import DiemTypes
+
+func demo_peer_to_peer_script() throws {
+    let address = DiemTypes.AccountAddress(value: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    let module = DiemTypes.Identifier(value: "XDX")
+    let name = DiemTypes.Identifier(value: "XDX")
+    let type_params: [DiemTypes.TypeTag] = []
+    let struct_tag = DiemTypes.StructTag(
+        address: address,
+        module: module,
+        name: name,
+        type_params: type_params
+    )
+    let token = DiemTypes.TypeTag.Struct(struct_tag)
+    let payee = DiemTypes.AccountAddress(value: [
+        0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+        0x22,
+    ])
+    let amount: UInt64 = 1234567
+    let script = encode_peer_to_peer_with_metadata_script(
+        currency: token,
+        payee: payee,
+        amount: amount,
+        metadata: [],
+        metadata_signature: []
+    )
+    switch try decode_peer_to_peer_with_metadata_script(script: script) {
+        case .PeerToPeerWithMetadata(_, let p, let a, _, _):
+            assert(p == payee, "Payee doesn't match")
+            assert(a == amount, "Amount doesn't match")
+        default: assertionFailure("Invalid scriptcall")
+    }
+
+    for o in try script.bcsSerialize() {
+        print(o, terminator: " ")
+    }
+    print()
+}
+
+func demo_peer_to_peer_script_function() throws {
+    let address = DiemTypes.AccountAddress(value: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    let module = DiemTypes.Identifier(value: "XDX")
+    let name = DiemTypes.Identifier(value: "XDX")
+    let type_params: [DiemTypes.TypeTag] = []
+    let struct_tag = DiemTypes.StructTag(
+        address: address,
+        module: module,
+        name: name,
+        type_params: type_params
+    )
+    let token = DiemTypes.TypeTag.Struct(struct_tag)
+    let payee = DiemTypes.AccountAddress(value: [
+        0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+        0x22,
+    ])
+    let amount: UInt64 = 1234567
+    let script = try PaymentScripts.encode_peer_to_peer_with_metadata_script_function(
+        currency: token,
+        payee: payee,
+        amount: amount,
+        metadata: [],
+        metadata_signature: []
+    )
+    switch try PaymentScripts.decode_peer_to_peer_with_metadata_script_function(payload: script) {
+        case .PeerToPeerWithMetadata(_, let p, let a, _, _):
+            assert(p == payee, "Payee doesn't match")
+            assert(a == amount, "Amount doesn't match")
+        default: assertionFailure("Invalid script function call")
+    }
+
+    for o in try script.bcsSerialize() {
+        print(o, terminator: " ")
+    }
+    print()
+}
+
+try demo_peer_to_peer_script()
+try demo_peer_to_peer_script_function()

--- a/diem-move/transaction-builder-generator/src/common.rs
+++ b/diem-move/transaction-builder-generator/src/common.rs
@@ -69,12 +69,11 @@ pub(crate) fn make_abi_enum_container(abis: &[ScriptABI]) -> ContainerFormat {
         for arg in abi.args() {
             fields.push(quote_parameter_as_field(arg));
         }
-        let format = VariantFormat::Struct(fields);
         variants.insert(
             index as u32,
             Named {
                 name: abi.name().to_camel_case(),
-                value: format,
+                value: VariantFormat::Struct(fields),
             },
         );
     }

--- a/diem-move/transaction-builder-generator/src/generate.rs
+++ b/diem-move/transaction-builder-generator/src/generate.rs
@@ -22,7 +22,8 @@ enum Language {
     Java,
     Csharp,
     Go,
-    TypeScript
+    TypeScript,
+    Swift,
 }
 }
 
@@ -114,6 +115,9 @@ fn main() {
                 Language::TypeScript => {
                     buildgen::typescript::output(&mut out, &abis).unwrap();
                 }
+                Language::Swift => {
+                    buildgen::swift::output(&mut out, &abis).unwrap();
+                }
                 Language::Csharp => {
                     panic!("Code generation in C# requires --target_source_dir");
                 }
@@ -138,6 +142,7 @@ fn main() {
                 Language::TypeScript => {
                     Box::new(serdegen::typescript::Installer::new(install_dir.clone()))
                 }
+                Language::Swift => Box::new(serdegen::swift::Installer::new(install_dir.clone())),
                 Language::Go => Box::new(serdegen::golang::Installer::new(
                     install_dir.clone(),
                     options.serde_package_name.clone(),
@@ -171,6 +176,7 @@ fn main() {
             Language::Csharp => ("Diem.Types".to_string(), vec!["Diem", "Types"]),
             Language::Go => ("diemtypes".to_string(), vec!["diemtypes"]),
             Language::TypeScript => ("diemTypes".to_string(), vec!["diemTypes"]),
+            Language::Swift => ("DiemTypes".to_string(), vec!["DiemTypes"]),
             _ => ("diem_types".to_string(), vec!["diem_types"]),
         };
         let custom_diem_code = buildgen::read_custom_code_from_paths(
@@ -192,6 +198,7 @@ fn main() {
                 options.diem_package_name,
             )),
             Language::TypeScript => Box::new(buildgen::typescript::Installer::new(install_dir)),
+            Language::Swift => Box::new(buildgen::swift::Installer::new(install_dir)),
             Language::Rust => Box::new(buildgen::rust::Installer::new(
                 install_dir,
                 options.diem_version_number,

--- a/diem-move/transaction-builder-generator/src/lib.rs
+++ b/diem-move/transaction-builder-generator/src/lib.rs
@@ -17,6 +17,8 @@ pub mod java;
 pub mod python3;
 /// Support for code-generation in Rust.
 pub mod rust;
+/// Support for code-generation in Swift.
+pub mod swift;
 /// Support for code-generation in TypeScript.
 pub mod typescript;
 

--- a/diem-move/transaction-builder-generator/src/swift.rs
+++ b/diem-move/transaction-builder-generator/src/swift.rs
@@ -1,0 +1,561 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::common;
+use diem_types::transaction::{
+    ArgumentABI, ScriptABI, ScriptFunctionABI, TransactionScriptABI, TypeArgumentABI,
+};
+use move_core_types::{
+    account_address::AccountAddress,
+    language_storage::{ModuleId, TypeTag},
+};
+use serde_generate::{
+    indent::{IndentConfig, IndentedWriter},
+    swift, CodeGeneratorConfig,
+};
+
+use heck::{CamelCase, ShoutySnakeCase};
+use std::{
+    collections::BTreeMap,
+    io::{Result, Write},
+    path::PathBuf,
+};
+
+pub struct Installer {
+    install_dir: PathBuf,
+}
+
+/// Shared state for the TypeScript code generator.
+struct SwiftEmitter<T> {
+    /// Writer.
+    out: IndentedWriter<T>,
+}
+
+/// Output transaction builders and decoders in TypeScript for the given ABIs.
+pub fn output(out: &mut dyn Write, abis: &[ScriptABI]) -> Result<()> {
+    writeln!(out, "import DiemTypes")?;
+    write_script_calls(out, abis)?;
+    write_helpers(out, abis)?;
+    Ok(())
+}
+
+fn write_helpers(out: &mut dyn Write, abis: &[ScriptABI]) -> Result<()> {
+    let mut emitter = SwiftEmitter {
+        out: IndentedWriter::new(out, IndentConfig::Space(2)),
+    };
+    let txn_script_abis = common::transaction_script_abis(abis);
+    let script_fun_abis = common::script_function_abis(abis);
+    emitter.output_preamble()?;
+
+    for abi in &txn_script_abis {
+        emitter.output_script_encoder_function(abi)?;
+    }
+
+    for abi in &txn_script_abis {
+        emitter.output_script_decoder_function(abi)?;
+    }
+
+    emitter.output_script_function_encoders(&script_fun_abis)?;
+
+    emitter.output_decoding_helpers(&common::filter_transaction_scripts(abis))?;
+    emitter.output_code_constants(&txn_script_abis)?;
+
+    Ok(())
+}
+
+fn write_script_calls(out: &mut dyn Write, abis: &[ScriptABI]) -> Result<()> {
+    let txn_script_abis = common::transaction_script_abis(abis);
+    let script_fun_abis = common::script_function_abis(abis);
+    let external_definitions = crate::common::get_external_definitions("DiemTypes");
+    let script_registry: BTreeMap<_, _> = vec![
+        (
+            "ScriptCall".to_string(),
+            common::make_abi_enum_container(
+                txn_script_abis
+                    .iter()
+                    .cloned()
+                    .map(ScriptABI::TransactionScript)
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            ),
+        ),
+        (
+            "ScriptFunctionCall".to_string(),
+            common::make_abi_enum_container(
+                script_fun_abis
+                    .iter()
+                    .cloned()
+                    .map(ScriptABI::ScriptFunction)
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            ),
+        ),
+    ]
+    .into_iter()
+    .collect();
+    let mut comments: BTreeMap<_, _> = txn_script_abis
+        .iter()
+        .map(|abi| {
+            let paths = vec!["ScriptCall".to_string(), abi.name().to_camel_case()];
+            (paths, crate::common::prepare_doc_string(abi.doc()))
+        })
+        .chain(script_fun_abis.iter().map(|abi| {
+            let paths = vec!["ScriptFunctionCall".to_string(), abi.name().to_camel_case()];
+            (paths, crate::common::prepare_doc_string(abi.doc()))
+        }))
+        .collect();
+    comments.insert(
+        vec!["ScriptCall".to_string()],
+        "Structured representation of a call into a known Move script.".into(),
+    );
+    comments.insert(
+        vec!["ScriptFunctionCall".to_string()],
+        "Structured representation of a call into a known Move script function.".into(),
+    );
+
+    let config = CodeGeneratorConfig::new("DiemStdlib".to_string())
+        .with_comments(comments)
+        .with_external_definitions(external_definitions)
+        .with_serialization(false);
+    swift::CodeGenerator::new(&config)
+        .output(out, &script_registry)
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, format!("{}", err)))?;
+    Ok(())
+}
+
+impl Installer {
+    pub fn new(install_dir: PathBuf) -> Self {
+        Installer { install_dir }
+    }
+}
+
+impl crate::SourceInstaller for Installer {
+    type Error = Box<dyn std::error::Error>;
+
+    fn install_transaction_builders(
+        &self,
+        name: &str,
+        abis: &[ScriptABI],
+    ) -> std::result::Result<(), Self::Error> {
+        let dir_path = self.install_dir.join("Sources").join(name);
+        std::fs::create_dir_all(&dir_path)?;
+        let mut file = std::fs::File::create(dir_path.join("DiemStdlib.swift"))?;
+        output(&mut file, abis)?;
+        Ok(())
+    }
+}
+
+impl<T> SwiftEmitter<T>
+where
+    T: Write,
+{
+    fn output_preamble(&mut self) -> Result<()> {
+        writeln!(
+            self.out,
+            r#"
+public enum PayloadDecodingError: Error {{
+    case invalidInput(issue: String)
+}}
+public func into_script_function(payload: DiemTypes.TransactionPayload) throws -> DiemTypes.ScriptFunction {{
+    switch payload {{
+        case .ScriptFunction(let script_function): return script_function
+        default: throw PayloadDecodingError.invalidInput(issue: "Unexpected transaction payload")
+    }}
+}}
+            "#
+        )?;
+        Ok(())
+    }
+
+    // Script functions are grouped by and namespaced by their declaring module. So a script
+    // function `f` in a module `M` will be called with `M.encode_f_script_function(...)`.
+    // Similarly for decode methods.
+    fn output_script_function_encoders(&mut self, abis: &[ScriptFunctionABI]) -> Result<()> {
+        let mut abis_by_module: BTreeMap<&ModuleId, Vec<&ScriptFunctionABI>> = BTreeMap::new();
+
+        for abi in abis {
+            let module_name = abi.module_name();
+            let entry = abis_by_module.entry(module_name).or_insert_with(Vec::new);
+            entry.push(abi);
+        }
+
+        for (module_name, abis) in abis_by_module {
+            writeln!(
+                self.out,
+                "public enum {} {{",
+                module_name.name().to_string().to_camel_case()
+            )?;
+            self.out.indent();
+            for abi in abis {
+                self.output_script_function_encoder_function(abi)?;
+                self.output_script_function_decoder_function(abi)?;
+            }
+            self.out.unindent();
+            writeln!(self.out, "}}")?;
+        }
+        Ok(())
+    }
+
+    fn output_script_encoder_function(&mut self, abi: &TransactionScriptABI) -> Result<()> {
+        self.output_comment(0, &common::prepare_doc_string(abi.doc()))?;
+        writeln!(
+            self.out,
+            "public func encode_{}_script({}) -> DiemTypes.Script {{",
+            abi.name(),
+            [
+                Self::quote_type_parameters(abi.ty_args()),
+                Self::quote_parameters(abi.args()),
+            ]
+            .concat()
+            .join(", ")
+        )?;
+        self.out.indent();
+        writeln!(
+            self.out,
+            "return DiemTypes.Script(code: CodeConstants.{}, ty_args: [{}], args: [{}])",
+            abi.name().to_shouty_snake_case(),
+            Self::quote_type_arguments(abi.ty_args()),
+            Self::quote_arguments_for_script(abi.args()),
+        )?;
+        self.out.unindent();
+        writeln!(self.out, "}}")
+    }
+
+    fn output_script_function_encoder_function(&mut self, abi: &ScriptFunctionABI) -> Result<()> {
+        self.output_comment(0, &common::prepare_doc_string(abi.doc()))?;
+        writeln!(
+            self.out,
+            "public static func encode_{}_script_function({}) throws -> DiemTypes.TransactionPayload {{",
+            abi.name(),
+            [
+                Self::quote_type_parameters(abi.ty_args()),
+                Self::quote_parameters(abi.args()),
+            ]
+            .concat()
+            .join(", ")
+        )?;
+        self.out.indent();
+        writeln!(self.out, "{}", Self::quote_arguments(abi.args()))?;
+        writeln!(self.out,
+            "return DiemTypes.TransactionPayload.ScriptFunction(DiemTypes.ScriptFunction(module: {}, function: {}, ty_args: [{}], args: [{}]))",
+            Self::quote_module_id(abi.module_name()),
+            Self::quote_identifier(abi.name()),
+            Self::quote_type_arguments(abi.ty_args()),
+            abi.args().iter().map(|arg| {
+                format!("{}_serialized", arg.name())
+            }).collect::<Vec<_>>().join(", ")
+            )?;
+        self.out.unindent();
+        writeln!(self.out, "}}")
+    }
+
+    fn output_script_function_decoder_function(&mut self, abi: &ScriptFunctionABI) -> Result<()> {
+        writeln!(self.out, "\n public static func decode_{}_script_function(payload: DiemTypes.TransactionPayload) throws -> ScriptFunctionCall {{", abi.name())?;
+        self.out.indent();
+        if !abi.args().is_empty() || !abi.ty_args().is_empty() {
+            writeln!(
+                self.out,
+                "let script = try into_script_function(payload: payload)"
+            )?;
+        }
+        let ty_params = abi
+            .ty_args()
+            .iter()
+            .enumerate()
+            .map(|(i, ty_arg)| format!("{}: script.ty_args[{}]", ty_arg.name(), i));
+        let params = abi.args().iter().map(|arg| format!("{0}: {0}", arg.name()));
+        for (i, arg) in abi.args().iter().enumerate() {
+            let data_access = format!("script.args[{}]", i);
+            writeln!(
+                self.out,
+                "{}",
+                Self::quote_deserialize_transaction_argument(
+                    arg.type_tag(),
+                    arg.name(),
+                    &data_access
+                )
+            )?;
+        }
+        let params = Self::format_args(ty_params.chain(params));
+        writeln!(
+            self.out,
+            "return ScriptFunctionCall.{}{}",
+            abi.name().to_camel_case(),
+            params
+        )?;
+        self.out.unindent();
+        writeln!(self.out, "}}")?;
+        Ok(())
+    }
+
+    fn output_script_decoder_function(&mut self, abi: &TransactionScriptABI) -> Result<()> {
+        writeln!(
+            self.out,
+            "\n public func decode_{}_script(script: DiemTypes.Script) throws -> ScriptCall {{",
+            abi.name()
+        )?;
+        self.out.indent();
+        let ty_params = abi
+            .ty_args()
+            .iter()
+            .enumerate()
+            .map(|(i, ty_arg)| format!("{}: script.ty_args[{}]", ty_arg.name(), i));
+        let params = abi.args().iter().enumerate().map(|(i, arg)| {
+            format!(
+                "{}: try decode_{}_argument(script.args[{}])",
+                arg.name(),
+                common::mangle_type(arg.type_tag()),
+                i
+            )
+        });
+        writeln!(
+            self.out,
+            "return ScriptCall.{}{}",
+            abi.name().to_camel_case(),
+            Self::format_args(ty_params.chain(params))
+        )?;
+        self.out.unindent();
+        writeln!(self.out, "}}")?;
+        Ok(())
+    }
+
+    fn output_decoding_helpers(&mut self, abis: &[ScriptABI]) -> Result<()> {
+        let required_types = common::get_required_helper_types(abis);
+        for required_type in required_types {
+            self.output_decoding_helper(required_type)?;
+        }
+        Ok(())
+    }
+
+    fn output_decoding_helper(&mut self, type_tag: &TypeTag) -> Result<()> {
+        use TypeTag::*;
+        let (constructor, expr) = match type_tag {
+            Bool => ("Bool", "value".to_string()),
+            U8 => ("U8", "value".to_string()),
+            U64 => ("U64", "value".to_string()),
+            U128 => ("U128", "value".to_string()),
+            Address => ("Address", "value".to_string()),
+            Vector(type_tag) => match type_tag.as_ref() {
+                U8 => ("U8Vector", "value".to_string()),
+                _ => common::type_not_allowed(type_tag),
+            },
+            Struct(_) | Signer => common::type_not_allowed(type_tag),
+        };
+        writeln!(
+            self.out,
+            r#"
+func decode_{}_argument(_ arg: DiemTypes.TransactionArgument) throws -> {} {{
+    switch arg {{
+        case .{}(let value): return {}
+        default: throw PayloadDecodingError.invalidInput(issue: "Unexpected transaction argument")
+    }}
+}}
+"#,
+            common::mangle_type(type_tag),
+            Self::quote_type(type_tag),
+            constructor,
+            expr,
+        )
+    }
+
+    fn output_code_constants(&mut self, abis: &[TransactionScriptABI]) -> Result<()> {
+        writeln!(self.out, "struct CodeConstants {{")?;
+        self.out.indent();
+        for abi in abis {
+            self.output_code_constant(abi)?;
+        }
+        self.out.unindent();
+        writeln!(self.out, "}}")?;
+        Ok(())
+    }
+
+    fn output_code_constant(&mut self, abi: &TransactionScriptABI) -> Result<()> {
+        writeln!(
+            self.out,
+            "static let {}: [UInt8] = [{}]",
+            abi.name().to_shouty_snake_case(),
+            abi.code()
+                .iter()
+                .map(|x| format!("{}", x))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )?;
+        Ok(())
+    }
+
+    fn quote_arguments_for_script(args: &[ArgumentABI]) -> String {
+        args.iter()
+            .map(|arg| Self::quote_transaction_argument_for_script(arg.type_tag(), arg.name()))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    fn quote_transaction_argument_for_script(type_tag: &TypeTag, name: &str) -> String {
+        use TypeTag::*;
+        match type_tag {
+            Bool => format!("DiemTypes.TransactionArgument.Bool({})", name),
+            U8 => format!("DiemTypes.TransactionArgument.U8({})", name),
+            U64 => format!("DiemTypes.TransactionArgument.U64({})", name),
+            U128 => format!("DiemTypes.TransactionArgument.U128({})", name),
+            Address => format!("DiemTypes.TransactionArgument.Address({})", name),
+            Vector(type_tag) => match type_tag.as_ref() {
+                U8 => format!("DiemTypes.TransactionArgument.U8Vector({})", name),
+                _ => common::type_not_allowed(type_tag),
+            },
+
+            Struct(_) | Signer => common::type_not_allowed(type_tag),
+        }
+    }
+
+    fn output_comment(&mut self, indentation: usize, doc: &str) -> std::io::Result<()> {
+        let prefix = " ".repeat(indentation) + "// ";
+        let empty_line = "\n".to_string() + &" ".repeat(indentation) + "///\n";
+        let text = textwrap::indent(doc, &prefix).replace("\n\n", &empty_line);
+        write!(self.out, "\n{}\n", text)
+    }
+
+    fn quote_type_parameters(ty_args: &[TypeArgumentABI]) -> Vec<String> {
+        ty_args
+            .iter()
+            .map(|ty_arg| format!("{}: DiemTypes.TypeTag", ty_arg.name()))
+            .collect()
+    }
+
+    fn quote_parameters(args: &[ArgumentABI]) -> Vec<String> {
+        args.iter()
+            .map(|arg| format!("{}: {}", arg.name(), Self::quote_type(arg.type_tag())))
+            .collect()
+    }
+
+    fn quote_type_arguments(ty_args: &[TypeArgumentABI]) -> String {
+        ty_args
+            .iter()
+            .map(|ty_arg| ty_arg.name().to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    fn quote_arguments(args: &[ArgumentABI]) -> String {
+        args.iter()
+            .map(|arg| Self::quote_serialize_transaction_argument(arg.type_tag(), arg.name()))
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    fn quote_type(type_tag: &TypeTag) -> String {
+        use TypeTag::*;
+        match type_tag {
+            Bool => "Bool".into(),
+            U8 => "UInt8".into(),
+            U64 => "UInt64".into(),
+            U128 => "BigInt8".into(),
+            Address => "DiemTypes.AccountAddress".into(),
+            Vector(type_tag) => match type_tag.as_ref() {
+                U8 => "[UInt8]".into(),
+                _ => common::type_not_allowed(type_tag),
+            },
+            Struct(_) | Signer => common::type_not_allowed(type_tag),
+        }
+    }
+
+    fn quote_deserialize_transaction_argument_type(type_tag: &TypeTag, ser_name: &str) -> String {
+        use TypeTag::*;
+        match type_tag {
+            Bool => format!("{}.deserialize_bool()", ser_name),
+            U8 => format!("{}.deserialize_u8()", ser_name),
+            U64 => format!("{}.deserialize_u64()", ser_name),
+            U128 => format!("{}.deserialize_u128()", ser_name),
+            Address => format!(
+                "DiemTypes.AccountAddress.deserialize(deserializer: {})",
+                ser_name
+            ),
+            Vector(type_tag) => match type_tag.as_ref() {
+                U8 => format!("{}.deserialize_bytes()", ser_name),
+                _ => common::type_not_allowed(type_tag),
+            },
+            Struct(_) | Signer => common::type_not_allowed(type_tag),
+        }
+    }
+
+    fn quote_deserialize_transaction_argument(
+        type_tag: &TypeTag,
+        name: &str,
+        data_access: &str,
+    ) -> String {
+        let deser_name = format!("{}_deserializer", name);
+        format!(
+            "let {} = BcsDeserializer(input: {})\n\
+            let {}: {} = try {}\n",
+            deser_name,
+            data_access,
+            name,
+            Self::quote_type(type_tag),
+            Self::quote_deserialize_transaction_argument_type(type_tag, &deser_name),
+        )
+    }
+
+    fn quote_serialize_transaction_argument_type(
+        type_tag: &TypeTag,
+        ser_name: &str,
+        arg_name: &str,
+    ) -> String {
+        use TypeTag::*;
+        match type_tag {
+            Bool => format!("{}.serialize_bool(value: {})", ser_name, arg_name),
+            U8 => format!("{}.serialize_u8(value: {})", ser_name, arg_name),
+            U64 => format!("{}.serialize_u64(value: {})", ser_name, arg_name),
+            U128 => format!("{}.serialize_u128(value: {})", ser_name, arg_name),
+            Address => format!("{}.serialize(serializer: {})", arg_name, ser_name),
+            Vector(type_tag) => match type_tag.as_ref() {
+                U8 => format!("{}.serialize_bytes(value: {})", ser_name, arg_name),
+                _ => common::type_not_allowed(type_tag),
+            },
+            Struct(_) | Signer => common::type_not_allowed(type_tag),
+        }
+    }
+
+    fn quote_serialize_transaction_argument(type_tag: &TypeTag, name: &str) -> String {
+        let ser_name = format!("{}_serializer", name);
+        format!(
+            "let {0} = BcsSerializer()\n\
+            try {1}\n\
+            let {2}_serialized: [UInt8] = {0}.get_bytes()\n",
+            ser_name,
+            Self::quote_serialize_transaction_argument_type(type_tag, &ser_name, name),
+            name
+        )
+    }
+
+    fn quote_module_id(module_id: &ModuleId) -> String {
+        format!(
+            "DiemTypes.ModuleId(address: {}, name: {})",
+            Self::quote_address(module_id.address()),
+            Self::quote_identifier(module_id.name().as_str())
+        )
+    }
+
+    fn quote_address(address: &AccountAddress) -> String {
+        format!(
+            "DiemTypes.AccountAddress(value: [{}])",
+            address
+                .to_vec()
+                .iter()
+                .map(|x| format!("{}", x))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+
+    fn quote_identifier(ident: &str) -> String {
+        format!("DiemTypes.Identifier(value: \"{}\")", ident)
+    }
+
+    fn format_args(x: impl Iterator<Item = String>) -> String {
+        let pre_args = x.collect::<Vec<_>>();
+        if pre_args.is_empty() {
+            "".to_string()
+        } else {
+            format!("({})", pre_args.join(", "))
+        }
+    }
+}

--- a/diem-move/transaction-builder-generator/tests/cli.rs
+++ b/diem-move/transaction-builder-generator/tests/cli.rs
@@ -12,7 +12,7 @@ fn test_examples_in_readme() -> std::io::Result<()> {
     let file = std::io::BufReader::new(std::fs::File::open("README.md")?);
     let quotes = get_bash_quotes(file)?;
     // Check that we have the expected number of examples starting with "```bash".
-    assert_eq!(quotes.len(), 12);
+    assert_eq!(quotes.len(), 14);
 
     let mut quotes = quotes.into_iter();
 

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -95,6 +95,7 @@ function update_path_and_profile {
     add_to_profile "export BOOGIE_EXE=\"${DOTNET_ROOT}/tools/boogie\""
   fi
   if [[ "$INSTALL_CODEGEN" == "true" ]] && [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
+    add_to_profile "export PATH=\$PATH:${INSTALL_DIR}swift/usr/bin"
     if [[ -n "${GOBIN}" ]]; then
       add_to_profile "export PATH=\$PATH:/usr/lib/golang/bin"
     else
@@ -590,6 +591,20 @@ function install_deno {
   chmod +x "${INSTALL_DIR}deno"
 }
 
+function install_swift {
+    echo Installing Swift.
+    install_pkg wget "$PACKAGE_MANAGER"
+    install_pkg libncurses5 "$PACKAGE_MANAGER"
+    install_pkg clang "$PACKAGE_MANAGER"
+    install_pkg libcurl4 "$PACKAGE_MANAGER"
+    install_pkg libpython2.7 "$PACKAGE_MANAGER"
+    install_pkg libpython2.7-dev "$PACKAGE_MANAGER"
+    wget -q https://swift.org/builds/swift-5.3.3-release/ubuntu1804/swift-5.3.3-RELEASE/swift-5.3.3-RELEASE-ubuntu18.04.tar.gz
+    tar xzf swift-5.3.3-RELEASE-ubuntu18.04.tar.gz
+    rm -rf swift-5.3.3-RELEASE-ubuntu18.04.tar.gz
+    mv swift-5.3.3-RELEASE-ubuntu18.04 "${INSTALL_DIR}swift"
+}
+
 function install_java {
     if [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
       "${PRE_COMMAND[@]}" apt-get install -y default-jdk
@@ -707,6 +722,7 @@ Codegen tools (since -s was provided):
   * Golang
   * Java
   * Deno
+  * Swift
 EOF
   fi
 
@@ -948,6 +964,13 @@ if [[ "$INSTALL_CODEGEN" == "true" ]]; then
   install_deno
   install_java
   install_golang
+  if [[ "$PACKAGE_MANAGER" == "apt-get" ]]; then
+    # Only looked at this for a little while, but depends on glibc so alpine
+    # support isn't easily added. On Mac it requires XCode to be installed,
+    # which is quite largs, so probably something we don't want to download in
+    # this script.
+    install_swift
+  fi
   if [[ "$PACKAGE_MANAGER" != "apk" ]]; then
     # depends on wheels which needs glibc which doesn't work on alpine's python.
     # Only invested a hour or so in this, a work around may exist.

--- a/shuffle/cli/Cargo.toml
+++ b/shuffle/cli/Cargo.toml
@@ -47,8 +47,8 @@ move-core-types = { path = "../../language/move-core/types" }
 move-lang = { path = "../../language/move-lang" }
 move-package = { path = "../../language/tools/move-package" }
 move-unit-test = { path = "../../language/tools/move-unit-test" }
-serde-generate = "0.20.2"
-serde-reflection = "0.3.4"
+serde-reflection = "0.3.5"
+serde-generate = "0.20.6"
 serde_json = "1.0.68"
 serde_yaml = "0.8.17"
 smoke-test = { path = "../../testsuite/smoke-test" }

--- a/testsuite/generate-format/Cargo.toml
+++ b/testsuite/generate-format/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 rand = "0.8.3"
 serde = { version = "1.0.124", features = ["derive"] }
-serde-reflection = "0.3.4"
+serde-reflection = "0.3.5"
 serde_yaml = "0.8.17"
 structopt = "0.3.21"
 


### PR DESCRIPTION
This PR adds transaction builder support for Swift. Tests have been written and they run, and this adds support for swift to run in the CI transaction builder pipeline. Additionally, the way that script functions are named differs slightly from other transaction builders. Particularly, every script function encoder/decoder is under the declaring module's namespace to prevent name conflicts if two script functions with the same name are declared. e.g., you would have `PaymentScripts.encode_peer_to_peer_with_metadata_script_function` and PaymentScripts.decode_peer_to_peer_with_metadata_script_function`

Before landing this, a release of serde-reflect will need to be cut and the Cargo file will need to be updated before this can land to point at a release of serde reflection instead of the tip of `main`. 