### PR TITLE
[shuffle] forge shuffle integration test runs move unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7762,6 +7762,7 @@ dependencies = [
  "move-core-types",
  "move-lang",
  "move-package",
+ "move-unit-test",
  "once_cell",
  "rand 0.8.4",
  "reqwest",

--- a/shuffle/cli/Cargo.toml
+++ b/shuffle/cli/Cargo.toml
@@ -44,6 +44,7 @@ move-cli = { path = "../../language/tools/move-cli" }
 move-core-types = { path = "../../language/move-core/types" }
 move-lang = { path = "../../language/move-lang" }
 move-package = { path = "../../language/tools/move-package" }
+move-unit-test = { path = "../../language/tools/move-unit-test" }
 serde-generate = "0.20.2"
 serde-reflection = "0.3.4"
 serde_json = "1.0.68"

--- a/shuffle/integration-tests/src/lib.rs
+++ b/shuffle/integration-tests/src/lib.rs
@@ -34,11 +34,11 @@ impl AdminTest for SetMessageHelloBlockchain {
         let handle = rt.handle().clone();
         handle.block_on(helper.deploy_project(ctx.chain_info().rest_api()))?;
 
-        let json_rpc_url = Url::from_str(ctx.chain_info().json_rpc())?;
+        shuffle::test::run_move_unit_tests(&helper.project_path())?;
         shuffle::test::run_deno_test(
             helper.home(),
             &helper.project_path(),
-            &json_rpc_url,
+            &Url::from_str(ctx.chain_info().json_rpc())?,
             &Url::from_str(ctx.chain_info().rest_api())?,
             helper.home().get_test_key_path(),
             helper.home().get_test_address()?,

--- a/shuffle/move/examples/main/sources/Message.move
+++ b/shuffle/move/examples/main/sources/Message.move
@@ -1,6 +1,7 @@
 module Sender::Message {
-    use Std::Signer;
+    use Std::Errors;
     use Std::Event;
+    use Std::Signer;
 
     struct MessageHolder has key {
         message: vector<u8>,
@@ -13,6 +14,11 @@ module Sender::Message {
 
     /// There is no message present
     const ENO_MESSAGE: u64 = 0;
+
+    public fun get_message(addr: address): vector<u8> acquires MessageHolder {
+        assert!(exists<MessageHolder>(addr), Errors::not_published(ENO_MESSAGE));
+        *&borrow_global<MessageHolder>(addr).message
+    }
 
     public(script) fun set_message(account: signer, message: vector<u8>)
     acquires MessageHolder {

--- a/shuffle/move/examples/main/sources/MessageTests.move
+++ b/shuffle/move/examples/main/sources/MessageTests.move
@@ -1,0 +1,23 @@
+#[test_only]
+module Sender::MessageTests {
+    use Sender::Message;
+    use Std::Signer;
+    use Std::UnitTest;
+    use Std::Vector;
+
+    fun get_account(): signer {
+        Vector::pop_back(&mut UnitTest::create_signers_for_testing(1))
+    }
+
+    #[test]
+    public(script) fun sender_can_set_message() {
+        let account = get_account();
+        let addr = Signer::address_of(&account);
+        Message::set_message(account,  b"Hello Blockchain");
+
+        assert!(
+          Message::get_message(addr) == b"Hello Blockchain",
+          0
+        );
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Previously, shuffle forge integration test skipped move unit tests because it exited early via `std::process:exit(1)` on a failed unit test. This refactor allows optional early failure on invocation of move package unit tests, and incorporates that into the force shuffle test.

This diff seems noisy, but it's mostly because of a poor rendering of the changes in move-cli, moving run_move_unit_tests outside of the handle_package_command

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo xtest -p shuffle-integration-tests`
