### PR TITLE
[shuffle] refactored files to use updated .shuffle folder structure

### DIFF
--- a/shuffle/cli/src/account.rs
+++ b/shuffle/cli/src/account.rs
@@ -1,9 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{send_transaction, Home};
-use anyhow::{anyhow, Context, Result};
-use diem_config::config::NodeConfig;
+use crate::shared::{send_transaction, Home, Network, NetworkHome, LOCALHOST_NAME};
+use anyhow::{anyhow, Result};
 use diem_crypto::PrivateKey;
 
 use diem_infallible::duration_since_epoch;
@@ -29,122 +28,127 @@ use std::{
 };
 
 // Creates new account from randomly generated private/public key pair.
-pub fn handle(home: &Home, root: Option<PathBuf>) -> Result<()> {
-    if !home.get_shuffle_path().is_dir() {
-        return Err(anyhow!(
-            "A node hasn't been created yet! Run shuffle node first"
-        ));
-    }
+pub fn handle(home: &Home, root: Option<PathBuf>, network: Network) -> Result<()> {
+    let network_home =
+        NetworkHome::new(home.get_networks_path().join(network.get_name()).as_path());
+    check_nodeconfig_exists_if_localhost_used(home, &network)?;
 
-    if home.get_latest_path().exists() {
-        let wants_another_key = confirm_user_decision(home);
-        if wants_another_key {
-            let time = duration_since_epoch();
-            let archive_dir = home.create_archive_dir(time)?;
-            home.archive_old_key(&archive_dir)?;
-            home.archive_old_address(&archive_dir)?;
-        } else {
-            return Ok(());
+    if network_home.get_latest_account_path().exists() {
+        match user_wants_another_key(&network_home) {
+            true => archive_current_files_in_latest(&network_home)?,
+            false => return Ok(()),
         }
     }
 
-    let config = NodeConfig::load(&home.get_validator_config_path()).with_context(|| {
-        format!(
-            "Failed to load NodeConfig from file: {:?}",
-            home.get_validator_config_path()
-        )
-    })?;
-    let json_rpc_url = format!("http://0.0.0.0:{}", config.json_rpc.address.port());
-    println!("Connecting to {}...", json_rpc_url);
-    let client = BlockingClient::new(json_rpc_url);
-    if root.is_some() {
-        home.save_root_key(
-            root.ok_or_else(|| anyhow::anyhow!("Invalid root key path"))?
-                .as_path(),
-        )?;
-    }
-    let mut treasury_account = get_treasury_account(&client, home.get_root_key_path());
+    network_home.generate_network_base_path_if_nonexistent()?;
 
-    create_local_accounts(home, client, &mut treasury_account)
-}
-
-pub fn create_local_accounts(
-    home: &Home,
-    client: BlockingClient,
-    treasury_account: &mut LocalAccount,
-) -> Result<()> {
+    println!("Connecting to {}...", network.get_json_rpc_url()?);
+    let client = BlockingClient::new(network.get_json_rpc_url()?);
     let factory = TransactionFactory::new(ChainId::test());
 
-    home.generate_shuffle_accounts_path()?;
-    home.generate_shuffle_latest_path()?;
+    if let Some(input_root_key) = root {
+        network_home.save_root_key(input_root_key.as_path())?
+    }
 
-    let new_account_key = home.generate_key_file()?;
-    let public_key = new_account_key.public_key();
-    home.generate_address_file(&public_key)?;
-    let new_account = LocalAccount::new(
-        AuthenticationKey::ed25519(&public_key).derived_address(),
-        new_account_key,
-        0,
-    );
+    network_home.generate_network_accounts_path_if_nonexistent()?;
+    network_home.generate_network_latest_account_path_if_nonexistent()?;
 
-    // Create a new account.
-    create_account_onchain(treasury_account, &new_account, &factory, &client)?;
+    let mut treasury_account = get_treasury_account(&client, home.get_root_key_path())?;
+    let new_account = generate_new_account(&network_home)?;
+    create_local_account(&mut treasury_account, &new_account, &factory, &client)?;
 
-    home.generate_shuffle_test_path()?;
-    let test_key = home.generate_testkey_file()?;
-    let public_test_key = test_key.public_key();
-    home.generate_testkey_address_file(&test_key.public_key())?;
-    let test_account = LocalAccount::new(
-        AuthenticationKey::ed25519(&public_test_key).derived_address(),
-        test_key,
-        0,
-    );
-
-    create_account_onchain(treasury_account, &test_account, &factory, &client)
+    network_home.generate_shuffle_test_path_if_nonexistent()?;
+    let test_account = generate_test_account(&network_home)?;
+    create_local_account(&mut treasury_account, &test_account, &factory, &client)
 }
 
-pub fn confirm_user_decision(home: &Home) -> bool {
-    let key_path = home.get_latest_key_path();
-    let prev_key = generate_key::load_key(&key_path);
+fn check_nodeconfig_exists_if_localhost_used(home: &Home, network: &Network) -> Result<()> {
+    match network.get_name().as_str() {
+        LOCALHOST_NAME => match home.get_node_config_path().is_dir() {
+            true => Ok(()),
+            false => Err(anyhow!(
+                "A node hasn't been created yet! Run shuffle node first"
+            )),
+        },
+        _ => Ok(()),
+    }
+}
+
+fn user_wants_another_key(network_home: &NetworkHome) -> bool {
+    let key_path = network_home.get_latest_account_key_path();
+    let prev_public_key = generate_key::load_key(&key_path).public_key();
     println!(
-        "Private Key already exists: {}",
-        ::hex::encode(prev_key.to_bytes())
+        "Public Key already exists: {}",
+        ::hex::encode(prev_public_key.to_bytes())
     );
     println!("Are you sure you want to generate a new key? [y/n]");
 
-    let mut user_response = String::new();
+    let user_response = ask_user_if_they_want_key(String::new());
+    delegate_user_response(user_response.as_str())
+}
+
+fn ask_user_if_they_want_key(mut user_response: String) -> String {
     io::stdin()
         .read_line(&mut user_response)
         .expect("Failed to read line");
-    let user_response = user_response.trim().to_owned();
-
-    if user_response != "y" && user_response != "n" {
-        println!("Please restart and enter either y or n");
-        return false;
-    } else if user_response == "n" {
-        return false;
-    }
-
-    true
+    user_response.trim().to_owned()
 }
 
-pub fn get_treasury_account(client: &BlockingClient, root_key_path: &Path) -> LocalAccount {
-    let root_account_key = load_key(root_key_path);
+fn delegate_user_response(user_response: &str) -> bool {
+    match user_response {
+        "y" => true,
+        "n" => false,
+        _ => {
+            println!("Please restart and enter either y or n");
+            false
+        }
+    }
+}
 
+fn archive_current_files_in_latest(network_home: &NetworkHome) -> Result<()> {
+    let time = duration_since_epoch();
+    let archive_dir = network_home.create_archive_dir(time)?;
+    network_home.archive_old_key(&archive_dir)?;
+    network_home.archive_old_address(&archive_dir)
+}
+
+fn generate_new_account(network_home: &NetworkHome) -> Result<LocalAccount> {
+    let new_account_key = network_home.generate_key_file()?;
+    let public_key = new_account_key.public_key();
+    network_home.generate_address_file(&public_key)?;
+    Ok(LocalAccount::new(
+        AuthenticationKey::ed25519(&public_key).derived_address(),
+        new_account_key,
+        0,
+    ))
+}
+
+fn generate_test_account(network_home: &NetworkHome) -> Result<LocalAccount> {
+    let test_key = network_home.generate_testkey_file()?;
+    let public_test_key = test_key.public_key();
+    network_home.generate_testkey_address_file(&test_key.public_key())?;
+    Ok(LocalAccount::new(
+        AuthenticationKey::ed25519(&public_test_key).derived_address(),
+        test_key,
+        0,
+    ))
+}
+
+pub fn get_treasury_account(client: &BlockingClient, root_key_path: &Path) -> Result<LocalAccount> {
+    let treasury_account_key = load_key(root_key_path);
     let treasury_seq_num = client
-        .get_account(account_config::treasury_compliance_account_address())
-        .unwrap()
+        .get_account(account_config::treasury_compliance_account_address())?
         .into_inner()
         .unwrap()
         .sequence_number;
-    LocalAccount::new(
+    Ok(LocalAccount::new(
         account_config::treasury_compliance_account_address(),
-        root_account_key,
+        treasury_account_key,
         treasury_seq_num,
-    )
+    ))
 }
 
-pub fn create_account_onchain(
+pub fn create_local_account(
     treasury_account: &mut LocalAccount,
     new_account: &LocalAccount,
     factory: &TransactionFactory,
@@ -172,10 +176,6 @@ pub fn create_account_onchain(
         send_transaction(client, create_new_account_txn)?;
         println!("Successfully created account {}", new_account.address());
     }
-    println!(
-        "Private key: {}",
-        ::hex::encode(new_account.private_key().to_bytes())
-    );
     println!("Public key: {}", new_account.public_key());
     Ok(())
 }
@@ -203,4 +203,43 @@ fn encode_create_parent_vasp_account_script_function(
             bcs::to_bytes(&add_all_currencies).unwrap(),
         ],
     ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::shared;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_check_nodeconfig_exists_if_localhost_used() {
+        let tmpdir = tempdir().unwrap();
+        let dir_path = tmpdir.path();
+        let home = Home::new(dir_path).unwrap();
+        assert_eq!(
+            check_nodeconfig_exists_if_localhost_used(&home, &shared::Network::default()).is_err(),
+            true
+        );
+        fs::create_dir_all(dir_path.join(".shuffle/nodeconfig")).unwrap();
+        assert_eq!(
+            check_nodeconfig_exists_if_localhost_used(&home, &shared::Network::default()).is_err(),
+            false
+        );
+    }
+
+    #[test]
+    fn test_delegate_user_response() {
+        assert_eq!(delegate_user_response("a"), false);
+        assert_eq!(delegate_user_response("n"), false);
+        assert_eq!(delegate_user_response("y"), true);
+    }
+
+    #[test]
+    fn test_ask_user_if_they_want_key() {
+        assert_eq!(ask_user_if_they_want_key("y".to_string()), "y".to_string());
+        assert_eq!(ask_user_if_they_want_key("y ".to_string()), "y".to_string());
+        assert_eq!(ask_user_if_they_want_key("n".to_string()), "n".to_string());
+        assert_eq!(ask_user_if_they_want_key("n ".to_string()), "n".to_string());
+    }
 }

--- a/shuffle/cli/src/console.rs
+++ b/shuffle/cli/src/console.rs
@@ -1,18 +1,17 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared;
+use crate::{shared, shared::Network};
 use anyhow::Result;
 use diem_types::account_address::AccountAddress;
 use std::{path::Path, process::Command};
-use url::Url;
 
 /// Launches a Deno REPL for the shuffle project, generating transaction
 /// builders and loading them into the REPL namespace for easy on chain interaction.
 pub fn handle(
     home: &shared::Home,
     project_path: &Path,
-    network: Url,
+    network: Network,
     key_path: &Path,
     sender_address: AccountAddress,
 ) -> Result<()> {
@@ -50,7 +49,7 @@ pub fn handle(
             .to_string_lossy()
     );
     let filtered_envs =
-        shared::get_filtered_envs_for_deno(home, project_path, &network, key_path, sender_address);
+        shared::get_filtered_envs_for_deno(home, project_path, &network, key_path, sender_address)?;
     Command::new("deno")
         .args(["repl", "--unstable", "--eval", deno_bootstrap.as_str()])
         .envs(&filtered_envs)

--- a/shuffle/cli/src/deploy.rs
+++ b/shuffle/cli/src/deploy.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{build_move_package, DevApiClient, Home, MAIN_PKG_PATH};
+use crate::shared::{build_move_package, DevApiClient, NetworkHome, MAIN_PKG_PATH};
 use anyhow::{anyhow, Result};
 use diem_crypto::PrivateKey;
 use diem_sdk::{
@@ -24,14 +24,14 @@ use std::{
 use url::Url;
 
 /// Deploys shuffle's main Move Package to the sender's address.
-pub async fn handle(home: &Home, project_path: &Path, network: Url) -> Result<()> {
+pub async fn handle(network_home: &NetworkHome, project_path: &Path, network: Url) -> Result<()> {
     let client = DevApiClient::new(reqwest::Client::new(), network)?;
-    if !home.get_latest_key_path().exists() {
+    if !network_home.get_latest_account_key_path().exists() {
         return Err(anyhow!(
             "An account hasn't been created yet! Run shuffle account first."
         ));
     }
-    let new_account_key = load_key(home.get_latest_key_path());
+    let new_account_key = load_key(network_home.get_latest_account_key_path());
     println!("Using Public Key {}", &new_account_key.public_key());
     let derived_address =
         AuthenticationKey::ed25519(&new_account_key.public_key()).derived_address();

--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -35,7 +35,7 @@ pub async fn main() -> Result<()> {
             network,
         } => {
             deploy::handle(
-                &home.get_network_home(normalized_network_name(network.clone()).as_str()),
+                &home.new_network_home(normalized_network_name(network.clone()).as_str()),
                 &shared::normalized_project_path(project_path)?,
                 shared::normalized_network_url(&home, network)?,
             )
@@ -59,11 +59,11 @@ pub async fn main() -> Result<()> {
             &shared::normalized_project_path(project_path)?,
             home.get_network_struct_from_toml(normalized_network_name(network.clone()).as_str())?,
             &normalized_key_path(
-                home.get_network_home(normalized_network_name(network.clone()).as_str()),
+                home.new_network_home(normalized_network_name(network.clone()).as_str()),
                 key_path,
             )?,
             normalized_address(
-                home.get_network_home(normalized_network_name(network).as_str()),
+                home.new_network_home(normalized_network_name(network).as_str()),
                 address,
             )?,
         ),
@@ -77,7 +77,7 @@ pub async fn main() -> Result<()> {
                 shared::normalized_network_url(&home, network.clone())?,
                 unwrap_nested_boolean_option(tail),
                 normalized_address(
-                    home.get_network_home(normalized_network_name(network.clone()).as_str()),
+                    home.new_network_home(normalized_network_name(network.clone()).as_str()),
                     address,
                 )?,
                 unwrap_nested_boolean_option(raw),

--- a/shuffle/cli/src/node.rs
+++ b/shuffle/cli/src/node.rs
@@ -5,15 +5,12 @@ use crate::{shared, shared::Home};
 use anyhow::Result;
 use diem_config::config::NodeConfig;
 use diem_types::{chain_id::ChainId, on_chain_config::VMPublishingOption};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 const LAZY_ENABLED: bool = true;
 
 pub fn handle(home: &Home, genesis: Option<String>) -> Result<()> {
-    if !home.get_shuffle_path().is_dir() {
+    if !home.get_node_config_path().is_dir() {
         println!(
             "Creating node config in {}",
             home.get_shuffle_path().display()
@@ -38,8 +35,6 @@ pub fn handle(home: &Home, genesis: Option<String>) -> Result<()> {
 }
 
 fn create_node(home: &Home, genesis: Option<String>) -> Result<()> {
-    fs::create_dir_all(home.get_shuffle_path())?;
-    home.write_default_networks_config_into_toml()?;
     let publishing_option = VMPublishingOption::open();
     let genesis_modules = genesis_modules_from_path(&genesis)?;
     diem_node::load_test_environment(

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -27,7 +27,7 @@ use transaction_builder_generator::SourceInstaller as BuildgenSourceInstaller;
 use url::Url;
 
 pub const MAIN_PKG_PATH: &str = "main";
-const NEW_KEY_FILE_CONTENT: &[u8] = include_bytes!("../new_account.key");
+pub const NEW_KEY_FILE_CONTENT: &[u8] = include_bytes!("../new_account.key");
 const DIEM_ACCOUNT_TYPE: &str = "0x1::DiemAccount::DiemAccount";
 
 pub const LOCALHOST_NAME: &str = "localhost";

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -36,8 +36,8 @@ pub async fn run_e2e_tests(
     let _config = shared::read_project_config(project_path)?;
     shared::generate_typescript_libraries(project_path)?;
 
-    println!("Connecting to {}...", network.get_json_rpc_url()?);
-    let client = BlockingClient::new(network.get_json_rpc_url()?.as_str());
+    println!("Connecting to {}...", network.get_json_rpc_url());
+    let client = BlockingClient::new(network.get_json_rpc_url().as_str());
     let factory = TransactionFactory::new(ChainId::test());
 
     let test_account = create_account(
@@ -52,7 +52,7 @@ pub async fn run_e2e_tests(
         &client,
         &factory,
     )?;
-    deploy::handle(&network_home, project_path, network.get_dev_api_url()?).await?;
+    deploy::handle(&network_home, project_path, network.get_dev_api_url()).await?;
 
     run_deno_test(
         home,
@@ -75,7 +75,7 @@ fn create_account(
     let public_key = account_key.public_key();
     let derived_address = AuthenticationKey::ed25519(&public_key).derived_address();
     let new_account = LocalAccount::new(derived_address, account_key, 0);
-    account::create_local_account(&mut treasury_account, &new_account, factory, client)?;
+    account::create_account_onchain(&mut treasury_account, &new_account, factory, client)?;
     Ok(new_account)
 }
 
@@ -116,8 +116,8 @@ pub fn run_deno_test_at_path(
             "--allow-read",
             format!(
                 "--allow-net={},{}",
-                host_and_port(&network.get_dev_api_url()?)?,
-                host_and_port(&network.get_json_rpc_url()?)?,
+                host_and_port(&network.get_dev_api_url())?,
+                host_and_port(&network.get_json_rpc_url())?,
             )
             .as_str(),
         ])

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -3,10 +3,9 @@
 
 use crate::{
     account, deploy,
-    shared::{self, MAIN_PKG_PATH},
+    shared::{self, normalized_network_name, Home, Network, NetworkHome, MAIN_PKG_PATH},
 };
-use anyhow::{anyhow, Context, Result};
-use diem_config::config::NodeConfig;
+use anyhow::{anyhow, Result};
 use diem_crypto::PrivateKey;
 use diem_sdk::{
     client::{AccountAddress, BlockingClient},
@@ -17,51 +16,49 @@ use diem_types::{chain_id::ChainId, transaction::authenticator::AuthenticationKe
 use move_cli::package::cli::{self, UnitTestResult};
 use move_package::BuildConfig;
 use move_unit_test::UnitTestingConfig;
-use shared::Home;
 use std::{
     path::{Path, PathBuf},
     process::{Command, ExitStatus},
-    str::FromStr,
 };
 use structopt::StructOpt;
 use url::Url;
 
-pub async fn run_e2e_tests(home: &Home, project_path: &Path, network: Url) -> Result<ExitStatus> {
+pub async fn run_e2e_tests(
+    home: &Home,
+    project_path: &Path,
+    network: Network,
+) -> Result<ExitStatus> {
+    let network_home = NetworkHome::new(
+        home.get_networks_path()
+            .join(shared::LOCALHOST_NAME)
+            .as_path(),
+    );
     let _config = shared::read_project_config(project_path)?;
     shared::generate_typescript_libraries(project_path)?;
 
-    let config = NodeConfig::load(&home.get_validator_config_path()).with_context(|| {
-        format!(
-            "Failed to load NodeConfig from file: {:?}",
-            home.get_validator_config_path()
-        )
-    })?;
-    println!("Connecting to {}...", network.as_str());
-    let client = BlockingClient::new(network.as_str());
+    println!("Connecting to {}...", network.get_json_rpc_url()?);
+    let client = BlockingClient::new(network.get_json_rpc_url()?.as_str());
     let factory = TransactionFactory::new(ChainId::test());
 
     let test_account = create_account(
         home.get_root_key_path(),
-        home.get_test_key_path(),
+        network_home.get_test_key_path(),
         &client,
         &factory,
     )?;
     let _receiver_account = create_account(
         home.get_root_key_path(),
-        home.get_test_key_path(), // TODO: update to a different key to sender
+        network_home.get_test_key_path(), // TODO: update to a different key to sender
         &client,
         &factory,
     )?;
-    deploy::handle(home, project_path, network.clone()).await?;
+    deploy::handle(&network_home, project_path, network.get_dev_api_url()?).await?;
 
     run_deno_test(
         home,
         project_path,
-        &Url::from_str(
-            ("http://".to_owned() + config.json_rpc.address.to_string().as_str()).as_str(),
-        )?,
         &network,
-        home.get_test_key_path(),
+        network_home.get_test_key_path(),
         test_account.address(),
     )
 }
@@ -72,21 +69,20 @@ fn create_account(
     client: &BlockingClient,
     factory: &TransactionFactory,
 ) -> Result<LocalAccount> {
-    let mut treasury_account = account::get_treasury_account(client, root_key_path);
+    let mut treasury_account = account::get_treasury_account(client, root_key_path)?;
     // TODO: generate random key by using let account_key = generate_key::generate_key();
     let account_key = generate_key::load_key(account_key_path);
     let public_key = account_key.public_key();
     let derived_address = AuthenticationKey::ed25519(&public_key).derived_address();
     let new_account = LocalAccount::new(derived_address, account_key, 0);
-    account::create_account_onchain(&mut treasury_account, &new_account, factory, client)?;
+    account::create_local_account(&mut treasury_account, &new_account, factory, client)?;
     Ok(new_account)
 }
 
 pub fn run_deno_test(
     home: &Home,
     project_path: &Path,
-    json_rpc_url: &Url,
-    dev_api_url: &Url,
+    network: &Network,
     key_path: &Path,
     sender_address: AccountAddress,
 ) -> Result<ExitStatus> {
@@ -94,8 +90,7 @@ pub fn run_deno_test(
     run_deno_test_at_path(
         home,
         project_path,
-        json_rpc_url,
-        dev_api_url,
+        network,
         key_path,
         sender_address,
         &test_path,
@@ -105,30 +100,24 @@ pub fn run_deno_test(
 pub fn run_deno_test_at_path(
     home: &Home,
     project_path: &Path,
-    json_rpc_url: &Url,
-    dev_api_url: &Url,
+    network: &Network,
     key_path: &Path,
     sender_address: AccountAddress,
     test_path: &Path,
 ) -> Result<ExitStatus> {
-    let filtered_envs = shared::get_filtered_envs_for_deno(
-        home,
-        project_path,
-        dev_api_url,
-        key_path,
-        sender_address,
-    );
+    let filtered_envs =
+        shared::get_filtered_envs_for_deno(home, project_path, network, key_path, sender_address)?;
     let status = Command::new("deno")
         .args([
             "test",
             "--unstable",
             test_path.to_string_lossy().as_ref(),
-            "--allow-env=PROJECT_PATH,SHUFFLE_HOME,SHUFFLE_NETWORK,PRIVATE_KEY_PATH,SENDER_ADDRESS",
+            "--allow-env=PROJECT_PATH,SHUFFLE_BASE_NETWORKS_PATH,SHUFFLE_NETWORK_NAME,SHUFFLE_NETWORK_DEV_API_URL,PRIVATE_KEY_PATH,SENDER_ADDRESS",
             "--allow-read",
             format!(
                 "--allow-net={},{}",
-                host_and_port(dev_api_url)?,
-                host_and_port(json_rpc_url)?,
+                host_and_port(&network.get_dev_api_url()?)?,
+                host_and_port(&network.get_json_rpc_url()?)?,
             )
             .as_str(),
         ])
@@ -211,7 +200,9 @@ pub async fn handle(home: &Home, cmd: TestCommand) -> Result<()> {
             run_e2e_tests(
                 home,
                 shared::normalized_project_path(project_path)?.as_path(),
-                shared::normalized_network(home, network)?,
+                home.get_network_struct_from_toml(
+                    normalized_network_name(network.clone()).as_str(),
+                )?,
             )
             .await?
         }
@@ -227,7 +218,9 @@ pub async fn handle(home: &Home, cmd: TestCommand) -> Result<()> {
             let e2e_status = run_e2e_tests(
                 home,
                 normalized_path.as_path(),
-                shared::normalized_network(home, network)?,
+                home.get_network_struct_from_toml(
+                    normalized_network_name(network.clone()).as_str(),
+                )?,
             )
             .await?;
 

--- a/shuffle/integration-tests/src/helper.rs
+++ b/shuffle/integration-tests/src/helper.rs
@@ -2,14 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use diem_sdk::{client::BlockingClient, types::LocalAccount};
-use shuffle::{account, deploy, new, shared::Home};
+use diem_sdk::{
+    client::BlockingClient, transaction_builder::TransactionFactory, types::LocalAccount,
+};
+use shuffle::{
+    account, deploy, new,
+    shared::{Home, NetworkHome, LOCALHOST_NAME},
+};
 use std::{path::PathBuf, str::FromStr};
 use tempfile::TempDir;
 use url::Url;
 
 pub struct ShuffleTestHelper {
     home: Home,
+    network_home: NetworkHome,
     tmp_dir: TempDir,
 }
 
@@ -17,11 +23,20 @@ impl ShuffleTestHelper {
     pub fn new() -> Result<Self> {
         let tmp_dir = TempDir::new()?;
         let home = Home::new(tmp_dir.path())?;
-        Ok(Self { tmp_dir, home })
+        let network_home = home.get_network_home(LOCALHOST_NAME);
+        Ok(Self {
+            home,
+            network_home,
+            tmp_dir,
+        })
     }
 
     pub fn home(&self) -> &Home {
         &self.home
+    }
+
+    pub fn network_home(&self) -> NetworkHome {
+        self.home.get_network_home(LOCALHOST_NAME)
     }
 
     pub fn project_path(&self) -> PathBuf {
@@ -31,17 +46,23 @@ impl ShuffleTestHelper {
     pub fn create_accounts(
         &self,
         treasury_account: &mut LocalAccount,
+        new_account: LocalAccount,
+        factory: TransactionFactory,
         client: BlockingClient,
     ) -> Result<()> {
-        account::create_local_accounts(&self.home, client, treasury_account)
+        account::create_local_account(treasury_account, &new_account, &factory, &client)
     }
 
     pub fn create_project(&self) -> Result<()> {
-        new::handle(new::DEFAULT_BLOCKCHAIN.to_string(), self.project_path())
+        new::handle(
+            &self.home,
+            new::DEFAULT_BLOCKCHAIN.to_string(),
+            self.project_path(),
+        )
     }
 
     pub async fn deploy_project(&self, dev_api_url: &str) -> Result<()> {
         let url = Url::from_str(dev_api_url)?;
-        deploy::handle(&self.home, &self.project_path(), url).await
+        deploy::handle(&self.network_home, &self.project_path(), url).await
     }
 }

--- a/shuffle/integration-tests/src/lib.rs
+++ b/shuffle/integration-tests/src/lib.rs
@@ -67,7 +67,8 @@ fn bootstrap_shuffle(ctx: &mut AdminContext<'_>) -> Result<ShuffleTestHelper> {
     let helper = ShuffleTestHelper::new(ctx.chain_info())?;
     helper.create_project()?;
 
-    let mut account = ctx.random_account();
+    // let mut account = ctx.random_account(); // TODO: Support arbitrary addresses
+    let mut account = ShuffleTestHelper::hardcoded_0x2416_account(&client)?;
     let tc = ctx.chain_info().treasury_compliance_account();
     helper.create_account(tc, &account, factory, client)?;
 

--- a/shuffle/move/examples/integration/devapi.test.ts
+++ b/shuffle/move/examples/integration/devapi.test.ts
@@ -14,7 +14,7 @@ Deno.test("ledgerInfo", async () => {
 
 Deno.test("sequenceNumber", async () => {
   const actual = await devapi.sequenceNumber();
-  assertEquals(actual, 0);
+  assert(Number.isInteger(actual));
 });
 
 Deno.test("transactions", async () => {
@@ -25,7 +25,7 @@ Deno.test("transactions", async () => {
 
 Deno.test("accountTransactions", async () => {
   const actual = await devapi.accountTransactions();
-  assertEquals(actual.length, 0);
+  assert(Array.isArray(actual));
 });
 
 Deno.test("resources", async () => {

--- a/shuffle/move/examples/main/context.ts
+++ b/shuffle/move/examples/main/context.ts
@@ -6,10 +6,11 @@ import urlcat from "https://deno.land/x/urlcat@v2.0.4/src/index.ts";
 import { BcsDeserializer } from "./generated/bcs/mod.ts";
 import { isURL } from "https://deno.land/x/is_url@v1.0.1/mod.ts";
 
-export const shuffleDir = String(Deno.env.get("SHUFFLE_HOME"));
+export const shuffleBaseNetworksPath = String(Deno.env.get("SHUFFLE_BASE_NETWORKS_PATH"));
 export const projectPath = String(Deno.env.get("PROJECT_PATH"));
+export const networkName = String(Deno.env.get("SHUFFLE_NETWORK_NAME"))
 export const nodeUrl = getNetworkEndpoint(
-  String(Deno.env.get("SHUFFLE_NETWORK")),
+  String(Deno.env.get("SHUFFLE_NETWORK_DEV_API_URL")),
 );
 export const senderAddress = String(Deno.env.get("SENDER_ADDRESS"));
 export const privateKeyPath = String(Deno.env.get("PRIVATE_KEY_PATH"));
@@ -18,12 +19,14 @@ const privateKeyBytes = bcsToBytes(
 );
 
 export const receiverPrivateKeyPath = path.join(
-  shuffleDir,
-  "accounts/test/dev.key",
+    shuffleBaseNetworksPath,
+    networkName,
+    "accounts/test/dev.key",
 );
 export const receiverAddressPath = path.join(
-  shuffleDir,
-  "accounts/test/address",
+    shuffleBaseNetworksPath,
+    networkName,
+    "accounts/test/address",
 );
 export const receiverAddress = await Deno.readTextFile(receiverAddressPath);
 

--- a/shuffle/move/examples/main/context.ts
+++ b/shuffle/move/examples/main/context.ts
@@ -18,18 +18,6 @@ const privateKeyBytes = bcsToBytes(
   await Deno.readFile(privateKeyPath)
 );
 
-export const receiverPrivateKeyPath = path.join(
-    shuffleBaseNetworksPath,
-    networkName,
-    "accounts/test/dev.key",
-);
-export const receiverAddressPath = path.join(
-    shuffleBaseNetworksPath,
-    networkName,
-    "accounts/test/address",
-);
-export const receiverAddress = await Deno.readTextFile(receiverAddressPath);
-
 export function privateKey(): Uint8Array {
   return privateKeyBytes.slice(0);
 }

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -34,14 +34,15 @@ export async function transaction(versionOrHash: string) {
 // Polls for a specific transaction to complete, returning the `success`
 // field when no longer pending.
 export async function transactionSuccess(versionOrHash: string): Promise<boolean> {
+  let txn = await transaction(versionOrHash);
   for (let i = 0; i < 20; i++) {
-    const txn = await transaction(versionOrHash);
     if (txn.type !== "pending_transaction") {
       return txn.success;
     }
     await delay(500);
+    txn = await transaction(versionOrHash);
   }
-  throw `txn ${versionOrHash} never completed`;
+  throw `txn ${versionOrHash} never completed: ${txn && txn.vm_status}`;
 }
 
 // Returns transactions specific to a particular address.


### PR DESCRIPTION
## Motivation

As we ramp up to connect to trove testnet, we need to update our folder structure to hold accounts in different networks. Many files were using the old folder structure, now with the introduction of the NetworkHome with this PR, I've refactored files to utilize this struct which will help support our new folder structure. 


## Test Plan

Run `cargo run -p shuffle -- new "project_path"`. You'll notice the .shuffle folder is now populated on your home drive. Inside of that folder, there is a Networks.toml which holds the networks we support. Right now, that is localhost. 

![image](https://user-images.githubusercontent.com/55404786/141385492-cb18ea04-9957-4768-bf13-91b9e7c35ed3.png)

Run `cargo run -p shuffle -- node`. Now you'll see the node config folder populate in the .shuffle folder. 

<img width="1118" alt="Screen Shot 2021-11-11 at 3 56 39 PM" src="https://user-images.githubusercontent.com/55404786/141385570-c152851e-420b-4a87-8cce-f855cab20bd5.png">

Run 'cargo run -p shuffle -- account'. You'll notice a networks folder generate with the localhost folder inside of it. In the localhost folder, there are the accounts on that network. and within accounts, we have the latest key/address pair and test key/address pair.

![image](https://user-images.githubusercontent.com/55404786/141385662-77efb60a-3734-494f-b0d8-efd9188bc359.png)

If we run  `cargo run -p shuffle -- account`, the user will be prompted if they want to create another account. 

![image](https://user-images.githubusercontent.com/55404786/141385786-1ac49e44-3321-4217-b1dc-6d3a0541369e.png)

After pressing y, if we look at the folder structure again, we see that we have the latest account, test account, and an archived account of the account we had before the user was prompted to create another one. 

![image](https://user-images.githubusercontent.com/55404786/141385830-29653a44-1bdb-4dee-afba-0a4b5a17403c.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
