### PR TITLE
[mempool] Unsupport MempoolRpc

### DIFF
--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -93,7 +93,7 @@ pub struct MempoolNetworkSender {
 
 pub fn network_endpoint_config(max_broadcasts_per_peer: usize) -> AppConfig {
     AppConfig::p2p(
-        [ProtocolId::MempoolDirectSend, ProtocolId::MempoolRpc],
+        [ProtocolId::MempoolDirectSend],
         diem_channel::Config::new(max_broadcasts_per_peer)
             .queue_style(QueueStyle::KLAST)
             .counters(&counters::PENDING_MEMPOOL_NETWORK_EVENTS),


### PR DESCRIPTION
## Motivation

MempoolRpc isn't currently supported, yet the current nodes think that
it is.  That's problematic as other nodes don't know that it isn't
supported.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

Caught this with backwards compatibility tests.

## Related PRs

Blocks https://github.com/diem/diem/pull/9640
