### PR TITLE
[move] Remove empty `;` statement from Move IR

### DIFF
--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global.mvir
@@ -18,7 +18,7 @@ module 0x1.A {
         let u1: u64;
         let u2: u64;
         Coin { u1 } = move(c1);
-        assert(copy(u1) >= copy(amt), 42)
+        assert(copy(u1) >= copy(amt), 42);
         u1 = move(u1) - copy(amt);
         u2 = copy(amt);
         return Coin { u: move(u1) }, Coin { u: move(u2) };

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_invalid.mvir
@@ -18,7 +18,7 @@ module 0x1.A {
         let u1: u64;
         let u2: u64;
         Coin { u1 } = move(c1);
-        assert(copy(u1) >= copy(amt), 42)
+        assert(copy(u1) >= copy(amt), 42);
         u1 = move(u1) - copy(amt);
         u2 = copy(amt);
         return Coin { u: move(u1) }, Coin { u: move(u2) };

--- a/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_lossy_acquire_invalid.mvir
+++ b/language/bytecode-verifier/transactional-tests/tests/reference_safety/imm_borrow_global_lossy_acquire_invalid.mvir
@@ -19,7 +19,7 @@ module 0x1.A {
         let u1: u64;
         let u2: u64;
         Coin { u1 } = move(c1);
-        assert(copy(u1) >= copy(amt), 42)
+        assert(copy(u1) >= copy(amt), 42);
         u1 = move(u1) - copy(amt);
         u2 = copy(amt);
         return Coin { u: move(u1) }, Coin { u: move(u2) };

--- a/language/ir-testsuite/tests/move/commands/if_branch_diverges_8.mvir
+++ b/language/ir-testsuite/tests/move/commands/if_branch_diverges_8.mvir
@@ -2,7 +2,7 @@ main() {
     let ret_if_val: bool;
     ret_if_val = true;
     if (move(ret_if_val)) {
-        loop { break; if (true) { return; } else { continue; }; }
+        loop { break; if (true) { return; } else { continue; } }
     } else {
         assert(false, 42);
         return;

--- a/language/move-ir-compiler/ir-to-bytecode/src/compiler.rs
+++ b/language/move-ir-compiler/ir-to-bytecode/src/compiler.rs
@@ -859,7 +859,6 @@ fn compile_block(
             Statement::IfElseStatement(if_else) => {
                 compile_if_else(context, function_frame, code, if_else)?
             }
-            Statement::EmptyStatement => continue,
         };
         cf_info = ControlFlowInfo::successor(cf_info, stmt_info);
     }

--- a/language/move-ir-compiler/ir-to-bytecode/syntax/src/syntax.rs
+++ b/language/move-ir-compiler/ir-to-bytecode/syntax/src/syntax.rs
@@ -1008,7 +1008,6 @@ fn parse_cmd_(tokens: &mut Lexer) -> Result<Cmd_, ParseError<Loc, anyhow::Error>
 //     <IfStatement>,
 //     <WhileStatement>,
 //     <LoopStatement>,
-//     ";" => Statement::EmptyStatement,
 // }
 
 fn parse_statement(tokens: &mut Lexer) -> Result<Statement, ParseError<Loc, anyhow::Error>> {
@@ -1019,6 +1018,7 @@ fn parse_statement(tokens: &mut Lexer) -> Result<Statement, ParseError<Loc, anyh
             consume_token(tokens, Tok::Comma)?;
             let err = parse_exp(tokens)?;
             consume_token(tokens, Tok::RParen)?;
+            consume_token(tokens, Tok::Semicolon)?;
             let cond = {
                 let loc = e.loc;
                 sp(loc, Exp_::UnaryExp(UnaryOp::Not, Box::new(e)))
@@ -1033,10 +1033,6 @@ fn parse_statement(tokens: &mut Lexer) -> Result<Statement, ParseError<Loc, anyh
         Tok::If => parse_if_statement(tokens),
         Tok::While => parse_while_statement(tokens),
         Tok::Loop => parse_loop_statement(tokens),
-        Tok::Semicolon => {
-            tokens.advance()?;
-            Ok(Statement::EmptyStatement)
-        }
         _ => {
             // Anything else should be parsed as a Cmd...
             let start_loc = tokens.start_loc();

--- a/language/move-ir/types/src/ast.rs
+++ b/language/move-ir/types/src/ast.rs
@@ -521,8 +521,6 @@ pub enum Statement {
     WhileStatement(While),
     /// `loop { s }`
     LoopStatement(Loop),
-    /// no-op that eases parsing in some places
-    EmptyStatement,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -1680,7 +1678,6 @@ impl fmt::Display for Statement {
             Statement::IfElseStatement(if_else) => write!(f, "{}", if_else),
             Statement::WhileStatement(while_) => write!(f, "{}", while_),
             Statement::LoopStatement(loop_) => write!(f, "{}", loop_),
-            Statement::EmptyStatement => write!(f, "<empty statement>"),
         }
     }
 }

--- a/language/move-vm/transactional-tests/tests/control_flow/if_branch_diverges_7.mvir
+++ b/language/move-vm/transactional-tests/tests/control_flow/if_branch_diverges_7.mvir
@@ -3,7 +3,14 @@ main() {
     let ret_if_val: bool;
     ret_if_val = true;
     if (move(ret_if_val)) {
-        loop { if (true) { return; } else { continue; }; break; }
+        loop {
+            if (true) {
+                return;
+            } else {
+                continue;
+            }
+            break;
+        }
     } else {
         assert(false, 42);
         return;

--- a/language/move-vm/transactional-tests/tests/example_programs/sorted-linked-list.mvir
+++ b/language/move-vm/transactional-tests/tests/example_programs/sorted-linked-list.mvir
@@ -149,7 +149,7 @@ module 0x1.SortedLinkedList
         sender_address = Signer.address_of(move(account));
 
         //fail if the caller does not own a list
-        assert(Self.is_head_node(copy(sender_address)), 18)
+        assert(Self.is_head_node(copy(sender_address)), 18);
 
         assert(exists<Node>(copy(sender_address)), 8);
         current_node_ref = borrow_global<Node>(copy(sender_address));


### PR DESCRIPTION
The documentation comment for the `EmptyStatement` claims it eases parsing to allow for an empty statement `;` in Move IR, but I think that it actually makes things more difficult: the statement `assert(e_1, e_2);` was being parsed incorrectly for some time, as an assert statement followed by the empty statement `;`. (Unless it was intentional that every `CommandStatement` ended in a semicolon except for `assert`, which personally I find a little confusing.)

I could see how it may make sense to allow for empty statements in a user-facing programming language such as Move, but for a language we primarily use to test Move, I think the empty statement should either lower to a "noop" bytecode instruction, or it should be treated as an error. And seeing as how there is no "noop" bytecode instruction, I think empty `;` should result in a parser error, as it does in this commit.

I'm currently working on eliminating structured control flow statements in Move IR in a separate commit, and removing the empty statement `;` now would allow me to greatly simplify statements overall (potentially, I could eliminate the `Statement` enum, because all `Statement` would be `CommandStatement`).