### PR TITLE
[shuffle] check response statuses after POST/GET transactions

### DIFF
--- a/shuffle/cli/src/deploy.rs
+++ b/shuffle/cli/src/deploy.rs
@@ -75,20 +75,17 @@ async fn send_module_transaction(
         TransactionPayload::ModuleBundle(ModuleBundle::singleton(module_binary)),
     ));
     let bytes = bcs::to_bytes(&publish_txn)?;
-    let resp = client.post_transactions(bytes).await?;
-    let json: serde_json::Value = serde_json::from_str(resp.text().await?.as_str())?;
+    let json = client.post_transactions(bytes).await?;
     let hash = get_hash_from_post_txn(json)?;
     Ok(hash)
 }
 
 async fn check_txn_executed_from_hash(client: &DevApiClient, hash: &str) -> Result<()> {
-    let mut resp = client.get_transactions_by_hash(hash).await?;
-    let mut json: serde_json::Value = serde_json::from_str(resp.text().await?.as_str())?;
+    let mut json = client.get_transactions_by_hash(hash).await?;
     let start = Instant::now();
     while json["type"] == "pending_transaction" {
         thread::sleep(time::Duration::from_secs(1));
-        resp = client.get_transactions_by_hash(hash).await?;
-        json = serde_json::from_str(resp.text().await?.as_str())?;
+        json = client.get_transactions_by_hash(hash).await?;
         let duration = start.elapsed();
         if duration > Duration::from_secs(10) {
             break;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Quick bug fix. Before if a GET or POST transactions request failed, we'd get an error like so: 
`send_module_transaction json: Object({"code": Number(400), "message": String("invalid transaction: INVALID_MODULE_PUBLISHER")})`.

Now we're checking responses after a GET/POST transactions and bubbling up an error message if there is an invalid request. 

## Test Plan

main is broken when creating accounts so to test out this code, first `git checkout bb59dc7164f6a3c57f0868385f84a2e45dc053b0"

Then pass in Invalid requests where I `check_get_transactions_response_status` and `check_post_transactions_response_status`:

![image](https://user-images.githubusercontent.com/55404786/141378290-b7f2a96f-34a1-44ae-ab5c-703a1d825e57.png)

![image](https://user-images.githubusercontent.com/55404786/141378302-1322aabb-a9b7-4c1e-9f0d-b47433caee9e.png)

When there are no errors, this is the output:

![image](https://user-images.githubusercontent.com/55404786/141378336-0be29162-b822-462b-87db-ec79ba7ff589.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
