### PR TITLE
Cherry-pick PR #9668 into release-1.5: [storage] fix fuzzer for schema decoding

### DIFF
--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -291,23 +291,30 @@ impl InternalNode {
     }
 
     pub fn new_migration(children: Children, leaf_count_migration: bool) -> Self {
+        Self::new_impl(children, leaf_count_migration).expect("Input children are logical.")
+    }
+
+    pub fn new_impl(children: Children, leaf_count_migration: bool) -> Result<Self> {
         // Assert the internal node must have >= 1 children. If it only has one child, it cannot be
         // a leaf node. Otherwise, the leaf node should be a child of this internal node's parent.
-        assert!(!children.is_empty());
+        ensure!(!children.is_empty(), "Children must not be empty");
         if children.len() == 1 {
-            assert!(!children
-                .values()
-                .next()
-                .expect("Must have 1 element")
-                .is_leaf())
+            ensure!(
+                !children
+                    .values()
+                    .next()
+                    .expect("Must have 1 element")
+                    .is_leaf(),
+                "If there's only one child, it must not be a leaf."
+            );
         }
 
         let leaf_count = Self::sum_leaf_count(&children);
-        Self {
+        Ok(Self {
             children,
             leaf_count,
             leaf_count_migration,
-        }
+        })
     }
 
     fn sum_leaf_count(children: &Children) -> Option<usize> {
@@ -433,10 +440,7 @@ impl InternalNode {
 
         // The "leaf_count_migration" flag doesn't matter here, since a deserialized node should
         // not be persisted again to the DB.
-        Ok(Self::new_migration(
-            children,
-            read_leaf_counts, /* leaf_count_migration */
-        ))
+        Self::new_impl(children, read_leaf_counts /* leaf_count_migration */)
     }
 
     /// Gets the `n`-th child.


### PR DESCRIPTION
This cherry-pick was triggerd by a request on #9668
Please review the diff to ensure there are not any unexpected changes.

> 
> ## Motivation
> 
> The fuzzer expects schema decoding never panics, while it's no longer the case because #9304 called InternalNode constructor in decoding.
> 
> ### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
> Y
> 
> ## Test Plan
> 
> Using corpus that failed the coverage test for branch 1.5, the failure was reproduced on main and not reproducable on this fix.

            
cc @msmouse