### PR TITLE
[api] enable api by default and change rest api and json-rpc to use same port

### DIFF
--- a/api/Operation.md
+++ b/api/Operation.md
@@ -1,0 +1,74 @@
+# Operation
+
+## Web Server Configuration
+
+Diem node generates the following default API configuration:
+
+```
+api:
+  enabled: true
+  address: "0.0.0.0:8080"
+```
+
+It's optional to configure TLS certificate and private key file paths for enabling TLS for the web server:
+```
+api:
+  enabled: true
+  address: "0.0.0.0:8080"
+  tls_cert_path: <file path>
+  tls_key_path: <file path>
+```
+
+When `api.enabled` is set to `true`, both API and JSON-RPC configured web server will serve the REST and JSON-RPC API.
+
+### JSON-RPC is enabled
+
+Regardless what the JSON-RPC `address` configuration is, JSON-RPC API is always available on the REST API port.
+
+However, JSON-RPC service still reads configurations from `json_rpc` section.
+
+To avoid enabling JSON-RPC and REST API at different ports, you can configure same address for `api.address` and
+`json_rpc.address` (you are required to set them same, as well as `tls_cert_path` and `tls_key_path`
+for `api` and `json_rpc`).
+
+
+## Health check endpoint
+
+Health check: `/-/healthy` returns 200
+
+Health check endpoint accepts an optional query parameter `duration_secs`.
+
+Health check returns 200 when `duration_secs` is provided and meet the following condition:
+* `server latest ledger info timestamp >= server current time timestamp - duration_secs`
+
+If no param is provided, server returns 200 to indicate HTTP server is running health.
+
+## Logging
+
+The request log level is set to DEBUG by default, 5xx error responses will be logged to ERROR level.
+
+You can add `diem_api=DEBUG` into RUST_LOG environment to configure the log output.
+
+
+## Metrics
+
+### Requests Processed by Handler
+
+The latency and counts of requests that are processed by a handler are recorded by a histogram
+named `diem_api_requests` and labelled by:
+
+* method: HTTP request method
+* operation_id: request handler/operation id, it should be same `operationId` defined in [OpenAPI specification](doc/openapi.yaml), except couple cases that are not defined in the [OpenAPI specification](doc/openapi.yaml), e.g. `json_rpc`.
+* status: HTTP response statuc code
+
+This metrics covers all requests responses served the API handlers.
+Some errors like invalid route path are not covered, because no handlers are used for processing the request.
+
+### All Requests by Status
+
+The latency and counts of requests regardless errors or hit any handlers are recorded by a histogram
+named `diem_api_response_status` and labelled by:
+
+* status: HTTP response status code
+
+This metrics covers all requests responses served by the API web server.

--- a/api/README.md
+++ b/api/README.md
@@ -74,12 +74,6 @@ An `anyhow::Error` is considered as server internal error (500) by default.
 All internal errors should be converted into `anyhow::Error` first.
 An `diem_api_types.Error` is defined for converting `anyhow::Error` to `warp.Rejection` with HTTP error code.
 
-## Logging
-
-The request log level is set to DEBUG by default.
-
-You can add `diem_api=DEBUG` into RUST_LOG environment to configure the log output.
-
 ## Testing
 
 ### Unit Test
@@ -105,3 +99,7 @@ cargo test --test "forge" "api::"
 
 * Run `scripts/dev_setup.sh -a` to setup tools.
 * Run `make test` inside the `api` directory.
