### PR TITLE
[consensus] Fast-forward waypoint in Safety Rules.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,6 +1083,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "channel",
+ "claim",
  "consensus-notifications",
  "consensus-types",
  "diem-config",

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -56,6 +56,7 @@ schemadb = { path = "../storage/schemadb" }
 storage-interface = { path = "../storage/storage-interface" }
 
 [dev-dependencies]
+claim = "0.5.0"
 proptest = "1.0.0"
 tempfile = "3.2.0"
 

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -51,6 +51,8 @@ pub enum Error {
     InconsistentExecutionResult(String, String),
     #[error("Invalid Ordered LedgerInfoWithSignatures: Empty or at least one of executed_state_id, version, or epoch_state are not dummy value: {0}")]
     InvalidOrderedLedgerInfo(String),
+    #[error("Waypoint out of date: Previous waypoint version {0}, updated version {1}, current epoch {2}, provided epoch {3}")]
+    WaypointOutOfDate(u64, u64, u64, u64),
 }
 
 impl From<serde_json::Error> for Error {

--- a/consensus/safety-rules/src/safety_rules.rs
+++ b/consensus/safety-rules/src/safety_rules.rs
@@ -294,10 +294,12 @@ impl SafetyRules {
         match current_epoch.cmp(&epoch_state.epoch) {
             Ordering::Greater => {
                 // waypoint is not up to the current epoch.
-                return Err(Error::NotInitialized(format!(
-                    "Provided epoch {} is older than current {}, likely waypoint is too old",
-                    epoch_state.epoch, current_epoch
-                )));
+                return Err(Error::WaypointOutOfDate(
+                    waypoint.version(),
+                    new_waypoint.version(),
+                    current_epoch,
+                    epoch_state.epoch,
+                ));
             }
             Ordering::Less => {
                 // start new epoch

--- a/consensus/src/metrics_safety_rules.rs
+++ b/consensus/src/metrics_safety_rules.rs
@@ -10,6 +10,7 @@ use consensus_types::{
     vote_proposal::MaybeSignedVoteProposal,
 };
 use diem_crypto::ed25519::Ed25519Signature;
+use diem_logger::prelude::info;
 use diem_metrics::monitor;
 use diem_types::{
     epoch_change::EpochChangeProof,
@@ -34,17 +35,33 @@ impl MetricsSafetyRules {
 
     pub fn perform_initialize(&mut self) -> Result<(), Error> {
         let consensus_state = self.consensus_state()?;
-        let sr_waypoint = consensus_state.waypoint();
-        let proofs = self
-            .storage
-            .retrieve_epoch_change_proof(sr_waypoint.version())
-            .map_err(|e| {
-                Error::InternalError(format!(
-                    "Unable to retrieve Waypoint state from storage, encountered Error:{}",
-                    e
-                ))
-            })?;
-        self.initialize(&proofs)
+        let mut waypoint_version = consensus_state.waypoint().version();
+        loop {
+            let proofs = self
+                .storage
+                .retrieve_epoch_change_proof(waypoint_version)
+                .map_err(|e| {
+                    Error::InternalError(format!(
+                        "Unable to retrieve Waypoint state from storage, encountered Error:{}",
+                        e
+                    ))
+                })?;
+            // We keep initializing safety rules as long as the waypoint continues to increase.
+            // This is due to limits in the number of epoch change proofs that storage can provide.
+            match self.initialize(&proofs) {
+                Err(Error::WaypointOutOfDate(
+                    prev_version,
+                    curr_version,
+                    current_epoch,
+                    provided_epoch,
+                )) if prev_version < curr_version => {
+                    waypoint_version = curr_version;
+                    info!("Previous waypoint version {}, updated version {}, current epoch {}, provided epoch {}", prev_version, curr_version, current_epoch, provided_epoch);
+                    continue;
+                }
+                result => return result,
+            }
+        }
     }
 
     fn retry<T, F: FnMut(&mut Box<dyn TSafetyRules + Send + Sync>) -> Result<T, Error>>(
@@ -53,7 +70,9 @@ impl MetricsSafetyRules {
     ) -> Result<T, Error> {
         let result = f(&mut self.inner);
         match result {
-            Err(Error::NotInitialized(_)) | Err(Error::IncorrectEpoch(_, _)) => {
+            Err(Error::NotInitialized(_))
+            | Err(Error::IncorrectEpoch(_, _))
+            | Err(Error::WaypointOutOfDate(_, _, _, _)) => {
                 self.perform_initialize()?;
                 f(&mut self.inner)
             }
@@ -123,5 +142,131 @@ impl TSafetyRules for MetricsSafetyRules {
                 inner.sign_commit_vote(ledger_info.clone(), new_ledger_info.clone())
             )
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{metrics_safety_rules::MetricsSafetyRules, test_utils::EmptyStorage};
+    use claim::{assert_matches, assert_ok};
+    use consensus_types::{
+        block_data::BlockData,
+        timeout::Timeout,
+        timeout_2chain::{TwoChainTimeout, TwoChainTimeoutCertificate},
+        vote::Vote,
+        vote_proposal::MaybeSignedVoteProposal,
+    };
+    use diem_crypto::ed25519::Ed25519Signature;
+    use diem_types::{
+        epoch_change::EpochChangeProof,
+        ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    };
+    use safety_rules::{ConsensusState, Error, TSafetyRules};
+
+    pub struct MockSafetyRules {
+        // number of initialize() calls
+        init_calls: i32,
+
+        // max initialize() calls to complete perform_initialize()
+        max_init_calls: i32,
+
+        // last initialize() returns Ok() or any error != WaypointOutOfDate
+        last_init_result: Result<(), Error>,
+    }
+
+    impl MockSafetyRules {
+        pub fn new(
+            init_calls: i32,
+            max_init_calls: i32,
+            last_init_result: Result<(), Error>,
+        ) -> Self {
+            Self {
+                init_calls,
+                max_init_calls,
+                last_init_result,
+            }
+        }
+    }
+
+    impl TSafetyRules for MockSafetyRules {
+        fn consensus_state(&mut self) -> Result<ConsensusState, Error> {
+            Ok(ConsensusState::default())
+        }
+
+        fn initialize(&mut self, _: &EpochChangeProof) -> Result<(), Error> {
+            self.init_calls += 1;
+            if self.init_calls < self.max_init_calls {
+                return Err(Error::WaypointOutOfDate(
+                    (self.init_calls - 1) as u64,
+                    self.init_calls as u64,
+                    self.max_init_calls as u64,
+                    self.init_calls as u64,
+                ));
+            }
+            self.last_init_result.clone()
+        }
+
+        fn construct_and_sign_vote(&mut self, _: &MaybeSignedVoteProposal) -> Result<Vote, Error> {
+            unimplemented!()
+        }
+
+        fn sign_proposal(&mut self, _: &BlockData) -> Result<Ed25519Signature, Error> {
+            unimplemented!()
+        }
+
+        fn sign_timeout(&mut self, _: &Timeout) -> Result<Ed25519Signature, Error> {
+            unimplemented!()
+        }
+
+        fn sign_timeout_with_qc(
+            &mut self,
+            _: &TwoChainTimeout,
+            _: Option<&TwoChainTimeoutCertificate>,
+        ) -> Result<Ed25519Signature, Error> {
+            unimplemented!()
+        }
+
+        fn construct_and_sign_vote_two_chain(
+            &mut self,
+            _: &MaybeSignedVoteProposal,
+            _: Option<&TwoChainTimeoutCertificate>,
+        ) -> Result<Vote, Error> {
+            unimplemented!()
+        }
+
+        fn sign_commit_vote(
+            &mut self,
+            _: LedgerInfoWithSignatures,
+            _: LedgerInfo,
+        ) -> Result<Ed25519Signature, Error> {
+            unimplemented!()
+        }
+    }
+
+    #[test]
+    fn test_perform_initialize_ok() {
+        ::diem_logger::Logger::init_for_testing();
+        let (_, mock_storage) = EmptyStorage::start_for_testing();
+        let mock_safety_rules = MockSafetyRules::new(0, 10, Ok(()));
+        let mut metric_safety_rules =
+            MetricsSafetyRules::new(Box::new(mock_safety_rules), mock_storage);
+        assert_ok!(metric_safety_rules.perform_initialize());
+    }
+
+    #[test]
+    fn test_perform_initialize_error() {
+        ::diem_logger::Logger::init_for_testing();
+        let (_, mock_storage) = EmptyStorage::start_for_testing();
+        let mock_safety_rules = MockSafetyRules::new(
+            0,
+            10,
+            Err(Error::InvalidEpochChangeProof(String::from("Error"))),
+        );
+        let mut metric_safety_rules =
+            MetricsSafetyRules::new(Box::new(mock_safety_rules), mock_storage);
+        assert_matches!(
+            metric_safety_rules.perform_initialize(),
+            Err(Error::InvalidEpochChangeProof(_))
+        );
     }
 }

--- a/consensus/src/test_utils/mock_storage.rs
+++ b/consensus/src/test_utils/mock_storage.rs
@@ -314,7 +314,7 @@ impl PersistentLivenessStorage for EmptyStorage {
     }
 
     fn retrieve_epoch_change_proof(&self, _version: u64) -> Result<EpochChangeProof> {
-        unimplemented!()
+        Ok(EpochChangeProof::new(vec![], false))
     }
 
     fn diem_db(&self) -> Arc<dyn DbReader<DpnProto>> {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

When a node starts and initializes safety rules, fast-forwarding the waypoint of the persistent storage will fail if the waypoint is far behind the current waypoint of the non-secured storage [(Issue #9139).](https://github.com/diem/diem/issues/9139) The current retry is limited: it only re-tries once upon failures. The initialization during startup can be improved by having the initialization keep doing fast-forwarding the waypoint until it is up-to-date.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The unit test emulates a scenario where multiple initialize() calls are required to bring the waypoint up-to-date. Specifically, the first N-1 initialize() calls will return an error saying that the waypoint is still not up-to-date. The N-th call will return Ok (i.e., waypoint is up-to-date). The test then checks that the perform_initialize() will terminate (i.e., the loop will stop), and there are N initialize() calls (which is manually checked).

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
