### PR TITLE
[data-client] port state-sync-v1 peer scoring system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8205,10 +8205,12 @@ dependencies = [
 name = "storage-service-types"
 version = "0.1.0"
 dependencies = [
+ "claim",
  "diem-crypto",
  "diem-types",
  "diem-workspace-hack",
  "num-traits",
+ "proptest",
  "serde",
  "thiserror",
 ]

--- a/state-sync/diem-data-client/src/diemnet/mod.rs
+++ b/state-sync/diem-data-client/src/diemnet/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    AdvertisedData, DiemDataClient, Error, GlobalDataSummary, OptimalChunkSizes, Response,
+    diemnet::state::PeerStates, DiemDataClient, Error, GlobalDataSummary, Response,
     ResponseCallback, ResponseContext, ResponseError, ResponseId, Result,
 };
 use async_trait::async_trait;
@@ -26,7 +26,7 @@ use network::{
     protocols::{rpc::error::RpcError, wire::handshake::v1::ProtocolId},
 };
 use rand::seq::SliceRandom;
-use std::{collections::HashMap, convert::TryFrom, fmt, sync::Arc, time::Duration};
+use std::{convert::TryFrom, fmt, sync::Arc, time::Duration};
 use storage_service_client::StorageServiceClient;
 use storage_service_types::{
     AccountStatesChunkWithProofRequest, Epoch, EpochEndingLedgerInfoRequest, StorageServerSummary,
@@ -34,6 +34,7 @@ use storage_service_types::{
     TransactionsWithProofRequest,
 };
 
+mod state;
 #[cfg(test)]
 mod tests;
 
@@ -420,120 +421,4 @@ impl DataSummaryPoller {
             self.data_client.update_global_summary_cache();
         }
     }
-}
-
-#[derive(Debug, Default)]
-struct PeerState {
-    storage_summary: Option<StorageServerSummary>,
-    // TODO(philiphayes): imagine storing some scoring info here.
-    metadata: (),
-}
-
-/// Contains all of the unbanned peers' most recent [`StorageServerSummary`] data
-/// advertisements and data-client internal metadata for scoring.
-#[derive(Debug)]
-struct PeerStates {
-    inner: HashMap<PeerNetworkId, PeerState>,
-}
-
-impl PeerStates {
-    fn new() -> Self {
-        Self {
-            inner: HashMap::new(),
-        }
-    }
-
-    /// Returns true if a connected storage service peer can actually fulfill a
-    /// request, given our current view of their advertised data summary.
-    fn can_service_request(&self, peer: &PeerNetworkId, request: &StorageServiceRequest) -> bool {
-        // Storage services can always respond to data advertisement requests.
-        // We need this outer check, since we need to be able to send data summary
-        // requests to new peers (who don't have a peer state yet).
-        if request.is_get_storage_server_summary() {
-            return true;
-        }
-
-        self.inner
-            .get(peer)
-            .and_then(|peer_state| peer_state.storage_summary.as_ref())
-            .map(|summary| summary.can_service(request))
-            .unwrap_or(false)
-    }
-
-    fn update_summary(&mut self, peer: PeerNetworkId, summary: StorageServerSummary) {
-        self.inner.entry(peer).or_default().storage_summary = Some(summary);
-    }
-
-    fn aggregate_summary(&self) -> GlobalDataSummary {
-        let mut aggregate_data = AdvertisedData::empty();
-
-        let mut max_epoch_chunk_sizes = vec![];
-        let mut max_transaction_chunk_sizes = vec![];
-        let mut max_transaction_output_chunk_sizes = vec![];
-        let mut max_account_states_chunk_sizes = vec![];
-
-        let summaries = self
-            .inner
-            .values()
-            .filter_map(|state| state.storage_summary.as_ref());
-
-        // collect each peer's protocol and data advertisements
-        for summary in summaries {
-            // collect aggregate data advertisements
-            if let Some(account_states) = summary.data_summary.account_states {
-                aggregate_data.account_states.push(account_states);
-            }
-            if let Some(epoch_ending_ledger_infos) = summary.data_summary.epoch_ending_ledger_infos
-            {
-                aggregate_data
-                    .epoch_ending_ledger_infos
-                    .push(epoch_ending_ledger_infos);
-            }
-            if let Some(synced_ledger_info) = summary.data_summary.synced_ledger_info.as_ref() {
-                aggregate_data
-                    .synced_ledger_infos
-                    .push(synced_ledger_info.clone());
-            }
-            if let Some(transactions) = summary.data_summary.transactions {
-                aggregate_data.transactions.push(transactions);
-            }
-            if let Some(transaction_outputs) = summary.data_summary.transaction_outputs {
-                aggregate_data.transaction_outputs.push(transaction_outputs);
-            }
-
-            // collect preferred max chunk sizes
-            max_epoch_chunk_sizes.push(summary.protocol_metadata.max_epoch_chunk_size);
-            max_transaction_chunk_sizes.push(summary.protocol_metadata.max_transaction_chunk_size);
-            max_transaction_output_chunk_sizes
-                .push(summary.protocol_metadata.max_transaction_output_chunk_size);
-            max_account_states_chunk_sizes
-                .push(summary.protocol_metadata.max_account_states_chunk_size);
-        }
-
-        // take the median for each max chunk size parameter.
-        // this works well when we have an honest majority that mostly agrees on
-        // the same chunk sizes.
-        // TODO(philiphayes): move these constants somewhere?
-        let aggregate_chunk_sizes = OptimalChunkSizes {
-            account_states_chunk_size: median(&mut max_account_states_chunk_sizes)
-                .unwrap_or(storage_service_server::MAX_ACCOUNT_STATES_CHUNK_SIZE),
-            epoch_chunk_size: median(&mut max_epoch_chunk_sizes)
-                .unwrap_or(storage_service_server::MAX_EPOCH_CHUNK_SIZE),
-            transaction_chunk_size: median(&mut max_transaction_chunk_sizes)
-                .unwrap_or(storage_service_server::MAX_TRANSACTION_CHUNK_SIZE),
-            transaction_output_chunk_size: median(&mut max_transaction_output_chunk_sizes)
-                .unwrap_or(storage_service_server::MAX_TRANSACTION_OUTPUT_CHUNK_SIZE),
-        };
-
-        GlobalDataSummary {
-            advertised_data: aggregate_data,
-            optimal_chunk_sizes: aggregate_chunk_sizes,
-        }
-    }
-}
-
-fn median<T: Ord + Copy>(values: &mut [T]) -> Option<T> {
-    values.sort_unstable();
-    let idx = values.len() / 2;
-    values.get(idx).copied()
 }

