### PR TITLE
[api] update dev_setup.sh to install nodejs & python tools for api build

### DIFF
--- a/.github/actions/build-setup/action.yml
+++ b/.github/actions/build-setup/action.yml
@@ -56,7 +56,7 @@ runs:
         echo '/usr/lib/golang/bin' | tee -a $GITHUB_PATH
     - name: install common dependencies (should be ~ 10 seconds in a linux build, on mac it's a beast.)
       shell: bash
-      run: scripts/dev_setup.sh -t -o -b -p -y -s -n
+      run: scripts/dev_setup.sh -t -o -b -p -y -s -n -a
     - id: rust-environment
       shell: bash
       run: |

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -145,7 +145,7 @@ jobs:
         name: find api changes.
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
-          pattern: '^api'
+          pattern: '^api\|^scripts/dev_setup.sh'
 
   dev-setup-sh-test:
     runs-on: ubuntu-20.04-xl
@@ -941,12 +941,13 @@ jobs:
     runs-on: ubuntu-20.04
     needs: prepare
     if: ${{ needs.prepare.outputs.test-api-spec == 'true' }}
+    container:
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
     steps:
       - uses: actions/checkout@v2.3.4
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2.4.0
-        with:
-          node-version: '14'
+      - uses: ./.github/actions/build-setup
       - name:
         working-directory: api
         run: make test

--- a/docker/ci/github/Dockerfile
+++ b/docker/ci/github/Dockerfile
@@ -14,7 +14,7 @@ ENV RUSTUP_HOME "/opt/rustup"
 RUN mkdir -p /github/home && \
     mkdir -p /opt/cargo/ && \
     mkdir -p /opt/git/ && \
-    /diem/scripts/dev_setup.sh -t -o -b -p -y -s -n && \
+    /diem/scripts/dev_setup.sh -t -o -b -p -y -s -n -a && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -54,6 +54,6 @@ RUN [ -x "$(set -x; command -v shellcheck)" ] \
 
 # should be a no-op
 # sccache builds fine, but is not executable ??? in alpine, ends up being recompiled.  Wierd.
-RUN /diem/scripts/dev_setup.sh -t -o -y -b -p -s
+RUN /diem/scripts/dev_setup.sh -t -o -y -b -p -s -a
 
 FROM setup_ci as build_environment


### PR DESCRIPTION
## Motivation

For testing API specification, we need use node-js and python tools, this PR setup them in the dev_setup.sh script, so that we don't need special handling in the build script, and it should be consistent for all dependencies setup for diem local dev as well.

#9193 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

1. Local manual test
2. CI Build

