### PR TITLE
[api] correct content type name and account resource field name

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -609,11 +609,11 @@ components:
       type: object
       required:
         - type
-        - value
+        - data
       properties:
         type:
           $ref: '#/components/schemas/MoveStructTagId'
-        value:
+        data:
           type: "object"
           description: |
             Account resource data is JSON representation of the Move struct `type`.
@@ -621,7 +621,7 @@ components:
             Move struct field name and value are serialized as object property name and value.
       example:
         type: "0x1::DiemAccount::Balance<0x1::XDX::XDX>"
-        value:
+        data:
           coin:
             value: "8000000000"
     MoveTypeTagId:

--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -213,7 +213,7 @@ paths:
           * Serialize [SignedTransaction](https://diem.github.io/diem/diem_types/transaction/struct.SignedTransaction.html)
             into BCS bytes.
           * Submit the [SignedTransaction](https://diem.github.io/diem/diem_types/transaction/struct.SignedTransaction.html)
-            BCS bytes (do not hex-encoded it). The request header "Content-Type" must set to "application/vnd.bcs+signed_transaction".
+            BCS bytes (do not hex-encoded it). The request header "Content-Type" must set to "application/x.diem.signed_transaction+bcs".
       tags:
         - transactions
       requestBody:
@@ -224,7 +224,7 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SubmitTransactionRequest'
-          application/vnd.bcs+signed_transaction:
+          application/x.diem.signed_transaction+bcs:
             schema:
               type: string
               format: binary

--- a/api/src/tests/accounts_test.rs
+++ b/api/src/tests/accounts_test.rs
@@ -79,7 +79,7 @@ async fn test_account_resources_response() {
         res,
         json!({
             "type": "0x1::DiemAccount::Balance<0x1::XDX::XDX>",
-            "value": {
+            "data": {
                 "coin": {
                     "value": "0"
                 }
@@ -484,7 +484,7 @@ async fn test_get_account_resources_by_ledger_version() {
     let tc_account = find_value(&ledger_version_1_resources, |f| {
         f["type"] == "0x1::DiemAccount::DiemAccount"
     });
-    assert_eq!(tc_account["value"]["sequence_number"], "1");
+    assert_eq!(tc_account["data"]["sequence_number"], "1");
 
     let ledger_version_0_resources = context
         .get(&account_resources_with_ledger_version(
@@ -495,7 +495,7 @@ async fn test_get_account_resources_by_ledger_version() {
     let tc_account = find_value(&ledger_version_0_resources, |f| {
         f["type"] == "0x1::DiemAccount::DiemAccount"
     });
-    assert_eq!(tc_account["value"]["sequence_number"], "0");
+    assert_eq!(tc_account["data"]["sequence_number"], "0");
 }
 
 #[tokio::test]

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -121,7 +121,7 @@ async fn test_get_transactions_output_genesis_transaction() {
             "address": "0xdd",
             "data": {
                 "type": "0x1::Roles::RoleId",
-                "value": {
+                "data": {
                     "role_id": "2"
                 }
             }

--- a/api/types/src/mime_types.rs
+++ b/api/types/src/mime_types.rs
@@ -1,5 +1,5 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-pub const BCS_SIGNED_TRANSACTION: &str = "application/vnd.bcs+signed_transaction";
+pub const BCS_SIGNED_TRANSACTION: &str = "application/x.diem.signed_transaction+bcs";
 pub const JSON: &str = "application/json";

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -33,7 +33,7 @@ use std::{
 pub struct MoveResource {
     #[serde(rename = "type")]
     pub typ: MoveStructTag,
-    pub value: MoveStructValue,
+    pub data: MoveStructValue,
 }
 
 impl TryFrom<AnnotatedMoveStruct> for MoveResource {
@@ -42,7 +42,7 @@ impl TryFrom<AnnotatedMoveStruct> for MoveResource {
     fn try_from(s: AnnotatedMoveStruct) -> anyhow::Result<Self> {
         Ok(Self {
             typ: s.type_.clone().into(),
-            value: s.try_into()?,
+            data: s.try_into()?,
         })
     }
 }
@@ -963,7 +963,7 @@ mod tests {
             value,
             json!({
                 "type": "0x1::Type::Values",
-                "value": {
+                "data": {
                     "field_u8": 7,
                     "field_u64": "7",
                     "field_u128": "7",
@@ -994,7 +994,7 @@ mod tests {
             value,
             json!({
                 "type": "0x1::Type::Values",
-                "value": {
+                "data": {
                     "address_0x0": "0x0",
                 }
             }),

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -237,7 +237,7 @@ impl DevApiClient {
         let mut seq_number_string = "";
         for object in &json_arr {
             if object["type"] == DIEM_ACCOUNT_TYPE {
-                seq_number_string = object["value"]["sequence_number"]
+                seq_number_string = object["data"]["sequence_number"]
                     .as_str()
                     .ok_or_else(|| anyhow!("Invalid sequence number string"))?;
                 break;
@@ -963,7 +963,7 @@ mod test {
     fn test_parse_json_for_seq_num() {
         let value_obj = json!([{
             "type":"0x1::DiemAccount::DiemAccount",
-            "value": {
+            "data": {
                 "authentication_key": "0x88cae30f0fea7879708788df9e7c9b7524163afcc6e33b0a9473852e18327fa9",
                 "key_rotation_capability":{
                     "vec":[{"account_address":"0x24163afcc6e33b0a9473852e18327fa9"}]

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -83,7 +83,7 @@ export async function account(addr?: string) {
 export async function sequenceNumber(addr?: string): Promise<number> {
   const acc: any = await account(addr);
   if (acc) {
-    return parseInt(acc["value"]["sequence_number"]);
+    return parseInt(acc["data"]["sequence_number"]);
   }
   throw "unable to find account";
 }

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -100,7 +100,7 @@ export async function postTransactionBcs(
     method: "POST",
     body: body,
     headers: {
-      "Content-Type": "application/vnd.bcs+signed_transaction",
+      "Content-Type": "application/x.diem.signed_transaction+bcs",
     },
   };
   return await checkingFetch(context.relativeUrl("/transactions"), settings);

--- a/shuffle/move/examples/main/mod.ts
+++ b/shuffle/move/examples/main/mod.ts
@@ -108,11 +108,11 @@ export async function createTestNFTScriptFunction(
 
 export async function decodedMessages() {
   return (await devapi.resourcesWithName("MessageHolder"))
-    .map((entry) => DiemHelpers.hexToAscii(entry.value.message));
+    .map((entry) => DiemHelpers.hexToAscii(entry.data.message));
 }
 
 export async function decodedNFTs() {
   return (await devapi.resourcesWithName("NFT"))
-    .filter((entry) => entry.value && entry.value.content_uri)
-    .map((entry) => DiemHelpers.hexToAscii(entry.value.content_uri));
+    .filter((entry) => entry.data && entry.data.content_uri)
+    .map((entry) => DiemHelpers.hexToAscii(entry.data.content_uri));
 }


### PR DESCRIPTION
#9193 

1. Changed BCS signed transaction request content type name to `application/x.diem.signed_transaction+bcs`: `x` as the name is not registered, `diem.signed_transaction` is the type name, `+bcs` is data format as the underlying structure of that media type.
2. Renamed account resource field `value` to `data`, we named similar field at other places as `data`, e.g. `Event#data`, `WriteSetChange#data`. 