### PR TITLE
[diem-node] launch test node with lazy mode for only commit block with user signed txns

### DIFF
--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -110,6 +110,7 @@ pub fn start(config: &NodeConfig, log_file: Option<PathBuf>) {
 pub fn load_test_environment<R>(
     config_path: Option<PathBuf>,
     random_ports: bool,
+    lazy: bool,
     publishing_option: Option<VMPublishingOption>,
     genesis_modules: Vec<Vec<u8>>,
     rng: R,
@@ -180,6 +181,12 @@ pub fn load_test_environment<R>(
     );
     println!("\tChainId: {}", ChainId::test());
     println!();
+    if lazy {
+        println!("\tLazy mode is enabled");
+        config.consensus.mempool_poll_count = u64::MAX;
+        println!();
+    }
+
     println!("Diem is running, press ctrl-c to exit");
     println!();
 

--- a/diem-node/src/main.rs
+++ b/diem-node/src/main.rs
@@ -46,6 +46,13 @@ struct Args {
         requires("test")
     )]
     genesis_modules: Option<Vec<PathBuf>>,
+
+    #[structopt(
+        long,
+        help = "Lazy mode, set this flag will set `consensus#mempool_poll_count` config to `u64::MAX` and only commit a block when there is user transaction in mempool",
+        requires("test")
+    )]
+    lazy: bool,
 }
 
 #[global_allocator]
@@ -73,6 +80,7 @@ fn main() {
         diem_node::load_test_environment(
             args.config,
             args.random_ports,
+            args.lazy,
             publishing_option,
             genesis_modules,
             rng,

--- a/shuffle/cli/src/node.rs
+++ b/shuffle/cli/src/node.rs
@@ -57,24 +57,10 @@ fn start_node(home: &Home) -> Result<()> {
     println!("\tConfig path: {:?}", home.get_validator_config_path());
     println!("\tDiem root key path: {:?}", home.get_root_key_path());
     println!("\tWaypoint: {}", home.read_genesis_waypoint()?);
-    // Configure json rpc to bind on 0.0.0.0
-    let mut config = NodeConfig::load(home.get_validator_config_path()).unwrap();
-    config.json_rpc.address = format!("0.0.0.0:{}", config.json_rpc.address.port())
-        .parse()
-        .unwrap();
-    println!("\tJSON-RPC endpoint: {}", config.json_rpc.address);
-    config.json_rpc.stream_rpc.enabled = true;
-    println!("\tStream-RPC enabled!");
-    config.api.enabled = true;
-    println!("\tREST API enabled!");
-    println!("\tREST API: {}", config.api.address);
-
-    println!(
-        "\tFullNode network: {}",
-        config.full_node_networks[0].listen_address
-    );
     println!("\tChainId: {}", ChainId::test());
-    println!();
+    let config = NodeConfig::load(home.get_validator_config_path()).unwrap();
+    diem_node::print_api_config(&config);
+
     println!("Diem is running, press ctrl-c to exit");
     println!();
 

--- a/shuffle/cli/src/node.rs
+++ b/shuffle/cli/src/node.rs
@@ -44,6 +44,7 @@ fn create_node(home: &Home, genesis: Option<String>) -> Result<()> {
     diem_node::load_test_environment(
         Some(PathBuf::from(home.get_node_config_path())),
         false,
+        true,
         Some(publishing_option),
         genesis_modules,
         rand::rngs::OsRng,


### PR DESCRIPTION
Add an option `--lazy` to start test node without continuous commit blank metadata block.

Set this flag will set `consensus#mempool_poll_count` config to `u64::MAX` and only commit a block when there is user transaction in mempool.

## Motivation

1. Low CPU consumption when doing local test.
2. Keep server state when no new user signed transaction is submitted for consistent testing result.
