### PR TITLE
[State Sync] Rename struct and remove unnecessary type declaration.

### DIFF
--- a/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
@@ -16,10 +16,6 @@ use std::fmt::{Debug, Formatter};
 /// A unique ID used to identify each notification.
 pub type NotificationId = u64;
 
-/// A generic data client response enum.
-// TODO(joshlind): remove me!
-pub type DataClientResponse = Response<ResponsePayload>;
-
 /// A single data notification with an ID and data payload.
 #[derive(Clone, Debug)]
 pub struct DataNotification {
@@ -92,7 +88,7 @@ pub struct TransactionOutputsWithProofRequest {
 /// network and will be available in `client_response` when received.
 pub struct PendingClientResponse {
     pub client_request: DataClientRequest,
-    pub client_response: Option<Result<DataClientResponse, diem_data_client::Error>>,
+    pub client_response: Option<Result<Response<ResponsePayload>, diem_data_client::Error>>,
 }
 
 impl Debug for PendingClientResponse {

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
@@ -3,9 +3,7 @@
 
 use crate::{
     data_notification,
-    data_notification::{
-        DataClientRequest, DataClientResponse, DataNotification, DataPayload, NotificationId,
-    },
+    data_notification::{DataClientRequest, DataNotification, DataPayload, NotificationId},
     error::Error,
     logging::{LogEntry, LogEvent, LogSchema},
     stream_progress_tracker::{DataStreamTracker, StreamProgressTracker},
@@ -13,7 +11,7 @@ use crate::{
 };
 use channel::{diem_channel, message_queues::QueueStyle};
 use diem_data_client::{
-    AdvertisedData, DiemDataClient, GlobalDataSummary, ResponseContext, ResponseError,
+    AdvertisedData, DiemDataClient, GlobalDataSummary, Response, ResponseContext, ResponseError,
     ResponsePayload,
 };
 use diem_id_generator::{IdGenerator, U64IdGenerator};
@@ -469,7 +467,7 @@ impl<T: DiemDataClient + Send + Clone + 'static> DataStream<T> {
     fn send_data_notification_to_client(
         &mut self,
         data_client_request: &DataClientRequest,
-        data_client_response: DataClientResponse,
+        data_client_response: Response<ResponsePayload>,
     ) -> Result<(), Error> {
         let (response_context, response_payload) = data_client_response.into_parts();
 
@@ -644,7 +642,7 @@ impl FusedStream for DataStreamListener {
 /// of the original request. No other sanity checks are done.
 fn sanity_check_client_response(
     data_client_request: &DataClientRequest,
-    data_client_response: &DataClientResponse,
+    data_client_response: &Response<ResponsePayload>,
 ) -> bool {
     match data_client_request {
         DataClientRequest::AccountsWithProof(_) => {

--- a/state-sync/state-sync-v2/data-streaming-service/src/lib.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/lib.rs
@@ -8,7 +8,7 @@ mod data_notification;
 mod data_stream;
 mod error;
 mod logging;
-mod stream_progress_tracker;
+mod stream_engine;
 mod streaming_client;
 mod streaming_service;
 

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -3,8 +3,7 @@
 
 use crate::{
     data_notification::{
-        DataClientRequest, DataClientResponse, DataPayload, EpochEndingLedgerInfosRequest,
-        PendingClientResponse,
+        DataClientRequest, DataPayload, EpochEndingLedgerInfosRequest, PendingClientResponse,
     },
     data_stream::{
         DataStream, DataStreamListener, MAX_NOTIFICATION_ID_MAPPINGS, MAX_REQUEST_RETRY,
@@ -59,7 +58,7 @@ async fn test_stream_blocked() {
         };
         let pending_response = PendingClientResponse {
             client_request: client_request.clone(),
-            client_response: Some(Ok(DataClientResponse {
+            client_response: Some(Ok(Response {
                 context,
                 payload: ResponsePayload::NumberOfAccountStates(10),
             })),

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod data_stream;
-mod stream_progress_tracker;
+mod stream_engine;
 mod streaming_client;
 mod streaming_service;
 mod utils;

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_progress_tracker.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_progress_tracker.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_notification::{DataClientRequest, DataClientResponse, EpochEndingLedgerInfosRequest},
+    data_notification::{DataClientRequest, EpochEndingLedgerInfosRequest},
     error::Error,
     stream_progress_tracker::{DataStreamTracker, EpochEndingStreamTracker, StreamProgressTracker},
     streaming_client::{GetAllEpochEndingLedgerInfosRequest, StreamRequest},
@@ -289,7 +289,7 @@ fn create_empty_client_response_payload() -> ResponsePayload {
     ResponsePayload::EpochEndingLedgerInfos(vec![])
 }
 
-fn create_empty_client_response() -> DataClientResponse {
+fn create_empty_client_response() -> Response<ResponsePayload> {
     let context = ResponseContext {
         id: 0,
         response_callback: Box::new(NoopResponseCallback),


### PR DESCRIPTION
## Motivation

Note: This PR makes no logical changes.

This PR offers two small refactors: (i) remove an unnecessary type definition and inline the type; and (ii) rename "Stream Progress Tracker" (and all references) to "Data Stream Engine". The reason for this rename is simply that the "Stream Progress Tracker" no longer just tracks the progress of each stream, but it now also drives each stream to completion. I think the name is clearer.

Each of these changes happen in their own commit.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing tests cover this.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906