--- a/state-sync/diem-data-client/src/diemnet/state.rs
+++ b/state-sync/diem-data-client/src/diemnet/state.rs
@@ -1,16 +1,78 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{AdvertisedData, GlobalDataSummary, OptimalChunkSizes};
+use crate::{AdvertisedData, GlobalDataSummary, OptimalChunkSizes, ResponseError};
 use diem_config::network_id::PeerNetworkId;
 use std::collections::HashMap;
 use storage_service_types::{StorageServerSummary, StorageServiceRequest};
 
-#[derive(Debug, Default)]
+/// Scores for peer rankings based on preferences and behavior.
+const MAX_SCORE: f64 = 100.0;
+const MIN_SCORE: f64 = 0.0;
+const STARTING_SCORE: f64 = 50.0;
+/// Add this score on a successful response.
+const SUCCESSFUL_RESPONSE_DELTA: f64 = 1.0;
+/// Not necessarily a malicious response, but not super useful.
+const NOT_USEFUL_MULTIPLIER: f64 = 0.95;
+/// Likely to be a malicious response.
+const MALICIOUS_MULTIPLIER: f64 = 0.8;
+
+pub(crate) enum ErrorType {
+    /// A response or error that's not actively malicious but also doesn't help
+    /// us make progress, e.g., timeouts, remote errors, invalid data, etc...
+    NotUseful,
+    /// A response or error that appears to be actively hindering progress or
+    /// attempting to deceive us, e.g., invalid proof.
+    Malicious,
+}
+
+impl From<ResponseError> for ErrorType {
+    fn from(error: ResponseError) -> Self {
+        match error {
+            ResponseError::InvalidData | ResponseError::InvalidPayloadDataType => {
+                ErrorType::NotUseful
+            }
+            ResponseError::ProofVerificationError => ErrorType::Malicious,
+        }
+    }
+}
+
+#[derive(Debug)]
 struct PeerState {
+    /// The latest observed advertised data for this peer, or `None` if we
+    /// haven't polled them yet.
     storage_summary: Option<StorageServerSummary>,
-    // TODO(philiphayes): imagine storing some scoring info here.
-    metadata: (),
+    /// For now, a simplified port of the original state-sync v1 scoring system.
+    ///
+    /// Note: this doesn't include any of the "multicast" logic, since the
+    /// data-client API explicitly tries to maintain a 1-request => 1-response
+    /// model, so we don't really want to handle multicasting a single request
+    /// across many networks/peers. An consumer should be able to just send many
+    /// requests and it should just work^tm.
+    score: f64,
+}
+
+impl Default for PeerState {
+    fn default() -> Self {
+        Self {
+            storage_summary: None,
+            score: STARTING_SCORE,
+        }
+    }
+}
+
+impl PeerState {
+    fn update_score_success(&mut self) {
+        self.score = f64::min(self.score + SUCCESSFUL_RESPONSE_DELTA, MAX_SCORE);
+    }
+
+    fn update_score_error(&mut self, error: ErrorType) {
+        let multiplier = match error {
+            ErrorType::NotUseful => NOT_USEFUL_MULTIPLIER,
+            ErrorType::Malicious => MALICIOUS_MULTIPLIER,
+        };
+        self.score = f64::max(self.score * multiplier, MIN_SCORE);
+    }
 }
 
 /// Contains all of the unbanned peers' most recent [`StorageServerSummary`] data
