### PR TITLE
[move-prover] parenthesis the ITE expression when translating to boogie

### DIFF
--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -583,12 +583,15 @@ impl<'env> SpecTranslator<'env> {
             }
             ExpData::IfElse(node_id, cond, on_true, on_false) => {
                 self.set_writer_location(*node_id);
-                emit!(self.writer, "if (");
-                self.translate_exp(cond);
-                emit!(self.writer, ") then ");
+                // The whole ITE is one expression so we wrap it with a parenthesis
+                emit!(self.writer, "(");
+                emit!(self.writer, "if ");
+                self.translate_exp_parenthesised(cond);
+                emit!(self.writer, " then ");
                 self.translate_exp_parenthesised(on_true);
                 emit!(self.writer, " else ");
                 self.translate_exp_parenthesised(on_false);
+                emit!(self.writer, ")");
             }
             ExpData::Invalid(_) => panic!("unexpected error expression"),
         }


### PR DESCRIPTION
This is motivated by the following expression generated by the spec
simplifier, which causes a type error in Boogie (but no type error in
our AST):

```boogie
(x > 0) && if (true) then (0) else (1) >= 0;
```

In this case, Boogie complains that the then-else branches return
different types which is int (for the then branch) and bool (for the
else branch).

This is caused by the fact that the ITE expression itself is not
enclosed in a parenthesis. The correct encoding should be:

```boogie
(x > 0) && (if (true) then (0) else (1)) >= 0;
```

This commit fixes this issue by wrapping the ITE expression with ().

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Fix an encoding issue

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI, everything should continue to verify
