### PR TITLE
[state-sync-v2] api get_first_txn_version

### DIFF
--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -794,6 +794,11 @@ impl DbReader<DpnProto> for DiemDB {
         })
     }
 
+    /// Get the first version that txn starts existent.
+    fn get_first_txn_version(&self) -> Result<Option<Version>> {
+        self.transaction_store.get_first_txn_version()
+    }
+
     /// Get the first version that write set starts existent.
     fn get_first_write_set_version(&self) -> Result<Option<Version>> {
         self.transaction_store.get_first_write_set_version()

--- a/storage/diemdb/src/transaction_store/mod.rs
+++ b/storage/diemdb/src/transaction_store/mod.rs
@@ -116,6 +116,13 @@ impl TransactionStore {
         })
     }
 
+    /// Get the first version that txn starts existent.
+    pub fn get_first_txn_version(&self) -> Result<Option<Version>> {
+        let mut iter = self.db.iter::<TransactionSchema>(Default::default())?;
+        iter.seek_to_first();
+        iter.next().map(|res| res.map(|(v, _)| v)).transpose()
+    }
+
     /// Returns the block metadata carried on the block metadata transaction at or preceding
     /// `version`, together with the version of the block metadata transaction.
     /// Returns None if there's no such transaction at or preceding `version` (it's likely the genesis

--- a/storage/diemdb/src/transaction_store/test.rs
+++ b/storage/diemdb/src/transaction_store/test.rs
@@ -38,6 +38,7 @@ proptest! {
         }
         store.db.write_schemas(cs.batch).unwrap();
 
+        assert_eq!(store.get_first_txn_version().unwrap(), Some(0));
         assert_eq!(store.get_first_write_set_version().unwrap(), Some(0));
 
         let ledger_version = txns.len() as Version - 1;

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -220,6 +220,13 @@ pub trait DbReader<PS: ProtocolSpec>: Send + Sync {
         unimplemented!()
     }
 
+    /// See [`DiemDB::get_txn_set_version`].
+    ///
+    /// [`DiemDB::get_first_txn_version`]: ../diemdb/struct.DiemDB.html#method.get_first_txn_version
+    fn get_first_txn_version(&self) -> Result<Option<Version>> {
+        unimplemented!()
+    }
+
     /// See [`DiemDB::get_first_write_set_version`].
     ///
     /// [`DiemDB::get_first_write_set_version`]: ../diemdb/struct.DiemDB.html#method.get_first_write_set_version


### PR DESCRIPTION
## Motivation

ready for state-sync v2. 
we need api to know the first available txn/txn_info version.

## Test Plan

ut