+
+## Diem Node Operation
+
+Please refer to [Operation](Operation.md) document for details, including configuration, logging, metrics etc.

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -8,6 +8,7 @@ use std::net::SocketAddr;
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ApiConfig {
+    #[serde(default = "default_enabled")]
     pub enabled: bool,
     pub address: SocketAddr,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -17,7 +18,11 @@ pub struct ApiConfig {
 }
 
 pub const DEFAULT_ADDRESS: &str = "127.0.0.1";
-pub const DEFAULT_PORT: u16 = 8081;
+pub const DEFAULT_PORT: u16 = 8080;
+
+fn default_enabled() -> bool {
+    true
+}
 
 impl Default for ApiConfig {
     fn default() -> ApiConfig {

--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -136,8 +136,8 @@ pub fn load_test_environment<R>(
     template.json_rpc.address = format!("0.0.0.0:{}", template.json_rpc.address.port())
         .parse()
         .unwrap();
+    template.api.address = template.json_rpc.address;
     template.json_rpc.stream_rpc.enabled = true;
-    template.api.enabled = true;
     if lazy {
         template.consensus.mempool_poll_count = u64::MAX;
     }
@@ -186,9 +186,8 @@ pub fn load_test_environment<R>(
 
 pub fn print_api_config(config: &NodeConfig) {
     println!("\tJSON-RPC endpoint: {}", config.json_rpc.address);
+    println!("\tREST API endpoint: {}", config.api.address);
     println!("\tStream-RPC enabled!");
-    println!("\tREST API enabled!");
-    println!("\tREST API: {}", config.api.address);
 
     println!(
         "\tFullNode network: {}",

--- a/docker/validator/Dockerfile
+++ b/docker/validator/Dockerfile
@@ -37,8 +37,6 @@ COPY --from=builder /diem/target/release/db-restore /opt/diem/bin
 
 # Admission control
 EXPOSE 8000
-# REST API
-EXPOSE 8081
 # Validator network
 EXPOSE 6180
 # Metrics

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -443,7 +443,7 @@ impl Network {
             name: String::from(LOCALHOST_NETWORK_NAME),
             base: String::from(LOCALHOST_NETWORK_BASE),
             json_rpc_port: 8080,
-            dev_api_port: 8081,
+            dev_api_port: 8080,
         }
     }
 }
@@ -746,7 +746,7 @@ mod test {
         let url_from_some = normalized_network(&home, Some("localhost".to_string())).unwrap();
         let url_from_none = normalized_network(&home, None).unwrap();
 
-        let correct_url = Url::from_str("http://127.0.0.1:8081").unwrap();
+        let correct_url = Url::from_str("http://127.0.0.1:8080").unwrap();
 
         assert_eq!(url_from_some, correct_url);
         assert_eq!(url_from_none, correct_url);
@@ -779,7 +779,7 @@ mod test {
             name: "localhost".to_string(),
             base: "http://127.0.0.1".to_string(),
             json_rpc_port: 8080,
-            dev_api_port: 8081,
+            dev_api_port: 8080,
         }
     }
 
@@ -805,7 +805,7 @@ mod test {
         let all_networks = NetworksConfig {
             networks: network_map,
         };
-        let correct_url = Url::from_str("http://127.0.0.1:8081").unwrap();
+        let correct_url = Url::from_str("http://127.0.0.1:8080").unwrap();
         assert_eq!(all_networks.url_for("localhost").unwrap(), correct_url);
         assert_eq!(all_networks.url_for("trove").is_err(), true);
     }
@@ -813,7 +813,7 @@ mod test {
     #[test]
     fn test_get_filtered_envs_for_deno() {
         let project_path = Path::new("/Users/project_path");
-        let network = Url::from_str("http://127.0.0.1:8081").unwrap();
+        let network = Url::from_str("http://127.0.0.1:8080").unwrap();
         let key_path = Path::new("/Users/private_key_path/dev.key");
         let address = AccountAddress::random();
         let shuffle_dir = get_shuffle_dir();

--- a/testsuite/forge/src/backend/k8s/swarm.rs
+++ b/testsuite/forge/src/backend/k8s/swarm.rs
@@ -24,7 +24,7 @@ use std::{collections::HashMap, convert::TryFrom, env, process::Command, str, sy
 use tokio::time::Duration;
 
 const JSON_RPC_PORT: u32 = 80;
-const REST_API_PORT: u32 = 8081;
+const REST_API_PORT: u32 = 80;
 const VALIDATOR_LB: &str = "validator-fullnode-lb";
 
 pub struct K8sSwarm {


### PR DESCRIPTION
#9193 

To keep configuration simple, changed enable REST API by default and used same port that is used by JSON-RPC API (removed 8081 default config).
Added diem-node operation document for API: `Operation.md` 