### PR TITLE
[mempool] Implement RPC for Mempool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2279,6 +2279,7 @@ dependencies = [
  "async-trait",
  "bcs",
  "bounded-executor",
+ "bytes",
  "channel",
  "diem-config",
  "diem-crypto",

--- a/mempool/Cargo.toml
+++ b/mempool/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 async-trait = "0.1.42"
+bytes = { version = "1.0.1", features = ["serde"] }
 fail = "0.4.0"
 futures = "0.3.12"
 itertools = "0.10.0"

--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -7,7 +7,6 @@ use diem_metrics::{
     register_int_gauge_vec, DurationHistogram, HistogramTimer, HistogramVec, IntCounter,
     IntCounterVec, IntGauge, IntGaugeVec,
 };
-use diem_types::PeerId;
 use once_cell::sync::Lazy;
 use short_hex_str::AsShortHexStr;
 use std::time::Duration;
@@ -371,21 +370,6 @@ static NETWORK_SEND_FAIL: Lazy<IntCounterVec> = Lazy::new(|| {
 
 pub fn network_send_fail_inc(label: &'static str) {
     NETWORK_SEND_FAIL.with_label_values(&[label]).inc();
-}
-
-static UNEXPECTED_NETWORK_MSG_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "diem_mempool_unexpected_network_count",
-        "Number of unexpected network msgs received",
-        &["network", "peer"]
-    )
-    .unwrap()
-});
-
-pub fn unexpected_msg_count_inc(network_id: &NetworkId, peer_id: &PeerId) {
-    UNEXPECTED_NETWORK_MSG_COUNT
-        .with_label_values(&[network_id.as_str(), peer_id.short_str().as_str()])
-        .inc();
 }
 
 /// Counter for failed callback response to JSON RPC

--- a/mempool/src/logging.rs
+++ b/mempool/src/logging.rs
@@ -145,7 +145,6 @@ pub enum LogEntry {
     CleanRejectedTxn,
     ProcessReadyTxns,
     DBError,
-    UnexpectedNetworkMsg,
     MempoolSnapshot,
 }
 

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -36,6 +36,10 @@ use tokio_stream::wrappers::IntervalStream;
 use vm_validator::vm_validator::TransactionValidation;
 
 use super::types::MempoolClientRequest;
