### PR TITLE
[mempool] Refactor execute broadcast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,6 +2276,7 @@ dependencies = [
  "short-hex-str",
  "storage-interface",
  "storage-service",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "vm-validator",

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -19,6 +19,7 @@ once_cell = "1.7.2"
 proptest = { version = "1.0.0", optional = true }
 rayon = "1.4.1"
 serde = { version = "1.0.124", default-features = false }
+thiserror = "1.0.24"
 tokio = { version = "1.8.1", features = ["full"] }
 tokio-stream = "0.1.4"
 

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -82,7 +82,7 @@ pub(crate) async fn coordinator<V>(
                 handle_mempool_reconfig_event(&mut smp, &bounded_executor, reconfig_notification.on_chain_configs).await;
             },
             (peer, backoff) = scheduled_broadcasts.select_next_some() => {
-                tasks::execute_broadcast(peer, backoff, &mut smp, &mut scheduled_broadcasts, executor.clone());
+                tasks::execute_broadcast(peer, backoff, &mut smp, &mut scheduled_broadcasts, executor.clone()).await;
             },
             (network_id, event) = events.select_next_some() => {
                 handle_network_event(&executor, &bounded_executor, &mut scheduled_broadcasts, &mut smp, network_id, event).await;
@@ -245,7 +245,8 @@ async fn handle_network_event<V>(
                 .is_upstream_peer(is_upstream_peer));
             notify_subscribers(SharedMempoolNotification::PeerStateChange, &smp.subscribers);
             if is_new_peer && is_upstream_peer {
-                tasks::execute_broadcast(peer, false, smp, scheduled_broadcasts, executor.clone());
+                tasks::execute_broadcast(peer, false, smp, scheduled_broadcasts, executor.clone())
+                    .await;
             }
         }
         Event::LostPeer(metadata) => {


### PR DESCRIPTION
## Motivation

In order to put an asynchronous RPC call in place of a synchronous DirectSend call, I had to refactor the code for async.  Now the section has errors and can actually give information about why it's not broadcasting at any one point.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Current tests

## Related PRs

Along with https://github.com/diem/diem/pull/9616 are required for Mempool RPC
