### PR TITLE
[move] Fix typo for `(` in TextMate language

### DIFF
--- a/language/move-analyzer/editors/code/move.tmLanguage.json
+++ b/language/move-analyzer/editors/code/move.tmLanguage.json
@@ -209,7 +209,7 @@
                     "match": "([_a-z][_a-zA-Z0-9]*)(\\()",
                     "captures": {
                         "1": { "name": "meta.function.move entity.name.function.move" },
-                        "2": { "name": "meta.punctuation.less.move" }
+                        "2": { "name": "meta.punctuation.left-parenthesis.move" }
                     }
                 }
             ]

--- a/language/move-analyzer/editors/code/tests/colorize-results/addresses.move.json
+++ b/language/move-analyzer/editors/code/tests/colorize-results/addresses.move.json
@@ -254,7 +254,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/language/move-analyzer/editors/code/tests/colorize-results/attributes.move.json
+++ b/language/move-analyzer/editors/code/tests/colorize-results/attributes.move.json
@@ -166,7 +166,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -331,7 +331,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -463,7 +463,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/language/move-analyzer/editors/code/tests/colorize-results/comments.move.json
+++ b/language/move-analyzer/editors/code/tests/colorize-results/comments.move.json
@@ -2080,7 +2080,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -2267,7 +2267,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/language/move-analyzer/editors/code/tests/colorize-results/everything.move.json
+++ b/language/move-analyzer/editors/code/tests/colorize-results/everything.move.json
@@ -430,7 +430,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -749,7 +749,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -936,7 +936,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1255,7 +1255,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1387,7 +1387,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1695,7 +1695,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1827,7 +1827,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/language/move-analyzer/editors/code/tests/colorize-results/functions.move.json
+++ b/language/move-analyzer/editors/code/tests/colorize-results/functions.move.json
@@ -122,7 +122,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -188,7 +188,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -265,7 +265,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/language/move-analyzer/editors/code/tests/colorize-results/keywords.move.json
+++ b/language/move-analyzer/editors/code/tests/colorize-results/keywords.move.json
@@ -155,7 +155,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",

--- a/language/move-analyzer/editors/code/tests/colorize-results/toycoin.move.json
+++ b/language/move-analyzer/editors/code/tests/colorize-results/toycoin.move.json
@@ -364,7 +364,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -661,7 +661,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -925,7 +925,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1519,7 +1519,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1673,7 +1673,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1761,7 +1761,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1816,7 +1816,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",
@@ -1915,7 +1915,7 @@
 	},
 	{
 		"c": "(",
-		"t": "source.move meta.punctuation.less.move",
+		"t": "source.move meta.punctuation.left-parenthesis.move",
 		"r": {
 			"dark_plus": "default: #D4D4D4",
 			"light_plus": "default: #000000",


### PR DESCRIPTION
Due to some lazy copy-pasting on my part, the TextMate language incorrectly tokenized the `(` in `<identifier>(` as "less", rather than correctly as "left-parenthesis".