### PR TITLE
[State Sync] Use indices for storage service requests, support transaction outputs and add logging.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8263,6 +8263,7 @@ dependencies = [
  "channel",
  "claim",
  "diem-crypto",
+ "diem-logger",
  "diem-types",
  "diem-workspace-hack",
  "futures",

--- a/state-sync/diem-data-client/src/diemnet/mod.rs
+++ b/state-sync/diem-data-client/src/diemnet/mod.rs
@@ -245,19 +245,6 @@ impl DiemNetDataClient {
     }
 }
 
-/// Calculate `(start..=end).len()`. Returns an error if `end < start` or
-/// `end == u64::MAX`.
-fn range_len(start: u64, end: u64) -> Result<u64, Error> {
-    // len = end - start + 1
-    let len = end.checked_sub(start).ok_or_else(|| {
-        Error::InvalidRequest(format!("end ({}) must be >= start ({})", end, start))
-    })?;
-    let len = len
-        .checked_add(1)
-        .ok_or_else(|| Error::InvalidRequest(format!("end ({}) must not be u64::MAX", end)))?;
-    Ok(len)
-}
-
 #[async_trait]
 impl DiemDataClient for DiemNetDataClient {
     fn get_global_data_summary(&self) -> GlobalDataSummary {
@@ -274,7 +261,7 @@ impl DiemDataClient for DiemNetDataClient {
             AccountStatesChunkWithProofRequest {
                 version,
                 start_account_index,
-                expected_num_account_states: range_len(start_account_index, end_account_index)?,
+                end_account_index,
             },
         );
         self.send_request_and_decode(request).await
@@ -309,7 +296,7 @@ impl DiemDataClient for DiemNetDataClient {
             TransactionOutputsWithProofRequest {
                 proof_version,
                 start_version,
-                expected_num_outputs: range_len(start_version, end_version)?,
+                end_version,
             },
         );
         self.send_request_and_decode(request).await
@@ -326,7 +313,7 @@ impl DiemDataClient for DiemNetDataClient {
             StorageServiceRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
                 proof_version,
                 start_version,
-                expected_num_transactions: range_len(start_version, end_version)?,
+                end_version,
                 include_events,
             });
         self.send_request_and_decode(request).await

--- a/state-sync/diem-data-client/src/diemnet/tests.rs
+++ b/state-sync/diem-data-client/src/diemnet/tests.rs
@@ -158,7 +158,7 @@ async fn test_request_works_only_when_data_available() {
             request,
             StorageServiceRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
                 start_version: 50,
-                expected_num_transactions: 51,
+                end_version: 100,
                 proof_version: 100,
                 include_events: false,
             })

--- a/state-sync/storage-service/server/Cargo.toml
+++ b/state-sync/storage-service/server/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1.8.1", features = ["rt", "macros"], default-features = fal
 
 bounded-executor = { path = "../../../common/bounded-executor" }
 channel = { path = "../../../common/channel" }
+diem-logger = { path = "../../../common/logger" }
 diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 network = { path = "../../../network" }

