### PR TITLE
[data-client] use callback for error notification instead of response id

### DIFF
--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_service.rs
@@ -215,7 +215,7 @@ impl<T: DiemDataClient + Send + Clone + 'static> DataStreamingService<T> {
     ) -> Result<(), Error> {
         let global_data_summary = self.global_data_summary.clone();
 
-        let data_stream = self.get_data_stream(data_stream_id);
+        let data_stream = self.get_data_stream_mut(data_stream_id);
         if !data_stream.data_requests_initialized() {
             // Initialize the request batch by sending out data client requests
             data_stream.initialize_data_requests(global_data_summary)?;
@@ -242,7 +242,18 @@ impl<T: DiemDataClient + Send + Clone + 'static> DataStreamingService<T> {
 
     /// Returns the data stream associated with the given `data_stream_id`.
     /// Note: this method assumes the caller has already verified the stream exists.
-    fn get_data_stream(&mut self, data_stream_id: &DataStreamId) -> &mut DataStream<T> {
+    fn get_data_stream(&self, data_stream_id: &DataStreamId) -> &DataStream<T> {
+        self.data_streams.get(data_stream_id).unwrap_or_else(|| {
+            panic!(
+                "Expected a data stream with ID: {:?}, but found None!",
+                data_stream_id
+            )
+        })
+    }
+
+    /// Returns the data stream associated with the given `data_stream_id`.
+    /// Note: this method assumes the caller has already verified the stream exists.
+    fn get_data_stream_mut(&mut self, data_stream_id: &DataStreamId) -> &mut DataStream<T> {
         self.data_streams
             .get_mut(data_stream_id)
             .unwrap_or_else(|| {


### PR DESCRIPTION
Previously the data client returned a `response_id: u64` for each response and allowed consumers to report errors through a `data_client.notify_bad_response(response_id, error)` API. Unfortunately, this pattern effectively mandates that a data client maintains an internal cache/queue of recent requests and their associated context, which is a big pain.

This PR instead allows a data client to piggyback whatever additional context its needs in a response error callback, which a consumer can then call to notify the data client that this specific request had an issue.

By adding context into the callback closure, the data client no longer needs to maintain a recent request/response queue since whatever internal indices or context the data client needs to update internal scores is already in the right place: the callback.