### PR TITLE
[move-package] Allow passing named addresses to packages in Rust

### DIFF
--- a/diem-move/diem-framework/DPN/releases/artifacts/current/build/DPNFramework/BuildInfo.yaml
+++ b/diem-move/diem-framework/DPN/releases/artifacts/current/build/DPNFramework/BuildInfo.yaml
@@ -173,6 +173,7 @@ compiled_package_info:
     generate_abis: true
     install_dir: DPN/releases/artifacts/current
     force_recompilation: false
+    additional_named_addresses: {}
 dependencies:
   - MoveStdlib
   - DiemCoreFramework

--- a/diem-move/diem-framework/DPN/releases/artifacts/current/build/DiemCoreFramework/BuildInfo.yaml
+++ b/diem-move/diem-framework/DPN/releases/artifacts/current/build/DiemCoreFramework/BuildInfo.yaml
@@ -173,5 +173,6 @@ compiled_package_info:
     generate_abis: true
     install_dir: DPN/releases/artifacts/current
     force_recompilation: false
+    additional_named_addresses: {}
 dependencies:
   - MoveStdlib

--- a/diem-move/diem-framework/DPN/releases/artifacts/current/build/MoveStdlib/BuildInfo.yaml
+++ b/diem-move/diem-framework/DPN/releases/artifacts/current/build/MoveStdlib/BuildInfo.yaml
@@ -48,4 +48,5 @@ compiled_package_info:
     generate_abis: true
     install_dir: DPN/releases/artifacts/current
     force_recompilation: false
+    additional_named_addresses: {}
 dependencies: []

--- a/diem-move/diem-framework/experimental/releases/artifacts/current/build/DiemExperimental/BuildInfo.yaml
+++ b/diem-move/diem-framework/experimental/releases/artifacts/current/build/DiemExperimental/BuildInfo.yaml
@@ -182,5 +182,6 @@ compiled_package_info:
     generate_abis: true
     install_dir: experimental/releases/artifacts/current
     force_recompilation: false
+    additional_named_addresses: {}
 dependencies:
   - MoveStdlib

--- a/diem-move/diem-framework/experimental/releases/artifacts/current/build/MoveStdlib/BuildInfo.yaml
+++ b/diem-move/diem-framework/experimental/releases/artifacts/current/build/MoveStdlib/BuildInfo.yaml
@@ -48,4 +48,5 @@ compiled_package_info:
     generate_abis: true
     install_dir: experimental/releases/artifacts/current
     force_recompilation: false
+    additional_named_addresses: {}
 dependencies: []

--- a/diem-move/diem-framework/src/release.rs
+++ b/diem-move/diem-framework/src/release.rs
@@ -77,12 +77,10 @@ impl ReleaseOptions {
         std::fs::create_dir_all(output_path.parent().unwrap()).unwrap();
 
         let build_config = move_package::BuildConfig {
-            dev_mode: false,
-            test_mode: false,
             generate_docs: !self.build_docs,
             generate_abis: !self.script_abis,
             install_dir: Some(output_path.clone()),
-            force_recompilation: false,
+            ..Default::default()
         };
 
         let package_path = Path::new(std::env!("CARGO_MANIFEST_DIR")).join(&self.package);

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -7,10 +7,12 @@ pub mod source_package;
 
 use anyhow::Result;
 use compilation::compiled_package::CompilationCachingStatus;
+use move_core_types::account_address::AccountAddress;
 use move_model::model::GlobalEnv;
 use serde::{Deserialize, Serialize};
 use source_package::layout::SourcePackageLayout;
 use std::{
+    collections::BTreeMap,
     io::Write,
     path::{Path, PathBuf},
 };
@@ -56,6 +58,10 @@ pub struct BuildConfig {
     /// Force recompilation of all packages
     #[structopt(name = "force-recompilation", long = "force", short = "f")]
     pub force_recompilation: bool,
+
+    /// Additional named address mapping. Useful for tools in rust
+    #[structopt(skip)]
+    pub additional_named_addresses: BTreeMap<String, AccountAddress>,
 }
 
 impl Default for BuildConfig {
@@ -67,6 +73,7 @@ impl Default for BuildConfig {
             generate_abis: false,
             install_dir: None,
             force_recompilation: false,
+            additional_named_addresses: BTreeMap::new(),
         }
     }
 }

--- a/language/tools/move-package/src/resolution/resolution_graph.rs
+++ b/language/tools/move-package/src/resolution/resolution_graph.rs
@@ -198,7 +198,18 @@ impl ResolvingGraph {
         };
 
         let mut renaming = BTreeMap::new();
