### PR TITLE
faucet: add initial currency to create-account

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -787,10 +787,9 @@ jobs:
           FAUCET_URL: "http://127.0.0.1:8000"
       - uses: actions/checkout@v2.4.0
         with:
-          ref: diem-core-v1.2.0
-      # Unfortunately this is spelled wrong in the release branch
-      - name: run sdk-compatability tests from release
-        run: cd sdk/compatability && cargo test -- --include-ignored
+          ref: diem-core-v1.4.1
+      - name: run sdk-compatibility tests from release
+        run: cd sdk/compatibility && cargo test -- --include-ignored
         env:
           JSON_RPC_URL: "http://127.0.0.1:8080"
           FAUCET_URL: "http://127.0.0.1:8000"

--- a/client/faucet/src/lib.rs
+++ b/client/faucet/src/lib.rs
@@ -115,6 +115,7 @@ fn accounts_routes(
 #[serde(rename_all = "kebab-case")]
 struct CreateAccountParams {
     authentication_key: AuthenticationKey,
+    currency: Currency,
 }
 
 fn create_account_route(
@@ -176,7 +177,7 @@ async fn create_account(
         }
 
         let builder = service.transaction_factory.create_parent_vasp_account(
-            Currency::XUS,
+            params.currency,
             0, // sliding_nonce
             params.authentication_key,
             &format!("No. {}", treasury_account.sequence_number()),

--- a/client/faucet/src/main.rs
+++ b/client/faucet/src/main.rs
@@ -650,7 +650,7 @@ mod tests {
             "459c77a38803bd53f3adee52703810e3a74fd7c46952c497e75afb0a7932586d",
         )
         .unwrap();
-        tokio::task::spawn_blocking(move || faucet_client.create_account(auth_key).unwrap())
+        tokio::task::spawn_blocking(move || faucet_client.create_account(auth_key, "XUS").unwrap())
             .await
             .unwrap();
     }
@@ -670,7 +670,7 @@ mod tests {
         )
         .unwrap();
         tokio::task::spawn_blocking(move || {
-            faucet_client.create_account(auth_key).unwrap();
+            faucet_client.create_account(auth_key, "XUS").unwrap();
             faucet_client
                 .fund(auth_key.derived_address(), "XUS", 10)
                 .unwrap()


### PR DESCRIPTION
Also rewrite the FaucetClient::mint method to internally call create_account and fund.

Also update CI to use latest release for testing. This unfortunately wont completely fix the problem we have with the racy faucet currently for the tests run based off of the older release. The issue should be solved for running tests off of the tip of main.