@@ -46,6 +108,17 @@ impl PeerStates {
             .and_then(|peer_state| peer_state.storage_summary.as_ref())
             .map(|summary| summary.can_service(request))
             .unwrap_or(false)
+    }
+
+    pub fn update_score_success(&mut self, peer: PeerNetworkId) {
+        self.inner.entry(peer).or_default().update_score_success()
+    }
+
+    pub fn update_score_error(&mut self, peer: PeerNetworkId, error: ErrorType) {
+        self.inner
+            .entry(peer)
+            .or_default()
+            .update_score_error(error)
     }
 
     pub fn update_summary(&mut self, peer: PeerNetworkId, summary: StorageServerSummary) {

--- a/state-sync/diem-data-client/src/diemnet/state.rs
+++ b/state-sync/diem-data-client/src/diemnet/state.rs
@@ -1,0 +1,127 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{AdvertisedData, GlobalDataSummary, OptimalChunkSizes};
+use diem_config::network_id::PeerNetworkId;
+use std::collections::HashMap;
+use storage_service_types::{StorageServerSummary, StorageServiceRequest};
+
+#[derive(Debug, Default)]
+struct PeerState {
+    storage_summary: Option<StorageServerSummary>,
+    // TODO(philiphayes): imagine storing some scoring info here.
+    metadata: (),
+}
+
+/// Contains all of the unbanned peers' most recent [`StorageServerSummary`] data
+/// advertisements and data-client internal metadata for scoring.
+#[derive(Debug)]
+pub(crate) struct PeerStates {
+    inner: HashMap<PeerNetworkId, PeerState>,
+}
+
+impl PeerStates {
+    pub fn new() -> Self {
+        Self {
+            inner: HashMap::new(),
+        }
+    }
+
+    /// Returns true if a connected storage service peer can actually fulfill a
+    /// request, given our current view of their advertised data summary.
+    pub fn can_service_request(
+        &self,
+        peer: &PeerNetworkId,
+        request: &StorageServiceRequest,
+    ) -> bool {
+        // Storage services can always respond to data advertisement requests.
+        // We need this outer check, since we need to be able to send data summary
+        // requests to new peers (who don't have a peer state yet).
+        if request.is_get_storage_server_summary() {
+            return true;
+        }
+
+        self.inner
+            .get(peer)
+            .and_then(|peer_state| peer_state.storage_summary.as_ref())
+            .map(|summary| summary.can_service(request))
+            .unwrap_or(false)
+    }
+
+    pub fn update_summary(&mut self, peer: PeerNetworkId, summary: StorageServerSummary) {
+        self.inner.entry(peer).or_default().storage_summary = Some(summary);
+    }
+
+    pub fn aggregate_summary(&self) -> GlobalDataSummary {
+        let mut aggregate_data = AdvertisedData::empty();
+
+        let mut max_epoch_chunk_sizes = vec![];
+        let mut max_transaction_chunk_sizes = vec![];
+        let mut max_transaction_output_chunk_sizes = vec![];
+        let mut max_account_states_chunk_sizes = vec![];
+
+        let summaries = self
+            .inner
+            .values()
+            .filter_map(|state| state.storage_summary.as_ref());
+
+        // collect each peer's protocol and data advertisements
+        for summary in summaries {
+            // collect aggregate data advertisements
+            if let Some(account_states) = summary.data_summary.account_states {
+                aggregate_data.account_states.push(account_states);
+            }
+            if let Some(epoch_ending_ledger_infos) = summary.data_summary.epoch_ending_ledger_infos
+            {
+                aggregate_data
+                    .epoch_ending_ledger_infos
+                    .push(epoch_ending_ledger_infos);
+            }
+            if let Some(synced_ledger_info) = summary.data_summary.synced_ledger_info.as_ref() {
+                aggregate_data
+                    .synced_ledger_infos
+                    .push(synced_ledger_info.clone());
+            }
+            if let Some(transactions) = summary.data_summary.transactions {
+                aggregate_data.transactions.push(transactions);
+            }
+            if let Some(transaction_outputs) = summary.data_summary.transaction_outputs {
+                aggregate_data.transaction_outputs.push(transaction_outputs);
+            }
+
+            // collect preferred max chunk sizes
+            max_epoch_chunk_sizes.push(summary.protocol_metadata.max_epoch_chunk_size);
+            max_transaction_chunk_sizes.push(summary.protocol_metadata.max_transaction_chunk_size);
+            max_transaction_output_chunk_sizes
+                .push(summary.protocol_metadata.max_transaction_output_chunk_size);
+            max_account_states_chunk_sizes
+                .push(summary.protocol_metadata.max_account_states_chunk_size);
+        }
+
+        // take the median for each max chunk size parameter.
+        // this works well when we have an honest majority that mostly agrees on
+        // the same chunk sizes.
+        // TODO(philiphayes): move these constants somewhere?
+        let aggregate_chunk_sizes = OptimalChunkSizes {
+            account_states_chunk_size: median(&mut max_account_states_chunk_sizes)
+                .unwrap_or(storage_service_server::MAX_ACCOUNT_STATES_CHUNK_SIZE),
+            epoch_chunk_size: median(&mut max_epoch_chunk_sizes)
+                .unwrap_or(storage_service_server::MAX_EPOCH_CHUNK_SIZE),
+            transaction_chunk_size: median(&mut max_transaction_chunk_sizes)
+                .unwrap_or(storage_service_server::MAX_TRANSACTION_CHUNK_SIZE),
+            transaction_output_chunk_size: median(&mut max_transaction_output_chunk_sizes)
+                .unwrap_or(storage_service_server::MAX_TRANSACTION_OUTPUT_CHUNK_SIZE),
+        };
+
+        GlobalDataSummary {
+            advertised_data: aggregate_data,
+            optimal_chunk_sizes: aggregate_chunk_sizes,
+        }
+    }
+}
+
+fn median<T: Ord + Copy>(values: &mut [T]) -> Option<T> {
+    values.sort_unstable();
+    let idx = values.len() / 2;
+    values.get(idx).copied()
+}

--- a/state-sync/diem-data-client/src/diemnet/tests.rs
+++ b/state-sync/diem-data-client/src/diemnet/tests.rs
@@ -246,7 +246,7 @@ async fn bad_peer_is_eventually_banned_internal() {
                 )));
             } else if peer == bad_peer.peer_id() {
                 // bad peer responds with error
-                response_sender.send(Err(StorageServiceError::InternalError));
+                response_sender.send(Err(StorageServiceError::InternalError("".to_string())));
             }
         }
     });

