### PR TITLE
[consensus] Add metric counter for safety rules waypoint version update.

### DIFF
--- a/consensus/safety-rules/src/counters.rs
+++ b/consensus/safety-rules/src/counters.rs
@@ -7,6 +7,11 @@ use diem_secure_push_metrics::{
 };
 use once_cell::sync::Lazy;
 
+pub const EPOCH: &str = "epoch";
+pub const LAST_VOTED_ROUND: &str = "last_voted_round";
+pub const PREFERRED_ROUND: &str = "preferred_round";
+pub const WAYPOINT_VERSION: &str = "waypoint_version";
+
 pub static LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_safety_rules_latency",
@@ -44,4 +49,9 @@ pub fn start_timer(source: &str, field: &str) -> HistogramTimer {
 
 pub fn set_state(field: &str, value: i64) {
     STATE_GAUGE.with_label_values(&[field]).set(value);
+}
+
+#[cfg(any(test))]
+pub fn get_state(field: &str) -> i64 {
+    STATE_GAUGE.with_label_values(&[field]).get()
 }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Currently we have limited observability into the current waypoint version stored in persistent (secure) storage, which makes it inconvenient to tell the current waypoint version (except by printing logs) [Issue #9176] To improve the observability of the waypoint in persistent secure storage, we introduce a new metric counter to keep track the waypoint version whenever it is initialized or updated.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

We first create and initialize a persistent storage and verify that the metric counter of waypoint version is the same as the default/initialized value. We then update the waypoint a few times. After each update, we verify the metric counter of waypoint version is the same as the updated version.
![Screen Shot 2021-11-12 at 2 42 46 PM](https://user-images.githubusercontent.com/10539152/141595379-921dff5d-b14a-4ab3-829e-97c4b4b920cf.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
