### PR TITLE
[api] change Move module id and script function to use a string id instead of struct type.

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -874,17 +874,19 @@ components:
 
         See [doc](https://diem.github.io/move/abilities.html) for more details.
     MoveModuleId:
-      type: object
-      required:
-        - address
-        - name
-      properties:
-        address:
-          $ref: '#/components/schemas/Address'
-        name:
-          type: string
-          description: Module identifier / name
-          example: "Diem"
+      type: string
+      description: |
+        Move module id is a string representation of Move module.
+
+        Format: "{address}::{module name}"
+
+        `address` should be hex-encoded 16 bytes account address
+        that is prefixed with `0x` and leading zeros are trimmed.
+
+        Module name is case sensitive.
+
+        See [doc](https://diem.github.io/move/modules-and-scripts.html#modules) for more details.
+      example: "0x1::Diem"
     UserTransactionRequest:
       type: object
       required:

--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -1080,7 +1080,6 @@ components:
       type: object
       required:
         - type
-        - module
         - function
         - type_arguments
         - arguments
@@ -1088,14 +1087,8 @@ components:
         type:
           type: string
           example: script_function_payload
-        module:
-          type: string
-          example: 0x1::PaymentScripts
-          description: Module identifier / name, case sensitive
         function:
-          type: string
-          example: peer_to_peer_with_metadata
-          description: Script function name, case sensitive.
+          $ref: '#/components/schemas/ScriptFunctionId'
         type_arguments:
           type: array
           description: Generic type arguments required by the script function.
@@ -1113,6 +1106,15 @@ components:
             - "2021000000"
             - "0x"
             - "0x"
+    ScriptFunctionId:
+      type: string
+      example: 0x1::PaymentScripts::peer_to_peer_with_metadata
+      description: |
+        Script function id is string representation of a script function defined on-chain.
+
+        Format: `{address}::{module name}::{function name}`
+
+        Both `module name` and `function name` are case sensitive.
     ScriptPayload:
       type: object
       required:

--- a/api/src/tests/accounts_test.rs
+++ b/api/src/tests/accounts_test.rs
@@ -189,30 +189,12 @@ async fn test_get_module_diem_config() {
             "address": "0x1",
             "name": "DiemConfig",
             "friends": [
-                {
-                    "address": "0x1",
-                    "name": "DiemConsensusConfig"
-                },
-                {
-                    "address": "0x1",
-                    "name": "DiemSystem"
-                },
-                {
-                    "address": "0x1",
-                    "name": "DiemTransactionPublishingOption"
-                },
-                {
-                    "address": "0x1",
-                    "name": "DiemVMConfig"
-                },
-                {
-                    "address": "0x1",
-                    "name": "DiemVersion"
-                },
-                {
-                    "address": "0x1",
-                    "name": "RegisteredCurrencies"
-                }
+                "0x1::DiemConsensusConfig",
+                "0x1::DiemSystem",
+                "0x1::DiemTransactionPublishingOption",
+                "0x1::DiemVMConfig",
+                "0x1::DiemVersion",
+                "0x1::RegisteredCurrencies"
             ],
             "exposed_functions": [
                 {

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -309,8 +309,7 @@ async fn test_get_transactions_output_user_transaction_with_script_function_payl
             ],
             "payload": {
                 "type": "script_function_payload",
-                "module": "0x1::AccountCreationScripts",
-                "function": "create_parent_vasp_account",
+                "function": "0x1::AccountCreationScripts::create_parent_vasp_account",
                 "type_arguments": [
                     "0x1::XUS::XUS"
                 ],
@@ -521,8 +520,7 @@ async fn test_post_bcs_format_transaction() {
             "expiration_timestamp_secs": expiration_timestamp.to_string(),
             "payload": {
                 "type": "script_function_payload",
-                "module": "0x1::AccountCreationScripts",
-                "function": "create_parent_vasp_account",
+                "function": "0x1::AccountCreationScripts::create_parent_vasp_account",
                 "type_arguments": [
                     "0x1::XUS::XUS"
                 ],
@@ -863,8 +861,7 @@ async fn test_signing_message_with_script_function_payload() {
 
     let payload = json!({
         "type": "script_function_payload",
-        "module": "0x1::AccountCreationScripts",
-        "function": "create_parent_vasp_account",
+        "function": "0x1::AccountCreationScripts::create_parent_vasp_account",
         "type_arguments": [
             "0x1::XUS::XUS"
         ],

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -309,10 +309,7 @@ async fn test_get_transactions_output_user_transaction_with_script_function_payl
             ],
             "payload": {
                 "type": "script_function_payload",
-                "module": {
-                    "address": "0x1",
-                    "name": "AccountCreationScripts"
-                },
+                "module": "0x1::AccountCreationScripts",
                 "function": "create_parent_vasp_account",
                 "type_arguments": [
                     "0x1::XUS::XUS"
@@ -475,10 +472,7 @@ async fn test_get_transactions_output_user_transaction_with_write_set_payload() 
                     {
                         "type": "delete_module",
                         "address": "0x1",
-                        "module": {
-                            "address": "0x1",
-                            "name": "AccountAdministrationScripts"
-                        }
+                        "module": "0x1::AccountAdministrationScripts"
                     },
                     {
                         "type": "delete_resource",
@@ -527,10 +521,7 @@ async fn test_post_bcs_format_transaction() {
             "expiration_timestamp_secs": expiration_timestamp.to_string(),
             "payload": {
                 "type": "script_function_payload",
-                "module": {
-                    "address": "0x1",
-                    "name": "AccountCreationScripts"
-                },
+                "module": "0x1::AccountCreationScripts",
                 "function": "create_parent_vasp_account",
                 "type_arguments": [
                     "0x1::XUS::XUS"
@@ -872,7 +863,7 @@ async fn test_signing_message_with_script_function_payload() {
 
     let payload = json!({
         "type": "script_function_payload",
-        "module": { "address": "0x1", "name": "AccountCreationScripts"},
+        "module": "0x1::AccountCreationScripts",
         "function": "create_parent_vasp_account",
         "type_arguments": [
             "0x1::XUS::XUS"
@@ -983,10 +974,7 @@ async fn test_signing_message_with_write_set_payload() {
                 {
                     "type": "delete_module",
                     "address": "0x1",
-                    "module": {
-                        "address": "0x1",
-                        "name": "AccountAdministrationScripts"
-                    }
+                    "module": "0x1::AccountAdministrationScripts"
                 },
                 {
                     "type": "delete_resource",

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -22,7 +22,8 @@ pub use hash::HashValue;
 pub use ledger_info::LedgerInfo;
 pub use move_types::{
     HexEncodedBytes, MoveFunction, MoveModule, MoveModuleBytecode, MoveModuleId, MoveResource,
-    MoveScriptBytecode, MoveStructTag, MoveStructValue, MoveType, MoveValue, U128, U64,
+    MoveScriptBytecode, MoveStructTag, MoveStructValue, MoveType, MoveValue, ScriptFunctionId,
+    U128, U64,
 };
 pub use response::{Response, X_DIEM_CHAIN_ID, X_DIEM_LEDGER_TIMESTAMP, X_DIEM_LEDGER_VERSION};
 pub use transaction::{

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     Address, EventKey, HashValue, HexEncodedBytes, MoveModuleBytecode, MoveModuleId, MoveResource,
-    MoveScriptBytecode, MoveStructTag, MoveType, MoveValue, U64,
+    MoveScriptBytecode, MoveStructTag, MoveType, MoveValue, ScriptFunctionId, U64,
 };
 
 use diem_crypto::{
@@ -21,7 +21,6 @@ use diem_types::{
         Script, SignedTransaction, TransactionInfoTrait,
     },
 };
-use move_core_types::identifier::Identifier;
 
 use serde::{Deserialize, Serialize};
 use std::{
@@ -278,8 +277,7 @@ pub enum TransactionPayload {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ScriptFunctionPayload {
-    pub module: MoveModuleId,
-    pub function: Identifier,
+    pub function: ScriptFunctionId,
     pub type_arguments: Vec<MoveType>,
     pub arguments: Vec<serde_json::Value>,
 }


### PR DESCRIPTION
#9193 

Similar to #9571, a string representation of Move module and script function is simpler for client to set instead of nested struct.

This change updates API responds and accepts Move module id string and script function id string.