+use bytes::Bytes;
+use diem_types::PeerId;
+use futures::channel::oneshot;
+use network::{protocols::network::RpcError, ProtocolId};
 
 /// Coordinator that handles inbound network events and outbound txn broadcasts.
 pub(crate) async fn coordinator<V>(
@@ -222,7 +226,6 @@ async fn handle_mempool_reconfig_event<V>(
 /// - NewPeer events start new automatic broadcasts if the peer is upstream. If the peer is not upstream, we ignore it.
 /// - LostPeer events disable the upstream peer, which will cancel ongoing broadcasts.
 /// - Network messages follow a simple Request/Response framework to accept new transactions
-/// TODO: Move to RPC off of DirectSend
 async fn handle_network_event<V>(
     executor: &Handle,
     bounded_executor: &BoundedExecutor,
@@ -264,62 +267,88 @@ async fn handle_network_event<V>(
         }
         Event::Message(peer_id, msg) => {
             counters::shared_mempool_event_inc("message");
-            match msg {
-                MempoolSyncMsg::BroadcastTransactionsRequest {
-                    request_id,
-                    transactions,
-                } => {
-                    let smp_clone = smp.clone();
-                    let peer = PeerNetworkId::new(network_id, peer_id);
-                    let timeline_state = match smp.network_interface.is_upstream_peer(&peer, None) {
-                        true => TimelineState::NonQualified,
-                        false => TimelineState::NotReady,
-                    };
-                    // This timer measures how long it took for the bounded executor to
-                    // *schedule* the task.
-                    let _timer = counters::task_spawn_latency_timer(
-                        counters::PEER_BROADCAST_EVENT_LABEL,
-                        counters::SPAWN_LABEL,
-                    );
-                    // This timer measures how long it took for the task to go from scheduled
-                    // to started.
-                    let task_start_timer = counters::task_spawn_latency_timer(
-                        counters::PEER_BROADCAST_EVENT_LABEL,
-                        counters::START_LABEL,
-                    );
-                    bounded_executor
-                        .spawn(tasks::process_transaction_broadcast(
-                            smp_clone,
-                            transactions,
-                            request_id,
-                            timeline_state,
-                            peer,
-                            task_start_timer,
-                        ))
-                        .await;
-                }
-                MempoolSyncMsg::BroadcastTransactionsResponse {
-                    request_id,
-                    retry,
-                    backoff,
-                } => {
-                    let ack_timestamp = SystemTime::now();
-                    smp.network_interface.process_broadcast_ack(
-                        PeerNetworkId::new(network_id, peer_id),
-                        request_id,
-                        retry,
-                        backoff,
-                        ack_timestamp,
-                    );
-                }
-            }
+            handle_message(bounded_executor, smp, network_id, peer_id, msg, None).await;
         }
-        Event::RpcRequest(peer_id, _msg, _, _res_tx) => {
-            counters::unexpected_msg_count_inc(&network_id, &peer_id);
-            sample!(
-                SampleRate::Duration(Duration::from_secs(60)),
-                warn!(LogSchema::new(LogEntry::UnexpectedNetworkMsg)
-                    .peer(&PeerNetworkId::new(network_id, peer_id)))
+        Event::RpcRequest(peer_id, msg, protocol_id, res_tx) => {
+            handle_message(
+                bounded_executor,
+                smp,
+                network_id,
+                peer_id,
+                msg,
+                Some((protocol_id, res_tx)),
+            )
+            .await;
+        }
+    }
+}
+
+async fn handle_message<V>(
+    bounded_executor: &BoundedExecutor,
+    smp: &mut SharedMempool<V>,
+    network_id: NetworkId,
+    peer_id: PeerId,
+    msg: MempoolSyncMsg,
+    rpc_info: Option<(ProtocolId, oneshot::Sender<Result<Bytes, RpcError>>)>,
+) where
+    V: TransactionValidation,
+{
+    let peer = PeerNetworkId::new(network_id, peer_id);
+    match msg {
+        MempoolSyncMsg::BroadcastTransactionsRequest {
+            request_id,
+            transactions,
+        } => {
+            let smp_clone = smp.clone();
+            let timeline_state = match smp.network_interface.is_upstream_peer(&peer, None) {
+                true => TimelineState::NonQualified,
+                false => TimelineState::NotReady,
+            };
+            // This timer measures how long it took for the bounded executor to
+            // *schedule* the task.
+            let _timer = counters::task_spawn_latency_timer(
+                counters::PEER_BROADCAST_EVENT_LABEL,
+                counters::SPAWN_LABEL,
+            );
+            // This timer measures how long it took for the task to go from scheduled
+            // to started.
+            let task_start_timer = counters::task_spawn_latency_timer(
+                counters::PEER_BROADCAST_EVENT_LABEL,
+                counters::START_LABEL,
+            );
+
+            bounded_executor
+                .spawn(tasks::process_transaction_broadcast(
+                    smp_clone,
+                    transactions,
+                    request_id,
+                    timeline_state,
+                    peer,
+                    task_start_timer,
+                    rpc_info,
+                ))
+                .await;
+        }
+        MempoolSyncMsg::BroadcastTransactionsResponse {
+            request_id,
+            retry,
+            backoff,
+        } => {
+            if rpc_info.is_some() {
+                warn!(
+                    "Received BroadcastTransactionsResponse as first message in RPC request_id: {:X?}",
+                    request_id
+                );
+                // Don't process this response, as it's potentially malicious
+                return;
+            }
+            let ack_timestamp = SystemTime::now();
+            smp.network_interface.process_broadcast_ack(
+                peer,
+                request_id,
+                retry,
+                backoff,
+                ack_timestamp,
             );
         }
     }

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -94,7 +94,7 @@ pub struct MempoolNetworkSender {
 
 pub fn network_endpoint_config(max_broadcasts_per_peer: usize) -> AppConfig {
     AppConfig::p2p(
-        [ProtocolId::MempoolDirectSend],
+        [ProtocolId::MempoolDirectSend, ProtocolId::MempoolRpc],
         diem_channel::Config::new(max_broadcasts_per_peer)
             .queue_style(QueueStyle::KLAST)
             .counters(&counters::PENDING_MEMPOOL_NETWORK_EVENTS),
@@ -140,6 +140,8 @@ impl ApplicationNetworkSender<MempoolSyncMsg> for MempoolNetworkSender {
 
 #[derive(Debug, Error)]
 pub enum BroadcastError {
+    #[error("Peer {0} received a rpc request instead of a response '{1:x?}'")]
+    InvalidRpcResponse(PeerNetworkId, Vec<u8>),
     #[error("Peer {0} NetworkError: '{1}'")]
     NetworkError(PeerNetworkId, anyhow::Error),
     #[error("Peer {0} has no transactions to broadcast")]
@@ -457,17 +459,64 @@ impl MempoolNetworkInterface {
         peer: PeerNetworkId,
         batch_id: BatchId,
         transactions: Vec<SignedTransaction>,
-    ) -> Result<(), BroadcastError> {
+    ) -> Result<Option<(Vec<u8>, bool, bool)>, BroadcastError> {
+        // Retrieve protocol id to determine send method
+        let protocol_id = if let Some(info) = self.peer_metadata_storage.read(peer) {
+            if info
+                .active_connection
+                .application_protocols
+                .contains(ProtocolId::MempoolRpc)
+            {
+                ProtocolId::MempoolRpc
+            } else {
+                ProtocolId::MempoolDirectSend
+            }
+        } else {
+            // No connection info, no reason to send
+            return Err(BroadcastError::PeerNotFound(peer));
+        };
+
         let request = MempoolSyncMsg::BroadcastTransactionsRequest {
             request_id: bcs::to_bytes(&batch_id).expect("failed BCS serialization of batch ID"),
             transactions,
         };
 
-        if let Err(e) = self.sender.send_to(peer, request) {
-            counters::network_send_fail_inc(counters::BROADCAST_TXNS);
-            return Err(BroadcastError::NetworkError(peer, e.into()));
-        }
-        Ok(())
+        let maybe_rpc_response = match protocol_id {
+            ProtocolId::MempoolDirectSend => {
+                if let Err(e) = self.sender.send_to(peer, request) {
+                    counters::network_send_fail_inc(counters::BROADCAST_TXNS);
+                    return Err(BroadcastError::NetworkError(peer, e.into()));
+                }
+                None
+            }
+            ProtocolId::MempoolRpc => {
+                match self
+                    .sender
+                    .send_rpc(
+                        peer,
+                        request,
+                        Duration::from_millis(self.mempool_config.shared_mempool_ack_timeout_ms),
+                    )
+                    .await
+                {
+                    Ok(MempoolSyncMsg::BroadcastTransactionsResponse {
+                        request_id,
+                        retry,
+                        backoff,
+                    }) => Some((request_id, retry, backoff)),
+                    Ok(MempoolSyncMsg::BroadcastTransactionsRequest { request_id, .. }) => {
+                        // We received a request instead of a response
+                        return Err(BroadcastError::InvalidRpcResponse(peer, request_id));
+                    }
+                    Err(e) => {
+                        counters::network_send_fail_inc(counters::BROADCAST_TXNS);
+                        return Err(BroadcastError::NetworkError(peer, e.into()));
+                    }
+                }
+            }
+            _ => unreachable!("ProtocolId is fixed as a Mempool protocol"),
+        };
+        Ok(maybe_rpc_response)
     }
 
     /// Updates the local tracker for a broadcast.  This is used to handle `DirectSend` tracking of
@@ -511,9 +560,14 @@ impl MempoolNetworkInterface {
 
         let num_txns = transactions.len();
         let send_time = SystemTime::now();
-        self.send_batch(peer, batch_id, transactions).await?;
+        let maybe_rpc_response = self.send_batch(peer, batch_id, transactions).await?;
         let num_pending_broadcasts = self.update_broadcast_state(peer, batch_id, send_time)?;
         notify_subscribers(SharedMempoolNotification::Broadcast, &smp.subscribers);
+
+        // If it was RPC, lets process ack
+        if let Some((request_id, retry, backoff)) = maybe_rpc_response {
+            self.process_broadcast_ack(peer, request_id, retry, backoff, SystemTime::now());
+        }
 
         // Log all the metrics
         let latency = start_time.elapsed();

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -453,6 +453,22 @@ impl MempoolNetworkInterface {
         Ok((batch_id, transactions, metric_label))
     }
 
+    pub fn get_protocol(&self, peer: PeerNetworkId) -> Result<ProtocolId, BroadcastError> {
+        if let Some(info) = self.peer_metadata_storage.read(peer) {
+            if info
+                .active_connection
+                .application_protocols
+                .contains(ProtocolId::MempoolRpc)
+            {
+                Ok(ProtocolId::MempoolRpc)
+            } else {
+                Ok(ProtocolId::MempoolDirectSend)
+            }
+        } else {
+            Err(BroadcastError::PeerNotFound(peer))
+        }
+    }
+
     /// Sends a batch to the given `Peer`
     async fn send_batch(
         &self,

--- a/mempool/src/shared_mempool/tasks.rs
+++ b/mempool/src/shared_mempool/tasks.rs
@@ -14,6 +14,7 @@ use crate::{
     ConsensusRequest, ConsensusResponse, SubmissionStatus,
 };
 use anyhow::Result;
+use bytes::Bytes;
 use diem_config::network_id::PeerNetworkId;
 use diem_crypto::HashValue;
 use diem_infallible::{Mutex, RwLock};
@@ -26,7 +27,7 @@ use diem_types::{
     vm_status::DiscardedVMStatus,
 };
 use futures::{channel::oneshot, stream::FuturesUnordered};
-use network::application::interface::NetworkInterface;
+use network::{application::interface::NetworkInterface, protocols::network::RpcError, ProtocolId};
 use rayon::prelude::*;
 use short_hex_str::AsShortHexStr;
 use std::{
@@ -66,6 +67,7 @@ pub(crate) async fn execute_broadcast<V>(
                 )
                 .peer(&peer)
                 .error(&error)),
+                BroadcastError::InvalidRpcResponse(_, _) => warn!("{:?}", err),
                 _ => {
                     trace!("{:?}", err)
                 }
@@ -152,6 +154,7 @@ pub(crate) async fn process_transaction_broadcast<V>(
     timeline_state: TimelineState,
     peer: PeerNetworkId,
     timer: HistogramTimer,
+    rpc_info: Option<(ProtocolId, oneshot::Sender<Result<Bytes, RpcError>>)>,
 ) where
     V: TransactionValidation,
 {
@@ -165,7 +168,15 @@ pub(crate) async fn process_transaction_broadcast<V>(
 
     let ack_response = gen_ack_response(request_id, results, &peer);
     let network_sender = smp.network_interface.sender();
-    if let Err(e) = network_sender.send_to(peer, ack_response) {
+
+    if let Some((protocol_id, rpc_sender)) = rpc_info {
+        let bytes = protocol_id
+            .to_bytes(&ack_response)
+            .expect("Expected to encode");
+        // Attempt to send the response, letting it go if it doesn't work
+        // TODO: use error responses to provide more accurate responses
+        let _ = rpc_sender.send(Ok(bytes.into()));
+    } else if let Err(e) = network_sender.send_to(peer, ack_response) {
         counters::network_send_fail_inc(counters::ACK_TXNS);
         error!(
             LogSchema::event_log(LogEntry::BroadcastACK, LogEvent::NetworkSendFail)

--- a/mempool/src/tests/test_framework.rs
+++ b/mempool/src/tests/test_framework.rs
@@ -87,7 +87,7 @@ impl ApplicationNode for MempoolNode {
     }
 
     fn default_protocols(&self) -> &[ProtocolId] {
-        &[ProtocolId::MempoolDirectSend]
+        &[ProtocolId::MempoolDirectSend, ProtocolId::MempoolRpc]
     }
 
     fn get_inbound_handle(&self, network_id: NetworkId) -> InboundNetworkHandle {


### PR DESCRIPTION
## Motivation

Built upon a new test framework, RPC now works.  DirectSend has to be used for the older multi node tests due to the overcomplications of running multiple nodes at once with RPC.  I will replace all the old tests in the future with single node tests to have greater control over what's happening.

This should be 100% backwards compatible.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

See existing tests.  Also, E2E tests / cluster test


## Related PRs

https://github.com/diem/diem/pull/9638
https://github.com/diem/diem/pull/9616