--- a/state-sync/diem-data-client/src/diemnet/tests.rs
+++ b/state-sync/diem-data-client/src/diemnet/tests.rs
@@ -5,7 +5,7 @@ use super::{
     DataSummaryPoller, DiemDataClient, DiemNetDataClient, Error, DATA_SUMMARY_POLL_INTERVAL,
 };
 use channel::{diem_channel, message_queues::QueueStyle};
-use claim::assert_matches;
+use claim::{assert_err, assert_matches};
 use diem_config::network_id::{NetworkId, PeerNetworkId};
 use diem_crypto::HashValue;
 use diem_time_service::{MockTimeService, TimeService};
@@ -204,6 +204,171 @@ async fn test_request_works_only_when_data_available() {
         .get_transactions_with_proof(100, 50, 100, false)
         .await
         .unwrap();
+    assert_eq!(response.payload, TransactionListWithProof::new_empty());
+}
 
-    assert_eq!(response.payload, TransactionListWithProof::new_empty(),);
+// 1. 2 peers
+// 2. one advertises bad range, one advertises honest range
+// 3. sending a bunch of requests to the bad range (which will always go to the
+//    bad peer) should lower bad peer's score
+// 4. eventually bad peer score should hit threshold and we err with no available
+
+#[tokio::test]
+async fn bad_peer_is_eventually_banned_internal() {
+    ::diem_logger::Logger::init_for_testing();
+    let (mut mock_network, _mock_time, client, _poller) = MockNetwork::new();
+
+    let good_peer = mock_network.add_connected_peer();
+    let bad_peer = mock_network.add_connected_peer();
+
+    // bypass poller and just add the storage summaries directly
+
+    // good peer advertises txns 0 -> 100
+    client.update_summary(good_peer, mock_storage_summary(100));
+    // bad peer advertises txns 0 -> 200 (but can't actually service)
+    client.update_summary(bad_peer, mock_storage_summary(200));
+    client.update_global_summary_cache();
+
+    // the global summary should contain the bad peer's advertisement
+    let global_summary = client.get_global_data_summary();
+    assert!(global_summary
+        .advertised_data
+        .transactions
+        .contains(&CompleteDataRange::new(0, 200).unwrap()));
+
+    // spawn a handler for both peers
+    tokio::spawn(async move {
+        while let Some((peer, _, _, response_sender)) = mock_network.next_request().await {
+            if peer == good_peer.peer_id() {
+                // good peer responds with good response
+                response_sender.send(Ok(StorageServiceResponse::TransactionsWithProof(
+                    TransactionListWithProof::new_empty(),
+                )));
+            } else if peer == bad_peer.peer_id() {
+                // bad peer responds with error
+                response_sender.send(Err(StorageServiceError::InternalError));
+            }
+        }
+    });
+
+    let mut seen_data_unavailable_err = false;
+
+    // sending a bunch of requests to the bad peer's upper range will fail
+    for _ in 0..20 {
+        let result = client
+            .get_transactions_with_proof(200, 200, 200, false)
+            .await;
+
+        // while the score is still decreasing, we should see a bunch of
+        // InternalError's. once we see a `DataIsUnavailable` error, we should
+        // only see that error.
+        if !seen_data_unavailable_err {
+            assert_err!(&result);
+            if let Err(Error::DataIsUnavailable(_)) = result {
+                seen_data_unavailable_err = true;
+            }
+        } else {
+            assert_matches!(result, Err(Error::DataIsUnavailable(_)));
+        }
+    }
+
+    // peer should eventually get ignored and we should consider this request
+    // range unserviceable.
+    assert!(seen_data_unavailable_err);
+
+    // the global summary should no longer contain the bad peer's advertisement
+    client.update_global_summary_cache();
+    let global_summary = client.get_global_data_summary();
+    assert!(!global_summary
+        .advertised_data
+        .transactions
+        .contains(&CompleteDataRange::new(0, 200).unwrap()));
+
+    // we should still be able to send the good peer a request
+    let response = client
+        .get_transactions_with_proof(100, 50, 100, false)
+        .await
+        .unwrap();
+    assert_eq!(response.payload, TransactionListWithProof::new_empty());
+}
+
+#[tokio::test]
+async fn bad_peer_is_eventually_banned_callback() {
+    ::diem_logger::Logger::init_for_testing();
+    let (mut mock_network, _mock_time, client, _poller) = MockNetwork::new();
+
+    let good_peer = mock_network.add_connected_peer();
+    let bad_peer = mock_network.add_connected_peer();
+
+    // bypass poller and just add the storage summaries directly
+
+    // good peer advertises txns 0 -> 100
+    client.update_summary(good_peer, mock_storage_summary(100));
+    // bad peer advertises txns 0 -> 200 (but can't actually service)
+    client.update_summary(bad_peer, mock_storage_summary(200));
+    client.update_global_summary_cache();
+
+    // the global summary should contain the bad peer's advertisement
+    let global_summary = client.get_global_data_summary();
+    assert!(global_summary
+        .advertised_data
+        .transactions
+        .contains(&CompleteDataRange::new(0, 200).unwrap()));
+
+    // spawn a handler for both peers
+    tokio::spawn(async move {
+        while let Some((_, _, _, response_sender)) = mock_network.next_request().await {
+            response_sender.send(Ok(StorageServiceResponse::TransactionsWithProof(
+                TransactionListWithProof::new_empty(),
+            )));
+        }
+    });
+
+    let mut seen_data_unavailable_err = false;
+
+    // sending a bunch of requests to the bad peer (that we later decide are bad)
+    for _ in 0..20 {
+        let result = client
+            .get_transactions_with_proof(200, 200, 200, false)
+            .await;
+
+        // while the score is still decreasing, we should see a bunch of
+        // InternalError's. once we see a `DataIsUnavailable` error, we should
+        // only see that error.
+        if !seen_data_unavailable_err {
+            match result {
+                Ok(response) => {
+                    response
+                        .context
+                        .response_callback
+                        .notify_bad_response(crate::ResponseError::ProofVerificationError);
+                }
+                Err(Error::DataIsUnavailable(_)) => {
+                    seen_data_unavailable_err = true;
+                }
+                Err(_) => panic!("unexpected result: {:?}", result),
+            }
+        } else {
+            assert_matches!(result, Err(Error::DataIsUnavailable(_)));
+        }
+    }
+
+    // peer should eventually get ignored and we should consider this request
+    // range unserviceable.
+    assert!(seen_data_unavailable_err);
+
+    // the global summary should no longer contain the bad peer's advertisement
+    client.update_global_summary_cache();
+    let global_summary = client.get_global_data_summary();
+    assert!(!global_summary
+        .advertised_data
+        .transactions
+        .contains(&CompleteDataRange::new(0, 200).unwrap()));
+
+    // we should still be able to send the good peer a request
+    let response = client
+        .get_transactions_with_proof(100, 50, 100, false)
+        .await
+        .unwrap();
+    assert_eq!(response.payload, TransactionListWithProof::new_empty());
 }

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -122,10 +122,10 @@ async fn test_get_storage_server_summary() {
                 highest_epoch,
                 highest_version,
             )),