--- a/state-sync/storage-service/server/src/lib.rs
+++ b/state-sync/storage-service/server/src/lib.rs
@@ -354,14 +354,16 @@ impl StorageReaderInterface for StorageReader {
 
     fn get_transaction_outputs_with_proof(
         &self,
-        _proof_version: u64,
-        _start_version: u64,
-        _end_version: u64,
+        proof_version: u64,
+        start_version: u64,
+        end_version: u64,
     ) -> Result<TransactionOutputListWithProof, Error> {
-        // TODO(joshlind): implement this once the transaction outputs are persisted in the DB.
-        Err(Error::UnexpectedErrorEncountered(
-            "Unimplemented! This API call needs to be implemented!".into(),
-        ))
+        let expected_num_outputs = inclusive_range_len(start_version, end_version)?;
+        let output_list_with_proof = self
+            .storage
+            .get_transaction_outputs(start_version, expected_num_outputs, proof_version)
+            .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+        Ok(output_list_with_proof)
     }
 
     fn get_account_states_chunk_with_proof(

--- a/state-sync/storage-service/server/src/logging.rs
+++ b/state-sync/storage-service/server/src/logging.rs
@@ -1,0 +1,36 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Error;
+use diem_logger::Schema;
+use serde::Serialize;
+use storage_service_types::{StorageServiceError, StorageServiceRequest, StorageServiceResponse};
+
+#[derive(Schema)]
+pub struct LogSchema<'a> {
+    name: LogEntry,
+    error: Option<&'a Error>,
+    message: Option<&'a str>,
+    response: Option<&'a Result<StorageServiceResponse, StorageServiceError>>,
+    request: Option<&'a StorageServiceRequest>,
+}
+
+impl<'a> LogSchema<'a> {
+    pub fn new(name: LogEntry) -> Self {
+        Self {
+            name,
+            error: None,
+            message: None,
+            response: None,
+            request: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LogEntry {
+    ReceivedStorageRequest,
+    SentStorageResponse,
+    StorageServiceError,
+}

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -78,7 +78,7 @@ async fn test_get_account_states_chunk_with_proof() {
         StorageServiceRequest::GetAccountStatesChunkWithProof(AccountStatesChunkWithProofRequest {
             version: 0,
             start_account_index: 0,
-            expected_num_account_states: 0,
+            end_account_index: 0,
         });
 
     // Process the request
@@ -146,11 +146,11 @@ async fn test_get_transactions_with_proof_events() {
 
     // Create a request to fetch transactions with a proof
     let start_version = 0;
-    let expected_num_transactions = 10;
+    let end_version = 10;
     let request = StorageServiceRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
         proof_version: 100,
         start_version,
-        expected_num_transactions,
+        end_version,
         include_events: true,
     });
 
@@ -161,8 +161,8 @@ async fn test_get_transactions_with_proof_events() {
     match response {
         StorageServiceResponse::TransactionsWithProof(transactions_with_proof) => {
             assert_eq!(
-                transactions_with_proof.transactions.len(),
-                expected_num_transactions as usize
+                transactions_with_proof.transactions.len() as u64,
+                end_version - start_version + 1,
             );
             assert_eq!(
                 transactions_with_proof.first_transaction_version,
@@ -170,9 +170,7 @@ async fn test_get_transactions_with_proof_events() {
             );
             assert_some!(transactions_with_proof.events);
         }
-        _ => {
-            panic!("Expected transactions with proof but got: {:?}", response);
-        }
+        _ => panic!("Expected transactions with proof but got: {:?}", response),
     };
 }
 
@@ -183,11 +181,11 @@ async fn test_get_transactions_with_proof_no_events() {
 
     // Create a request to fetch transactions with a proof (excluding events)
     let start_version = 10;
-    let expected_num_transactions = 20;
+    let end_version = 30;
     let request = StorageServiceRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
         proof_version: 1000,
         start_version,
-        expected_num_transactions,
+        end_version,
         include_events: false,
     });
 
@@ -198,8 +196,8 @@ async fn test_get_transactions_with_proof_no_events() {
     match response {
         StorageServiceResponse::TransactionsWithProof(transactions_with_proof) => {
             assert_eq!(
-                transactions_with_proof.transactions.len(),
-                expected_num_transactions as usize
+                transactions_with_proof.transactions.len() as u64,
+                end_version - start_version + 1,
             );
             assert_eq!(
                 transactions_with_proof.first_transaction_version,
@@ -207,9 +205,7 @@ async fn test_get_transactions_with_proof_no_events() {
             );
             assert_none!(transactions_with_proof.events);
         }
-        _ => {
-            panic!("Expected transactions with proof but got: {:?}", response);
-        }
+        _ => panic!("Expected transactions with proof but got: {:?}", response),
     };
 }
 
@@ -223,7 +219,7 @@ async fn test_get_transaction_outputs_with_proof() {
         StorageServiceRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
             proof_version: 1000,
             start_version: 0,
-            expected_num_outputs: 10,
+            end_version: 0,
         });
 
     // Process the request
@@ -266,9 +262,7 @@ async fn test_get_epoch_ending_ledger_infos() {
                 );
             }
         }
-        _ => {
-            panic!("Expected epoch ending ledger infos but got: {:?}", response);
-        }
+        _ => panic!("Expected epoch ending ledger infos but got: {:?}", response),
     };
 }
 

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use channel::diem_channel;
 use claim::{assert_matches, assert_none, assert_some};
 use diem_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
