### PR TITLE
[executor-benchmark] improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3374,6 +3374,7 @@ dependencies = [
  "storage-interface",
  "storage-service",
  "structopt 0.3.21",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,6 @@ dependencies = [
  "serde",
  "storage-client",
  "storage-interface",
- "storage-service",
  "structopt 0.3.21",
  "toml",
 ]

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.8.3"
 rayon = "1.5.0"
 serde = "1.0.124"
 structopt = "0.3.21"
+toml = "0.5.8"
 
 executor = { path = "../executor" }
 executor-types = { path = "../executor-types" }

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -35,7 +35,6 @@ diem-workspace-hack = { path = "../../common/workspace-hack" }
 schemadb = { path = "../../storage/schemadb" }
 storage-client = { path = "../../storage/storage-client" }
 storage-interface = { path = "../../storage/storage-interface" }
-storage-service = { path = "../../storage/storage-service" }
 diem-transaction-builder = { path = "../../sdk/transaction-builder" }
 
 [dev-dependencies]

--- a/execution/executor-benchmark/benches/executor_benchmark.rs
+++ b/execution/executor-benchmark/benches/executor_benchmark.rs
@@ -3,7 +3,7 @@
 
 use criterion::{criterion_group, criterion_main, measurement::Measurement, BatchSize, Criterion};
 use executor_benchmark::{
-    create_storage_service_and_executor, transaction_executor::TransactionExecutor,
+    init_db_and_executor, transaction_executor::TransactionExecutor,
     transaction_generator::TransactionGenerator,
 };
 use std::sync::Arc;
@@ -21,7 +21,7 @@ pub const INITIAL_BALANCE: u64 = 1000000;
 fn executor_benchmark<M: Measurement + 'static>(c: &mut Criterion<M>) {
     let (config, genesis_key) = diem_genesis_tool::test_config();
 
-    let (_db, executor) = create_storage_service_and_executor(&config);
+    let (_db, executor) = init_db_and_executor(&config);
     let parent_block_id = executor.committed_block_id();
     let executor = Arc::new(executor);
 

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -62,18 +62,16 @@ pub fn run_benchmark(
     }
     std::fs::create_dir_all(checkpoint_dir.as_ref()).unwrap();
 
-    {
-        DiemDB::open(
-            &source_dir,
-            true, /* readonly */
-            None, /* pruner */
-            RocksdbConfig::default(),
-            true, /* account_count_migration */
-        )
-        .expect("db open failure.")
-        .create_checkpoint(checkpoint_dir.as_ref().join("diemdb"))
-        .expect("db checkpoint creation fails.");
-    }
+    DiemDB::open(
+        &source_dir,
+        true, /* readonly */
+        None, /* pruner */
+        RocksdbConfig::default(),
+        true, /* account_count_migration */
+    )
+    .expect("db open failure.")
+    .create_checkpoint(checkpoint_dir.as_ref().join("diemdb"))
+    .expect("db checkpoint creation fails.");
 
     let (mut config, genesis_key) = diem_genesis_tool::test_config();
     config.storage.dir = checkpoint_dir.as_ref().to_path_buf();

--- a/execution/executor/src/block_executor_impl.rs
+++ b/execution/executor/src/block_executor_impl.rs
@@ -202,8 +202,10 @@ impl<PS, V> Executor<PS, V> {
         if num_txns_in_li < num_persistent_txns {
             return Err(Error::InternalError {
                 error: format!(
-                    "Try to commit stale transactions with the last version as {}",
-                    version
+                    "Trying to commit stale transactions. version {}, num_txns_in_li {}, num_persistent_txns {}",
+                    version,
+                    num_txns_in_li,
+                    num_persistent_txns,
                 ),
             });
         }

--- a/storage/diemdb/src/lib.rs
+++ b/storage/diemdb/src/lib.rs
@@ -462,7 +462,14 @@ impl DiemDB {
 
     /// Creates new physical DB checkpoint in directory specified by `path`.
     pub fn create_checkpoint<P: AsRef<Path>>(&self, path: P) -> Result<()> {
-        self.db.create_checkpoint(path)
+        let start = Instant::now();
+        self.db.create_checkpoint(&path).map(|_| {
+            info!(
+                path = path.as_ref(),
+                time_ms = %start.elapsed().as_millis(),
+                "Made DiemDB checkpoint."
+            );
+        })
     }
 
     // ================================== Private APIs ==================================


### PR DESCRIPTION
## Motivation

Some improvements to the Executor Benchmark:

1. fix the accumulative metrics reported.
2. no longer persist all generated accounts as part of the test case (too slow to persist and reload), instead, regenerated part of the accounts at test case run time.
3. remove the storage service in between the executor and the DB, mimicking the new real scenario in product.

On @lightmark's test DB with 10 million accounts, the benchmark runs at ~1.8k TPS (up from ~420 TPS, on my MacPro)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

local machine