-        let mut resolution_table = BTreeMap::new();
+        let mut resolution_table = self
+            .build_options
+            .additional_named_addresses
+            .clone()
+            .into_iter()
+            .map(|(name, addr)| {
+                (
+                    NamedAddress::from(name),
+                    ResolvingNamedAddress::new(Some(addr)),
+                )
+            })
+            .collect();
 
         // include dev dependencies if in dev mode
         let additional_deps = if self.build_options.dev_mode {

--- a/language/tools/move-package/tests/test_additional_addresses.rs
+++ b/language/tools/move-package/tests/test_additional_addresses.rs
@@ -1,0 +1,96 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_core_types::account_address::AccountAddress;
+use move_package::{
+    resolution::resolution_graph as RG, source_package::manifest_parser as MP, BuildConfig,
+};
+use std::{collections::BTreeMap, path::Path};
+use tempfile::tempdir;
+
+#[test]
+fn test_additonal_addresses() {
+    let path = Path::new(
+        "tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment",
+    );
+    let pm = MP::parse_move_manifest_from_file(path).unwrap();
+
+    let mut additional_named_addresses = BTreeMap::new();
+    additional_named_addresses.insert(
+        "A".to_string(),
+        AccountAddress::from_hex_literal("0x1").unwrap(),
+    );
+
+    assert!(RG::ResolutionGraph::new(
+        pm.clone(),
+        path.parent().unwrap().to_path_buf(),
+        BuildConfig {
+            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            additional_named_addresses,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .resolve()
+    .is_ok());
+
+    assert!(RG::ResolutionGraph::new(
+        pm,
+        path.parent().unwrap().to_path_buf(),
+        BuildConfig {
+            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .resolve()
+    .is_err());
+}
+
+#[test]
+fn test_additonal_addresses_already_assigned_same_value() {
+    let path = Path::new("tests/test_sources/resolution/basic_no_deps_address_assigned");
+    let pm = MP::parse_move_manifest_from_file(path).unwrap();
+
+    let mut additional_named_addresses = BTreeMap::new();
+    additional_named_addresses.insert(
+        "A".to_string(),
+        AccountAddress::from_hex_literal("0x0").unwrap(),
+    );
+
+    assert!(RG::ResolutionGraph::new(
+        pm,
+        path.parent().unwrap().to_path_buf(),
+        BuildConfig {
+            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            additional_named_addresses,
+            ..Default::default()
+        },
+    )
+    .unwrap()
+    .resolve()
+    .is_ok());
+}
+
+#[test]
+fn test_additonal_addresses_already_assigned_different_value() {
+    let path = Path::new("tests/test_sources/resolution/basic_no_deps_address_assigned");
+    let pm = MP::parse_move_manifest_from_file(path).unwrap();
+
+    let mut additional_named_addresses = BTreeMap::new();
+    additional_named_addresses.insert(
+        "A".to_string(),
+        AccountAddress::from_hex_literal("0x1").unwrap(),
+    );
+
+    assert!(RG::ResolutionGraph::new(
+        pm,
+        path.parent().unwrap().to_path_buf(),
+        BuildConfig {
+            install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+            additional_named_addresses,
+            ..Default::default()
+        },
+    )
+    .is_err());
+}

--- a/language/tools/move-package/tests/test_runner.rs
+++ b/language/tools/move-package/tests/test_runner.rs
@@ -46,6 +46,7 @@ pub fn run_test(path: &Path) -> datatest_stable::Result<()> {
                     generate_abis: false,
                     install_dir: Some(tempdir().unwrap().path().to_path_buf()),
                     force_recompilation: false,
+                    ..Default::default()
                 },
             )
         })

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps/Move.exp
@@ -14,5 +14,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_assigned/Move.exp
@@ -23,5 +23,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -23,5 +23,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
@@ -89,5 +89,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_backflow_resolution/Move.exp
@@ -42,5 +42,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/diamond_problem_no_conflict/Move.exp
@@ -42,5 +42,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename/Move.exp
@@ -37,5 +37,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/multiple_deps_rename_one/Move.exp
@@ -30,5 +30,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep/Move.exp
@@ -29,5 +29,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_assigned_address/Move.exp
@@ -29,5 +29,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_renamed/Move.exp
@@ -29,5 +29,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -35,5 +35,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/test_symlinks/Move.exp
@@ -29,5 +29,6 @@ CompiledPackageInfo {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
 }

--- a/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/invalid_identifier_package_name/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/parsing/minimal_manifest/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_assigned/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/basic_no_deps_address_not_assigned_with_dev_assignment/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/dep_good_digest/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_backflow_resolution/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/diamond_problem_no_conflict/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/multiple_deps_rename/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_assigned_address/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_multiple_of_same_name/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_reassigned_address/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
+++ b/language/tools/move-package/tests/test_sources/resolution/one_dep_unification_across_local_renamings/Move.exp
@@ -9,6 +9,7 @@ ResolutionGraph {
             "ELIDED_FOR_TEST",
         ),
         force_recompilation: false,
+        additional_named_addresses: {},
     },
     root_package: SourceManifest {
         package: PackageInfo {

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -489,11 +489,8 @@ pub fn build_move_package(pkg_path: &Path) -> Result<CompiledPackage> {
     println!("Building {}...", pkg_path.display());
     let config = move_package::BuildConfig {
         dev_mode: true,
-        test_mode: false,
-        generate_docs: false,
         generate_abis: true,
-        force_recompilation: false,
-        install_dir: None,
+        ..Default::default()
     };
 
     config.compile_package(pkg_path, &mut std::io::stdout())

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -168,10 +168,8 @@ fn generate_build_config_for_testing() -> Result<BuildConfig> {
     Ok(BuildConfig {
         dev_mode: true,
         test_mode: true,
-        generate_docs: false,
         generate_abis: true,
-        install_dir: None,
-        force_recompilation: false,
+        ..Default::default()
     })
 }
 


### PR DESCRIPTION
This adds the ability to assign and bind additional named addresses when calling into the package system from Rust.

Only look at the bottom commit -- that's where all the changes are. The top commit is simply regenerated files.