### PR TITLE
[shuffle] generate Networks.toml in /.shuffle

### DIFF
--- a/shuffle/cli/src/new.rs
+++ b/shuffle/cli/src/new.rs
@@ -11,7 +11,6 @@ use std::{
 
 /// Default blockchain configuration
 pub const DEFAULT_BLOCKCHAIN: &str = "goodday";
-pub const DEFAULT_NETWORK: &str = "127.0.0.1:8081";
 
 /// Directory of generated transaction builders for helloblockchain.
 const EXAMPLES_DIR: Dir = include_dir!("../move/examples");
@@ -23,7 +22,7 @@ pub fn handle(blockchain: String, pathbuf: PathBuf) -> Result<()> {
     println!("Creating shuffle project in {}", project_path.display());
     fs::create_dir_all(project_path)?;
 
-    let config = shared::Config::new(blockchain, Some(String::from(DEFAULT_NETWORK)));
+    let config = shared::ProjectConfig::new(blockchain);
     write_project_files(project_path, &config)?;
     write_example_move_packages(project_path)?;
 
@@ -32,7 +31,7 @@ pub fn handle(blockchain: String, pathbuf: PathBuf) -> Result<()> {
     Ok(())
 }
 
-fn write_project_files(path: &Path, config: &shared::Config) -> Result<()> {
+fn write_project_files(path: &Path, config: &shared::ProjectConfig) -> Result<()> {
     let toml_path = path.join("Shuffle.toml");
     let toml_string = toml::to_string(config)?;
     fs::write(toml_path, toml_string)?;
@@ -62,22 +61,19 @@ pub(crate) fn write_example_move_packages(project_path: &Path) -> Result<()> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use shared::Config;
+    use shared::ProjectConfig;
     use tempfile::tempdir;
 
     #[test]
     fn test_write_project_config() {
         let dir = tempdir().unwrap();
-        let config = Config::new(
-            String::from(DEFAULT_BLOCKCHAIN),
-            Some(String::from(DEFAULT_NETWORK)),
-        );
+        let config = ProjectConfig::new(String::from(DEFAULT_BLOCKCHAIN));
 
         write_project_files(dir.path(), &config).unwrap();
 
         let config_string =
             fs::read_to_string(dir.path().join("Shuffle").with_extension("toml")).unwrap();
-        let read_config: Config = toml::from_str(config_string.as_str()).unwrap();
+        let read_config: ProjectConfig = toml::from_str(config_string.as_str()).unwrap();
         assert_eq!(config, read_config);
     }
 

--- a/shuffle/cli/src/node.rs
+++ b/shuffle/cli/src/node.rs
@@ -38,7 +38,7 @@ pub fn handle(genesis: Option<String>) -> Result<()> {
 
 fn create_node(home: &Home, genesis: Option<String>) -> Result<()> {
     fs::create_dir_all(home.get_shuffle_path())?;
-
+    home.write_top_level_networks_config_into_toml()?;
     let publishing_option = VMPublishingOption::open();
     let genesis_modules = genesis_modules_from_path(&genesis)?;
     diem_node::load_test_environment(

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -26,7 +26,7 @@ use std::{
 use structopt::StructOpt;
 
 pub fn run_e2e_tests(project_path: &Path) -> Result<()> {
-    let _config = shared::read_config(project_path)?;
+    let _config = shared::read_project_config(project_path)?;
     shared::generate_typescript_libraries(project_path)?;
     let home = Home::new(shared::get_home_path().as_path())?;
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently the network field is tied to the project folder. As shuffle grows and we connect to more networks, it's not intuitive to pull the network value from the project folders, instead we want to pull from a centralized location. Hence, this PR!


## Test Plan

Run cargo run -p shuffle -- node in your terminal. As we know, the .shuffle folder should generate from this:

<img width="1755" alt="Screen Shot 2021-11-05 at 3 00 59 PM" src="https://user-images.githubusercontent.com/55404786/140583371-3def0e03-caa6-4016-bcc5-d10f10fc3527.png">


If we take a look inside the .shuffle folder, there is now a Networks.toml which currently supports the localhost network:

![image](https://user-images.githubusercontent.com/55404786/140785168-8db61459-1bb1-4862-a53f-d7cfc6ae91ca.png)

Note, as we connect to more networks or users want to other networks, they will be responsible for editing this Networks.toml file with the appropriate parameters. 

Now that we have a network name in our Networks.toml, I ran shuffle console -p "project_path" --network localhost. It works with this localhost string as opposed to the user inputting http://127.0.0.1:8081 that they had to put before: 

![image](https://user-images.githubusercontent.com/55404786/140583581-2bea64a6-79bc-4ebd-97ba-8d6b8ec8d8d5.png)

Furthermore, I ran shuffle transactions --network localhost --raw and it works:

![image](https://user-images.githubusercontent.com/55404786/140583733-d3d1e83a-99a4-4ddf-bbd4-0a7222034e36.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
