### PR TITLE
[read-write-set] Rename `read-write-set-types` to `move-read-write-set-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,12 +605,12 @@ dependencies = [
  "move-core-types",
  "move-model",
  "move-prover-test-utils",
+ "move-read-write-set-types",
  "move-stdlib",
  "num 0.4.0",
  "once_cell",
  "paste",
  "petgraph 0.5.1",
- "read-write-set-types",
  "serde",
  "serde_json",
 ]
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "move-binary-format"
-version = "0.1.0"
+version = "0.0.3"
 dependencies = [
  "anyhow",
  "diem-workspace-hack",
@@ -5311,6 +5311,16 @@ dependencies = [
  "move-command-line-common",
  "prettydiff",
  "regex",
+]
+
+[[package]]
+name = "move-read-write-set-types"
+version = "0.0.3"
+dependencies = [
+ "anyhow",
+ "diem-workspace-hack",
+ "move-binary-format",
+ "move-core-types",
 ]
 
 [[package]]
@@ -6728,8 +6738,8 @@ dependencies = [
  "move-bytecode-utils",
  "move-core-types",
  "move-model",
+ "move-read-write-set-types",
  "read-write-set-dynamic",
- "read-write-set-types",
  "resource-viewer",
 ]
 
@@ -6742,17 +6752,7 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
- "read-write-set-types",
-]
-
-[[package]]
-name = "read-write-set-types"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "diem-workspace-hack",
- "move-binary-format",
- "move-core-types",
+ "move-read-write-set-types",
 ]
 
 [[package]]

--- a/language/move-binary-format/Cargo.toml
+++ b/language/move-binary-format/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "move-binary-format"
-version = "0.1.0"
+version = "0.0.3"
 authors = ["Diem Association <opensource@diem.com>"]
 description = "Move Binary Format"
 repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
-publish = false
+publish = ["crates-io"]
 edition = "2018"
 
 [dependencies]
@@ -17,10 +17,10 @@ proptest = { version = "1.0.0", optional = true }
 proptest-derive = { version = "0.3.0", optional = true }
 ref-cast = "1.0.6"
 variant_count = "1.1.0"
-diem-workspace-hack = { path = "../../common/workspace-hack" }
-move-core-types = { path = "../move-core/types" }
+move-core-types = { path = "../move-core/types", version = "0.0.3" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 move-core-types = { path = "../move-core/types", features = ["fuzzing"] }

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -18,7 +18,7 @@ ir-to-bytecode = { path = "../../compiler/ir-to-bytecode" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-command-line-common = { path = "../../move-command-line-common" }
-read-write-set-types = { path = "../../tools/read-write-set/types" }
+move-read-write-set-types = { path = "../../tools/read-write-set/types" }
 
 codespan = "0.11.1"
 codespan-reporting = { version = "0.11.1", features = ["serde", "serialization"] }

--- a/language/move-prover/bytecode/src/read_write_set_analysis.rs
+++ b/language/move-prover/bytecode/src/read_write_set_analysis.rs
@@ -26,7 +26,7 @@ use move_model::{
     model::{FunctionEnv, GlobalEnv, ModuleId, StructId},
     ty::Type,
 };
-use read_write_set_types::{
+use move_read_write_set_types::{
     Access, AccessPath as RWAccessPath, Offset as RWOffset, ReadWriteSet, Root as RWRoot,
     RootAddress as RWRootAddress,
 };

--- a/language/tools/read-write-set/Cargo.toml
+++ b/language/tools/read-write-set/Cargo.toml
@@ -18,5 +18,5 @@ move-core-types = { path = "../../move-core/types" }
 move-model = { path = "../../move-model" }
 prover_bytecode = { path = "../../move-prover/bytecode", package="bytecode" }
 resource-viewer = { path = "../resource-viewer" }
-read-write-set-types = { path = "types" }
+move-read-write-set-types = { path = "types" }
 read-write-set-dynamic = { path = "dynamic" }

--- a/language/tools/read-write-set/dynamic/Cargo.toml
+++ b/language/tools/read-write-set/dynamic/Cargo.toml
@@ -15,4 +15,4 @@ diem-workspace-hack = { path = "../../../../common/workspace-hack" }
 move-binary-format = { path = "../../../move-binary-format" }
 move-bytecode-utils = { path = "../../move-bytecode-utils" }
 move-core-types = { path = "../../../move-core/types" }
-read-write-set-types = { path = "../types" }
+move-read-write-set-types = { path = "../types" }

--- a/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
@@ -14,7 +14,7 @@ use move_core_types::{
     resolver::MoveResolver,
     value::MoveValue,
 };
-use read_write_set_types::{Access, AccessPath, Offset, ReadWriteSet, RootAddress};
+use move_read_write_set_types::{Access, AccessPath, Offset, ReadWriteSet, RootAddress};
 use std::{
     fmt::{self, Formatter},
     ops::Deref,

--- a/language/tools/read-write-set/dynamic/src/normalize.rs
+++ b/language/tools/read-write-set/dynamic/src/normalize.rs
@@ -12,7 +12,7 @@ use move_core_types::{
     language_storage::{ModuleId, ResourceKey, TypeTag},
     resolver::MoveResolver,
 };
-use read_write_set_types::ReadWriteSet;
+use move_read_write_set_types::ReadWriteSet;
 use std::collections::BTreeMap;
 
 pub struct NormalizedReadWriteSetAnalysis(BTreeMap<ModuleId, BTreeMap<Identifier, ReadWriteSet>>);

--- a/language/tools/read-write-set/src/lib.rs
+++ b/language/tools/read-write-set/src/lib.rs
@@ -9,12 +9,12 @@ use move_core_types::{
     language_storage::ModuleId,
 };
 use move_model::model::{FunctionEnv, GlobalEnv};
+use move_read_write_set_types::ReadWriteSet;
 use prover_bytecode::{
     function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder, FunctionVariant},
     read_write_set_analysis::{ReadWriteSetProcessor, ReadWriteSetState},
 };
 use read_write_set_dynamic::NormalizedReadWriteSetAnalysis;
-use read_write_set_types::ReadWriteSet;
 use std::collections::BTreeMap;
 
 pub struct ReadWriteSetAnalysis {

--- a/language/tools/read-write-set/types/Cargo.toml
+++ b/language/tools/read-write-set/types/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
-name = "read-write-set-types"
-version = "0.1.0"
+name = "move-read-write-set-types"
+version = "0.0.3"
 authors = ["Diem Association <opensource@diem.com>"]
 description = "Type definition for read/write set inference for Move bytecode programs"
 repository = "https://github.com/diem/diem"
 homepage = "https://diem.com"
 license = "Apache-2.0"
-publish = false
+publish = ["crates-io"]
 edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
+move-binary-format = { path = "../../../move-binary-format", version = "0.0.3" }
+move-core-types = { path = "../../../move-core/types", version = "0.0.3" }
+
+[dev-dependencies]
 diem-workspace-hack = { path = "../../../../common/workspace-hack" }
-move-binary-format = { path = "../../../move-binary-format" }
-move-core-types = { path = "../../../move-core/types" }


### PR DESCRIPTION
## Motivation

Rename `read-write-set-types` to `move-read-write-set-types` and changed its version number to publish this crate. The crate needs to be published because of #9648.

Also published `move-binary-format` because of the transitive dependencies. The version numbers were picked to follow the current version of `diem-types`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test`