### PR TITLE
[consensus] disseminiate sync info when mempool waits for available txns

### DIFF
--- a/consensus/src/state_replication.rs
+++ b/consensus/src/state_replication.rs
@@ -7,6 +7,7 @@ use consensus_types::{block::Block, common::Payload, executed_block::ExecutedBlo
 use diem_crypto::HashValue;
 use diem_types::ledger_info::LedgerInfoWithSignatures;
 use executor_types::{Error as ExecutionError, StateComputeResult};
+use futures::future::BoxFuture;
 use std::sync::Arc;
 
 pub type StateComputerCommitCallBackType =
@@ -22,10 +23,13 @@ pub trait TxnManager: Send + Sync {
     /// Brings new transactions to be applied.
     /// The `exclude_txns` list includes the transactions that are already pending in the
     /// branch of blocks consensus is trying to extend.
+    ///
+    /// wait_callback is executed when there's no transactions available and it decides to wait.
     async fn pull_txns(
         &self,
         max_size: u64,
         exclude: Vec<&Payload>,
+        wait_callback: BoxFuture<'static, ()>,
     ) -> Result<Payload, MempoolError>;
 
     /// Notifies TxnManager about the txns which failed execution. (Committed txns is notified by

--- a/consensus/src/test_utils/mock_txn_manager.rs
+++ b/consensus/src/test_utils/mock_txn_manager.rs
@@ -13,7 +13,7 @@ use diem_types::{
     vm_status::{KeptVMStatus, StatusCode},
 };
 use executor_types::StateComputeResult;
-use futures::channel::mpsc;
+use futures::{channel::mpsc, future::BoxFuture};
 use rand::Rng;
 
 #[derive(Clone)]
@@ -54,6 +54,7 @@ impl TxnManager for MockTransactionManager {
         &self,
         _max_size: u64,
         _exclude_txns: Vec<&Payload>,
+        _callback: BoxFuture<'static, ()>,
     ) -> Result<Payload, MempoolError> {
         // generate 1k txn is too slow with coverage instrumentation
         Ok(random_payload(10))

--- a/consensus/src/txn_manager.rs
+++ b/consensus/src/txn_manager.rs
@@ -10,7 +10,10 @@ use diem_metrics::monitor;
 use diem_types::transaction::TransactionStatus;
 use executor_types::StateComputeResult;
 use fail::fail_point;
-use futures::channel::{mpsc, oneshot};
+use futures::{
+    channel::{mpsc, oneshot},
+    future::BoxFuture,
+};
 use itertools::Itertools;
 use std::time::Duration;
 use tokio::time::{sleep, timeout};
@@ -87,6 +90,7 @@ impl TxnManager for MempoolProxy {
         &self,
         max_size: u64,
         exclude_payloads: Vec<&Payload>,
+        wait_callback: BoxFuture<'static, ()>,
     ) -> Result<Payload, MempoolError> {
         fail_point!("consensus::pull_txns", |_| {
             Err(anyhow::anyhow!("Injected error in pull_txns").into())
@@ -100,6 +104,7 @@ impl TxnManager for MempoolProxy {
                 });
             }
         }
+        let mut callback_wrapper = Some(wait_callback);
         let no_pending_txns = exclude_txns.is_empty();
         // keep polling mempool until there's txn available or there's still pending txns
         let mut count = self.poll_count;
@@ -107,6 +112,9 @@ impl TxnManager for MempoolProxy {
             count -= 1;
             let txns = self.pull_internal(max_size, exclude_txns.clone()).await?;
             if txns.is_empty() && no_pending_txns && count > 0 {
+                if let Some(callback) = callback_wrapper.take() {
+                    callback.await;
+                }
                 sleep(Duration::from_millis(NO_TXN_DELAY)).await;
                 continue;
             }


### PR DESCRIPTION
This should fit the last piece of slowing down the empty blocks without impacting user experience.
Broadcast syncinfo will send out the newest qc that the leader aggregates which may commit the latest block.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
