### PR TITLE
[shuffle] add network arg to deploy and test

### DIFF
--- a/shuffle/cli/src/account.rs
+++ b/shuffle/cli/src/account.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{get_home_path, send_transaction, Home};
+use crate::shared::{send_transaction, Home};
 use anyhow::{anyhow, Context, Result};
 use diem_config::config::NodeConfig;
 use diem_crypto::PrivateKey;
@@ -23,8 +23,7 @@ use std::{
 };
 
 // Creates new account from randomly generated private/public key pair.
-pub fn handle(root: Option<PathBuf>) -> Result<()> {
-    let home = Home::new(get_home_path().as_path())?;
+pub fn handle(home: &Home, root: Option<PathBuf>) -> Result<()> {
     if !home.get_shuffle_path().is_dir() {
         return Err(anyhow!(
             "A node hasn't been created yet! Run shuffle node first"
@@ -32,7 +31,7 @@ pub fn handle(root: Option<PathBuf>) -> Result<()> {
     }
 
     if home.get_latest_path().exists() {
-        let wants_another_key = confirm_user_decision(&home);
+        let wants_another_key = confirm_user_decision(home);
         if wants_another_key {
             let time = duration_since_epoch();
             let archive_dir = home.create_archive_dir(time)?;

--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -1,12 +1,14 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::test::TestCommand;
+use crate::{
+    shared::{get_home_path, Home},
+    test::TestCommand,
+};
 use anyhow::{anyhow, Result};
 use diem_types::account_address::AccountAddress;
 use std::{fs, path::PathBuf};
 use structopt::StructOpt;
-use url::Url;
 
 mod account;
 mod build;
@@ -20,18 +22,24 @@ mod transactions;
 
 #[tokio::main]
 pub async fn main() -> Result<()> {
+    let home = Home::new(get_home_path().as_path())?;
     let subcommand = Subcommand::from_args();
     match subcommand {
         Subcommand::New { blockchain, path } => new::handle(blockchain, path),
-        Subcommand::Node { genesis } => node::handle(genesis),
+        Subcommand::Node { genesis } => node::handle(&home, genesis),
         Subcommand::Build { project_path } => {
             build::handle(&shared::normalized_project_path(project_path)?)
         }
-        Subcommand::Deploy { project_path } => {
-            deploy::handle(&shared::normalized_project_path(project_path)?)
-        }
-        Subcommand::Account { root } => account::handle(root),
-        Subcommand::Test { cmd } => test::handle(cmd),
+        Subcommand::Deploy {
+            project_path,
+            network,
+        } => deploy::handle(
+            &home,
+            &shared::normalized_project_path(project_path)?,
+            shared::normalized_network(&home, network)?,
+        ),
+        Subcommand::Account { root } => account::handle(&home, root),
+        Subcommand::Test { cmd } => test::handle(&home, cmd),
         Subcommand::Console {
             project_path,
             network,
@@ -39,9 +47,9 @@ pub async fn main() -> Result<()> {
             address,
         } => console::handle(
             &shared::normalized_project_path(project_path)?,
-            normalized_network(network)?,
-            &normalized_key_path(key_path)?,
-            normalized_address(address)?,
+            shared::normalized_network(&home, network)?,
+            &normalized_key_path(&home, key_path)?,
+            normalized_address(&home, address)?,
         ),
         Subcommand::Transactions {
             network,
@@ -50,9 +58,9 @@ pub async fn main() -> Result<()> {
             raw,
         } => {
             transactions::handle(
-                normalized_network(network)?,
+                shared::normalized_network(&home, network)?,
                 unwrap_nested_boolean_option(tail),
-                normalized_address(address)?,
+                normalized_address(&home, address)?,
                 unwrap_nested_boolean_option(raw),
             )
             .await
@@ -86,6 +94,9 @@ pub enum Subcommand {
     Deploy {
         #[structopt(short, long)]
         project_path: Option<PathBuf>,
+
+        #[structopt(short, long)]
+        network: Option<String>,
     },
     Account {
         #[structopt(short, long, help = "Creates account from mint.key passed in by user")]
@@ -136,7 +147,7 @@ pub enum Subcommand {
     },
 }
 
-fn normalized_address(account_address: Option<String>) -> Result<AccountAddress> {
+fn normalized_address(home: &Home, account_address: Option<String>) -> Result<AccountAddress> {
     let normalized_string = match account_address {
         Some(input_address) => {
             if &input_address[0..2] != "0x" {
@@ -145,21 +156,22 @@ fn normalized_address(account_address: Option<String>) -> Result<AccountAddress>
                 input_address
             }
         }
-        None => get_latest_address()?,
+        None => get_latest_address(home)?,
     };
     Ok(AccountAddress::from_hex_literal(
         normalized_string.as_str(),
     )?)
 }
 
-fn get_latest_address() -> Result<String> {
-    let home = shared::Home::new(shared::get_home_path().as_path())?;
+fn get_latest_address(home: &Home) -> Result<String> {
     home.check_account_path_exists()?;
-    Ok("0x".to_owned() + &fs::read_to_string(home.get_latest_address_path())?)
+    Ok(
+        AccountAddress::from_hex(fs::read_to_string(home.get_latest_address_path())?)?
+            .to_hex_literal(),
+    )
 }
 
-fn normalized_key_path(diem_root_key_path: Option<PathBuf>) -> Result<PathBuf> {
-    let home = shared::Home::new(shared::get_home_path().as_path())?;
+fn normalized_key_path(home: &Home, diem_root_key_path: Option<PathBuf>) -> Result<PathBuf> {
     match diem_root_key_path {
         Some(key_path) => Ok(key_path),
         None => {
@@ -170,20 +182,6 @@ fn normalized_key_path(diem_root_key_path: Option<PathBuf>) -> Result<PathBuf> {
             }
             Ok(PathBuf::from(home.get_latest_key_path()))
         }
-    }
-}
-
-fn normalized_network(network: Option<String>) -> Result<Url> {
-    let home = shared::Home::new(shared::get_home_path().as_path())?;
-    match network {
-        Some(input) => Ok(shared::build_url(
-            input.as_str(),
-            &home.read_networks_toml()?,
-        )?),
-        None => Ok(shared::build_url(
-            shared::LOCALHOST_NETWORK_NAME,
-            &home.read_networks_toml()?,
-        )?),
     }
 }
 

--- a/shuffle/cli/src/node.rs
+++ b/shuffle/cli/src/node.rs
@@ -10,15 +10,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-pub fn handle(genesis: Option<String>) -> Result<()> {
-    let home = Home::new(shared::get_home_path().as_path())?;
+pub fn handle(home: &Home, genesis: Option<String>) -> Result<()> {
     if !home.get_shuffle_path().is_dir() {
         println!(
             "Creating node config in {}",
             home.get_shuffle_path().display()
         );
 
-        create_node(&home, genesis)
+        create_node(home, genesis)
     } else {
         println!(
             "Accessing node config in {}",
@@ -32,13 +31,13 @@ pub fn handle(genesis: Option<String>) -> Result<()> {
             );
         }
 
-        start_node(&home)
+        start_node(home)
     }
 }
 
 fn create_node(home: &Home, genesis: Option<String>) -> Result<()> {
     fs::create_dir_all(home.get_shuffle_path())?;
-    home.write_top_level_networks_config_into_toml()?;
+    home.write_default_networks_config_into_toml()?;
     let publishing_option = VMPublishingOption::open();
     let genesis_modules = genesis_modules_from_path(&genesis)?;
     diem_node::load_test_environment(


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

As we're ramping up to connect to trove testnet, we need the ability to specify which network to use in shuffle deploy and shuffle test. This PR accomplishes this

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

The goal was to add the network argument and make sure shuffle deploy and shuffle test still functioned properly.

I ran cargo run -p shuffle -- deploy -p /Users/avinash00/a --network localhost and got the same output as I would've without the network flag:

![image](https://user-images.githubusercontent.com/55404786/140825311-f9df9306-5d93-4bd4-a238-e93fb7a97235.png)

Similarly I ran cargo run -p shuffle -- test e2e -p /Users/avinash00/a --network localhost and got the same output as I would've without the network flag:

![image](https://user-images.githubusercontent.com/55404786/140832449-65f29216-8b6c-49ff-a8c4-86e72929f64d.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