+use diem_logger::Level;
 use diem_types::{
     account_address::AccountAddress,
     account_state_blob::{default_protocol::AccountStateWithProof, AccountStateBlob},
@@ -87,7 +88,7 @@ async fn test_get_account_states_chunk_with_proof() {
     let error = mock_client.send_request(request).await.unwrap_err();
 
     // Verify the response is correct (the API call is currently unsupported)
-    assert_matches!(error, StorageServiceError::InternalError);
+    assert_matches!(error, StorageServiceError::InternalError(_));
 }
 
 #[tokio::test]
@@ -102,7 +103,7 @@ async fn test_get_number_of_accounts_at_version() {
     let error = mock_client.send_request(request).await.unwrap_err();
 
     // Verify the response is correct (the API call is currently unsupported)
-    assert_matches!(error, StorageServiceError::InternalError);
+    assert_matches!(error, StorageServiceError::InternalError(_));
 }
 
 #[tokio::test]
@@ -290,6 +291,7 @@ struct MockClient {
 
 impl MockClient {
     fn new() -> (Self, StorageServiceServer<StorageReader>) {
+        initialize_logger();
         let storage = StorageReader::new(Arc::new(MockDbReader));
 
         let queue_cfg = crate::network::network_endpoint_config()
@@ -610,4 +612,12 @@ impl DbReader<DpnProto> for MockDbReader {
     ) -> Result<LedgerInfoWithSignatures> {
         unimplemented!()
     }
+}
+
+/// Initializes the Diem logger for tests
+pub fn initialize_logger() {
+    diem_logger::DiemLogger::builder()
+        .is_async(false)
+        .level(Level::Debug)
+        .build();
 }

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -189,27 +189,27 @@ impl TryFrom<StorageServiceResponse> for TransactionListWithProof {
 /// specified version.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AccountStatesChunkWithProofRequest {
-    pub version: u64,                     // The version to fetch the account states at
-    pub start_account_index: u64,         // The account index to start fetching account states
-    pub expected_num_account_states: u64, // Expected number of account states to fetch
+    pub version: u64,             // The version to fetch the account states at
+    pub start_account_index: u64, // The account index to start fetching account states
+    pub end_account_index: u64,   // The account index to stop fetching account states (inclusive)
 }
 
 /// A storage service request for fetching a transaction output list with a
 /// corresponding proof.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TransactionOutputsWithProofRequest {
-    pub proof_version: u64,        // The version the proof should be relative to
-    pub start_version: u64,        // The starting version of the transaction output list
-    pub expected_num_outputs: u64, // Expected number of transaction outputs in the list
+    pub proof_version: u64, // The version the proof should be relative to
+    pub start_version: u64, // The starting version of the transaction output list
+    pub end_version: u64,   // The ending version of the transaction output list (inclusive)
 }
 
 /// A storage service request for fetching a transaction list with a
 /// corresponding proof.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct TransactionsWithProofRequest {
-    pub proof_version: u64, // The version the proof should be relative to
-    pub start_version: u64, // The starting version of the transaction list
-    pub expected_num_transactions: u64, // Expected number of transactions in the list
+    pub proof_version: u64,   // The version the proof should be relative to
+    pub start_version: u64,   // The starting version of the transaction list
+    pub end_version: u64,     // The ending version of the transaction list (inclusive)
     pub include_events: bool, // Whether or not to include events in the response
 }
 

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -24,8 +24,8 @@ pub type Result<T, E = StorageServiceError> = ::std::result::Result<T, E>;
 /// to process a service request.
 #[derive(Clone, Debug, Deserialize, Eq, Error, PartialEq, Serialize)]
 pub enum StorageServiceError {
-    #[error("Internal service error")]
-    InternalError,
+    #[error("Internal service error: {0}")]
+    InternalError(String),
 }
 
 /// A single storage service message sent or received over DiemNet.


### PR DESCRIPTION
## Motivation

This PR refactors and extends the storage service:
1. Use `start` and `end` indices for requesting storage data (instead of `start` and `expected_num` as used by DbReader). This interface is easier to reason about.
2. Connect the storage service server to the transaction output fetching functionality now offered by DbReader. This will allow us to fetch transaction outputs from remote peers.
3. Add simple logging support to the server side of the storage service. This will improve our ability to debug live (and test) failures.

Each of these happens in their own commit.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The unit tests have been updated.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906