-            epoch_ending_ledger_infos: Some(CompleteDataRange::from_genesis(highest_epoch - 1)),
-            transactions: Some(CompleteDataRange::from_genesis(highest_version)),
-            transaction_outputs: Some(CompleteDataRange::from_genesis(highest_version)),
-            account_states: Some(CompleteDataRange::from_genesis(highest_version)),
+            epoch_ending_ledger_infos: Some(CompleteDataRange::new(0, highest_epoch - 1).unwrap()),
+            transactions: Some(CompleteDataRange::new(0, highest_version).unwrap()),
+            transaction_outputs: Some(CompleteDataRange::new(0, highest_version).unwrap()),
+            account_states: Some(CompleteDataRange::new(0, highest_version).unwrap()),
         },
     };
     assert_eq!(

--- a/state-sync/storage-service/types/Cargo.toml
+++ b/state-sync/storage-service/types/Cargo.toml
@@ -19,3 +19,5 @@ diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [dev-dependencies]
+claim = "0.5.0"
+proptest = "1.0.0"


### PR DESCRIPTION
this PR ports part of the state-sync-v1 peer scoring system to the DiemNet data client. summarizing the scoring system:

```
1. peers start at score 50
2. when receive peer response:
3.     if good response:
4.         peer.score = min(peer.score + 1, 100)
5.     else if not useful response:
6.         peer.score = max(peer.score * 0.95, 0)
7.     else if malicious response:
8.         peer.score = max(peer.score * 0.8, 0)
```

one notably absent piece is the logic around "multicasting" state-sync-v1 requests across multiple networks. the current data client model explicitly tries to maintain a 1-request => 1-response model, so the multicasting logic is not necessary.

if a peer's score drops below 25, we ignore them and drop their entries from the `GlobalDataSummary`. their scores will slowly recover (assuming they recover or stop acting maliciously) by the natural `get_storage_summary` calls from the `DataSummaryPoller`. I think there's also an argument to be made that we should _only_ drop them from the `GlobalDataSummary` but still include them in the set of possible peers to send a request to.

for now, we only use this score for banning/ignoring peers (since that's the most critical piece needed to ensure robustness against attackers).

in order to make the peer scoring work properly, this PR also fleshes out the `DataSummary::can_service` and `ProtocolMetadata::can_service` methods, allowing us to properly filter out peers that can't service a request based on their current advertised data availability.

finally, this PR adds an invariant to the `CompleteDataRange` type in which the range length must always be expressible without overflowing. attempting to construct or deserialize a "degenerate" range will fail with an `Err`.