### PR TITLE
[shuffle] removed panic handling in move_unit_tests()

### DIFF
--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -5,7 +5,7 @@ use crate::{
     account, deploy,
     shared::{self, MAIN_PKG_PATH},
 };
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use diem_config::config::{NodeConfig, DEFAULT_PORT};
 use diem_crypto::PrivateKey;
 use diem_sdk::{
@@ -18,7 +18,6 @@ use move_cli::package::cli;
 use move_package::BuildConfig;
 use shared::Home;
 use std::{
-    panic,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -136,24 +135,12 @@ fn run_move_unit_tests(project_path: &Path) -> Result<()> {
         compute_coverage: false,
     };
 
-    panic::set_hook(Box::new(|_info| {
-        // Allows us to return the error below instead of panic!
-        // todo: Remove all panic catching after @tzakian PR lands
-    }));
-
-    let result = panic::catch_unwind(|| {
-        cli::handle_package_commands(
-            &Some(project_path.join(MAIN_PKG_PATH)),
-            generate_build_config_for_testing()?,
-            &unit_test_cmd,
-            diem_vm::natives::diem_natives(),
-        )
-    });
-
-    match result {
-        Ok(_) => Ok(()),
-        Err(_) => Err(anyhow!("Run move package build in the main folder of the project directory, then rerun shuffle test [subcommand]")),
-    }
+    cli::handle_package_commands(
+        &Some(project_path.join(MAIN_PKG_PATH)),
+        generate_build_config_for_testing()?,
+        &unit_test_cmd,
+        diem_vm::natives::diem_natives(),
+    )
 }
 
 fn generate_build_config_for_testing() -> Result<BuildConfig> {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Before, we had to handle a panic that fired when we ran move commands on a move folder more than once. PR #9491 fixed that panic. In this PR, i remove the panic handling that was once in our code. 

## Test Plan

I ran `cargo run -p shuffle -- test unit -p project_path` many times and now there are no panics that come up:

![image](https://user-images.githubusercontent.com/55404786/141389624-85ca5ac5-32b1-4d53-9ac8-b180ad0cab5d.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
