### PR TITLE
[api] handle POST requests properly

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -2,10 +2,10 @@
 
 This module provides REST API for client applications to query the Diem blockchain.
 
-The [API specification](doc/openapi.yaml) is documented in [OpenAPI](https://www.openapis.org/) 3.0.3.
-You can load the specification into a renderer (e.g. [redocly](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/diem/diem/main/api/doc/openapi.yaml)).
+* [API specification](doc/openapi.yaml)
+* [Documentation](https://diem.github.io/diem/diem_api/spec.html)
 
-For a Diem node enabled API, you can get the specification document at `/spec.html`.
+> For a Diem node, you can view the documentation at `/spec.html`.
 
 ## Overview
 

--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -277,6 +277,10 @@ paths:
                 $ref: '#/components/schemas/PendingTransaction'
         "400":
           $ref: '#/components/responses/400'
+        "413":
+          $ref: '#/components/responses/413'
+        "415":
+          $ref: '#/components/responses/415'
         "500":
           $ref: '#/components/responses/500'
   /accounts/{address}/transactions:
@@ -393,6 +397,10 @@ paths:
           $ref: '#/components/responses/400'
         "404":
           $ref: '#/components/responses/404'
+        "413":
+          $ref: '#/components/responses/413'
+        "415":
+          $ref: '#/components/responses/415'
         "500":
           $ref: '#/components/responses/500'
   /events/{event_key}:
@@ -511,6 +519,20 @@ components:
       description: >-
         Resource or data not found.
         Client may retry the request if it is waiting for transaction execution or ledger synchronization.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    "413":
+      description: >-
+        The request payload is too large.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    "415":
+      description: >-
+        The request's content-type is not supported.
       content:
         application/json:
           schema:

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_api_types::{Error, LedgerInfo, MoveConverter, TransactionOnChainData};
-use diem_config::config::{JsonRpcConfig, RoleType};
+use diem_config::config::{ApiConfig, JsonRpcConfig, RoleType};
 use diem_crypto::HashValue;
 use diem_mempool::{MempoolClientRequest, MempoolClientSender, SubmissionStatus};
 use diem_types::{
@@ -35,6 +35,7 @@ pub struct Context {
     mp_sender: MempoolClientSender,
     role: RoleType,
     jsonrpc_config: JsonRpcConfig,
+    api_config: ApiConfig,
 }
 
 impl Context {
@@ -44,6 +45,7 @@ impl Context {
         mp_sender: MempoolClientSender,
         role: RoleType,
         jsonrpc_config: JsonRpcConfig,
+        api_config: ApiConfig,
     ) -> Self {
         Self {
             chain_id,
@@ -51,6 +53,7 @@ impl Context {
             mp_sender,
             role,
             jsonrpc_config,
+            api_config,
         }
     }
 
@@ -60,6 +63,10 @@ impl Context {
 
     pub fn chain_id(&self) -> ChainId {
         self.chain_id
+    }
+
+    pub fn content_length_limit(&self) -> u64 {
+        self.api_config.content_length_limit()
     }
 
     pub fn filter(self) -> impl Filter<Extract = (Context,), Error = Infallible> + Clone {

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -15,7 +15,7 @@ use warp::{
     body::BodyDeserializeError,
     cors::CorsForbidden,
     http::StatusCode,
-    reject::{MethodNotAllowed, PayloadTooLarge, UnsupportedMediaType},
+    reject::{LengthRequired, MethodNotAllowed, PayloadTooLarge, UnsupportedMediaType},
     reply, Filter, Rejection, Reply,
 };
 
@@ -90,6 +90,9 @@ async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
         body = reply::json(&Error::new(code, cause.to_string()));
     } else if let Some(cause) = err.find::<BodyDeserializeError>() {
         code = StatusCode::BAD_REQUEST;
+        body = reply::json(&Error::new(code, cause.to_string()));
+    } else if let Some(cause) = err.find::<LengthRequired>() {
+        code = StatusCode::LENGTH_REQUIRED;
         body = reply::json(&Error::new(code, cause.to_string()));
     } else if let Some(cause) = err.find::<PayloadTooLarge>() {
         code = StatusCode::PAYLOAD_TOO_LARGE;

--- a/api/src/runtime.rs
+++ b/api/src/runtime.rs
@@ -34,13 +34,13 @@ pub fn bootstrap(
     let role = config.base.role;
     let json_rpc_config = config.json_rpc.clone();
     let api_config = config.api.clone();
-    let api = WebServer::from(api_config);
+    let api = WebServer::from(api_config.clone());
     let jsonrpc = WebServer::from(json_rpc_config.clone());
     if api.port() == jsonrpc.port() && api != jsonrpc {
         bail!("API and JSON-RPC should have same configuration when they are configured to use same port. api: {:?}, jsonrpc: {:?}", api, jsonrpc);
     }
     runtime.spawn(async move {
-        let context = Context::new(chain_id, db, mp_sender, role, json_rpc_config);
+        let context = Context::new(chain_id, db, mp_sender, role, json_rpc_config, api_config);
         let routes = index::routes(context);
         if api.port() == jsonrpc.port() {
             api.serve(routes).await;

--- a/api/src/tests/index_test.rs
+++ b/api/src/tests/index_test.rs
@@ -30,13 +30,13 @@ async fn test_returns_not_found_for_the_invalid_path() {
 async fn test_return_bad_request_if_method_not_allowed() {
     let context = new_test_context();
     let resp = context
-        .expect_status_code(400)
+        .expect_status_code(405)
         .post("/accounts/0x1/resources", json!({}))
         .await;
 
     let expected = json!({
-        "code": 400,
-        "message": "Method not allowed or request body is invalid.",
+        "code": 405,
+        "message": "HTTP method not allowed",
     });
 
     assert_eq!(expected, resp);

--- a/api/src/tests/test_context.rs
+++ b/api/src/tests/test_context.rs
@@ -7,7 +7,7 @@ use diem_api_types::{
     mime_types, TransactionOnChainData, X_DIEM_CHAIN_ID, X_DIEM_LEDGER_TIMESTAMP,
     X_DIEM_LEDGER_VERSION,
 };
-use diem_config::config::{JsonRpcConfig, RoleType};
+use diem_config::config::{ApiConfig, JsonRpcConfig, RoleType};
 use diem_crypto::hash::HashValue;
 use diem_genesis_tool::validator_builder::{RootKeys, ValidatorBuilder};
 use diem_global_constants::OWNER_ACCOUNT;
@@ -75,6 +75,7 @@ pub fn new_test_context() -> TestContext {
             mempool.ac_client.clone(),
             RoleType::Validator,
             JsonRpcConfig::default(),
+            ApiConfig::default(),
         ),
         rng,
         root_keys,

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -1627,6 +1627,24 @@ async fn test_create_signing_message_rejects_invalid_json() {
     );
 }
 
+#[tokio::test]
+async fn test_create_signing_message_rejects_no_content_length_request() {
+    let context = new_test_context();
+    let req = warp::test::request()
+        .header("content-type", "application/json")
+        .method("POST")
+        .path("/transactions/signing_message");
+
+    let resp = context.expect_status_code(411).execute(req).await;
+    assert_json(
+        resp,
+        json!({
+            "code": 411,
+            "message": "A content-length header is required"
+        }),
+    );
+}
+
 fn gen_string(len: u64) -> String {
     let mut rng = thread_rng();
     std::iter::repeat(())

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -564,7 +564,7 @@ async fn test_post_invalid_bcs_format_transaction() {
         resp,
         json!({
           "code": 400,
-          "message": "invalid request body: deserialize SignedTransaction BCS bytes failed"
+          "message": "invalid request body: deserialize error: unexpected end of input"
         }),
     );
 }
@@ -1530,6 +1530,44 @@ async fn test_submit_transaction_rejects_payload_too_large_json_body() {
 }
 
 #[tokio::test]
+async fn test_submit_transaction_rejects_invalid_content_type() {
+    let context = new_test_context();
+    let req = warp::test::request()
+        .header("content-type", "invalid")
+        .method("POST")
+        .body("text")
+        .path("/transactions");
+
+    let resp = context.expect_status_code(415).execute(req).await;
+    assert_json(
+        resp,
+        json!({
+            "code": 415,
+            "message": "The request's content-type is not supported"
+        }),
+    );
+}
+
+#[tokio::test]
+async fn test_submit_transaction_rejects_invalid_json() {
+    let context = new_test_context();
+    let req = warp::test::request()
+        .header("content-type", "application/json")
+        .method("POST")
+        .body("invalid json")
+        .path("/transactions");
+
+    let resp = context.expect_status_code(400).execute(req).await;
+    assert_json(
+        resp,
+        json!({
+            "code": 400,
+            "message": "Request body deserialize error: expected value at line 1 column 1"
+        }),
+    );
+}
+
+#[tokio::test]
 async fn test_create_signing_message_rejects_payload_too_large_json_body() {
     let context = new_test_context();
 
@@ -1547,6 +1585,44 @@ async fn test_create_signing_message_rejects_payload_too_large_json_body() {
         json!({
           "code": 413,
           "message": "The request payload is too large"
+        }),
+    );
+}
+
+#[tokio::test]
+async fn test_create_signing_message_rejects_invalid_content_type() {
+    let context = new_test_context();
+    let req = warp::test::request()
+        .header("content-type", "invalid")
+        .method("POST")
+        .body("text")
+        .path("/transactions/signing_message");
+
+    let resp = context.expect_status_code(415).execute(req).await;
+    assert_json(
+        resp,
+        json!({
+            "code": 415,
+            "message": "The request's content-type is not supported"
+        }),
+    );
+}
+
+#[tokio::test]
+async fn test_create_signing_message_rejects_invalid_json() {
+    let context = new_test_context();
+    let req = warp::test::request()
+        .header("content-type", "application/json")
+        .method("POST")
+        .body("invalid json")
+        .path("/transactions/signing_message");
+
+    let resp = context.expect_status_code(400).execute(req).await;
+    assert_json(
+        resp,
+        json!({
+            "code": 400,
+            "message": "Request body deserialize error: expected value at line 1 column 1"
         }),
     );
 }

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 
 use diem_api_types::{
-    mime_types, Error, LedgerInfo, Response, Transaction, TransactionData, TransactionId,
-    TransactionOnChainData, TransactionSigningMessage, UserTransactionRequest,
+    mime_types::BCS_SIGNED_TRANSACTION, Error, LedgerInfo, Response, Transaction, TransactionData,
+    TransactionId, TransactionOnChainData, TransactionSigningMessage, UserTransactionRequest,
 };
 use diem_types::{
     mempool_status::MempoolStatusCode,
@@ -27,7 +27,8 @@ pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Rej
     get_transaction(context.clone())
         .or(get_transactions(context.clone()))
         .or(get_account_transactions(context.clone()))
-        .or(post_transactions(context.clone()))
+        .or(submit_bcs_transactions(context.clone()))
+        .or(submit_json_transactions(context.clone()))
         .or(create_signing_message(context))
 }
 
@@ -87,49 +88,60 @@ async fn handle_get_account_transactions(
     Ok(Transactions::new(context)?.list_by_account(address, page)?)
 }
 
-// POST /transactions
-pub fn post_transactions(
+// POST /transactions with JSON
+pub fn submit_json_transactions(
     context: Context,
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("transactions")
         .and(warp::post())
-        .and(warp::header::<String>(CONTENT_TYPE.as_str()))
         .and(warp::body::content_length_limit(
             context.content_length_limit(),
         ))
-        .and(warp::body::bytes())
+        .and(warp::body::json::<UserTransactionRequest>())
         .and(context.filter())
-        .and_then(handle_post_transactions)
-        .with(metrics("submit_transactions"))
+        .and_then(handle_submit_json_transactions)
+        .with(metrics("submit_json_transactions"))
 }
 
-async fn handle_post_transactions(
-    content_type: String,
+// POST /transactions with BCS
+pub fn submit_bcs_transactions(
+    context: Context,
+) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    // The `warp::body::bytes` does not check content-type like `warp::body::json`,
+    // so we used `warp::header::exact` to ensure only BCS signed txn matches this route.
+    // When the content-type is invalid (not json / bcs signed txn), `submit_json_transactions`
+    // route will emit correct rejection (UnsupportedMediaType) which will be handled by recover
+    // handler, the invalid header error should be ignored.
+    warp::path!("transactions")
+        .and(warp::post())
+        .and(warp::body::content_length_limit(
+            context.content_length_limit(),
+        ))
+        .and(warp::header::exact(
+            CONTENT_TYPE.as_str(),
+            BCS_SIGNED_TRANSACTION,
+        ))
+        .and(warp::body::bytes())
+        .and(context.filter())
+        .and_then(handle_submit_bcs_transactions)
+        .with(metrics("submit_bcs_transactions"))
+}
+
+async fn handle_submit_json_transactions(
+    body: UserTransactionRequest,
+    context: Context,
+) -> Result<impl Reply, Rejection> {
+    Ok(Transactions::new(context)?
+        .create_from_request(body)
+        .await?)
+}
+
+async fn handle_submit_bcs_transactions(
     body: bytes::Bytes,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
-    let txn = match content_type.to_lowercase().as_str() {
-        mime_types::BCS_SIGNED_TRANSACTION => bcs::from_bytes(&body).map_err(|_| {
-            Error::invalid_request_body("deserialize SignedTransaction BCS bytes failed".to_owned())
-        })?,
-        mime_types::JSON => {
-            let txn = deserialize_user_transaction_request(body)?;
-            let converter = context.move_converter();
-            converter
-                .try_into_signed_transaction(txn, context.chain_id())
-                .map_err(|e| {
-                    Error::invalid_request_body(format!(
-                        "failed to create SignedTransaction from UserTransactionRequest: {}",
-                        e
-                    ))
-                })?
-        }
-        _ => {
-            return Err(
-                Error::bad_request(format!("unsupported content-type: {}", content_type)).into(),
-            )
-        }
-    };
+    let txn = bcs::from_bytes(&body)
+        .map_err(|err| Error::invalid_request_body(format!("deserialize error: {}", err)))?;
     Ok(Transactions::new(context)?.create(txn).await?)
 }
 
@@ -139,33 +151,20 @@ pub fn create_signing_message(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     warp::path!("transactions" / "signing_message")
         .and(warp::post())
-        .and(warp::header::exact(CONTENT_TYPE.as_str(), mime_types::JSON))
         .and(warp::body::content_length_limit(
             context.content_length_limit(),
         ))
-        .and(warp::body::bytes())
+        .and(warp::body::json::<UserTransactionRequest>())
         .and(context.filter())
         .and_then(handle_create_signing_message)
         .with(metrics("create_signing_message"))
 }
 
 async fn handle_create_signing_message(
-    body: bytes::Bytes,
+    body: UserTransactionRequest,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
-    let txn = deserialize_user_transaction_request(body)?;
-    Ok(Transactions::new(context)?.signing_message(txn)?)
-}
-
-fn deserialize_user_transaction_request(
-    body: bytes::Bytes,
-) -> Result<UserTransactionRequest, Error> {
-    serde_json::from_slice(&body).map_err(|e| {
-        Error::invalid_request_body(format!(
-            "deserialize into UserTransactionRequest failed: {:?}",
-            e
-        ))
-    })
+    Ok(Transactions::new(context)?.signing_message(body)?)
 }
 
 struct Transactions {
@@ -180,6 +179,23 @@ impl Transactions {
             ledger_info,
             context,
         })
+    }
+
+    pub async fn create_from_request(
+        self,
+        req: UserTransactionRequest,
+    ) -> Result<impl Reply, Error> {
+        let txn = self
+            .context
+            .move_converter()
+            .try_into_signed_transaction(req, self.context.chain_id())
+            .map_err(|e| {
+                Error::invalid_request_body(format!(
+                    "failed to create SignedTransaction from UserTransactionRequest: {}",
+                    e
+                ))
+            })?;
+        self.create(txn).await
     }
 
     pub async fn create(self, txn: SignedTransaction) -> Result<impl Reply, Error> {

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -94,6 +94,9 @@ pub fn post_transactions(
     warp::path!("transactions")
         .and(warp::post())
         .and(warp::header::<String>(CONTENT_TYPE.as_str()))
+        .and(warp::body::content_length_limit(
+            context.content_length_limit(),
+        ))
         .and(warp::body::bytes())
         .and(context.filter())
         .and_then(handle_post_transactions)
@@ -137,6 +140,9 @@ pub fn create_signing_message(
     warp::path!("transactions" / "signing_message")
         .and(warp::post())
         .and(warp::header::exact(CONTENT_TYPE.as_str(), mime_types::JSON))
+        .and(warp::body::content_length_limit(
+            context.content_length_limit(),
+        ))
         .and(warp::body::bytes())
         .and(context.filter())
         .and_then(handle_create_signing_message)

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -19,6 +19,7 @@ pub struct ApiConfig {
 
 pub const DEFAULT_ADDRESS: &str = "127.0.0.1";
 pub const DEFAULT_PORT: u16 = 8080;
+pub const DEFAULT_REQUEST_CONTENT_LENGTH_LIMIT: u64 = 4 * 1024 * 1024; // 4mb
 
 fn default_enabled() -> bool {
     true
@@ -27,7 +28,6 @@ fn default_enabled() -> bool {
 impl Default for ApiConfig {
     fn default() -> ApiConfig {
         ApiConfig {
-            // disable by default until the API is ready for production
             enabled: false,
             address: format!("{}:{}", DEFAULT_ADDRESS, DEFAULT_PORT)
                 .parse()
@@ -41,5 +41,9 @@ impl Default for ApiConfig {
 impl ApiConfig {
     pub fn randomize_ports(&mut self) {
         self.address.set_port(utils::get_available_port());
+    }
+
+    pub fn content_length_limit(&self) -> u64 {
+        DEFAULT_REQUEST_CONTENT_LENGTH_LIMIT
     }
 }


### PR DESCRIPTION
#9193 
1. Add request content length limit to routes that accept request body. Default to 4mb, the JSON format transaction size is larger than BCS transactions. We only have 2 endpoints accepts request body, submit transaction and create signing message.
2. Switched to use `warp::body::json` to deserialize POST json request body.
3. We need response json error body for the API, but `warp` built-in rejection handling responses text, thus we need to convert the `warp` rejections properly inside recover handler.
4. Correct response code for unsupported content-type.
5. Updated openapi spec doc to include 413 and 415 error in post endpoints.