### PR TITLE
[move-package] Fix issue where we werent' removing build artifacts between builds

### DIFF
--- a/language/tools/move-package/src/compilation/compiled_package.rs
+++ b/language/tools/move-package/src/compilation/compiled_package.rs
@@ -151,9 +151,12 @@ impl OnDiskCompiledPackage {
             |path| extension_equals(path, SOURCE_MAP_EXTENSION),
         )
         .unwrap_or_else(|_| vec![]);
-        assert!(
-            compiled_units.len() == source_maps.len(),
-            "compiled units and source maps differ"
+        assert_eq!(
+            compiled_units.len(),
+            source_maps.len(),
+            "number of compiled units and source maps differ, {} != {}",
+            compiled_units.len(),
+            source_maps.len()
         );
         let compiled_units = compiled_units
             .iter()
@@ -629,6 +632,12 @@ impl CompiledPackage {
                     .collect(),
             },
         };
+
+        // Clear out the build dir for this package so we don't keep artifacts from previous
+        // compilations
+        if on_disk_package.root_path.is_dir() {
+            std::fs::remove_dir_all(&on_disk_package.root_path)?;
+        }
 
         std::fs::create_dir_all(&on_disk_package.root_path)?;
 

--- a/language/tools/move-package/tests/test_removal_second_compilation.rs
+++ b/language/tools/move-package/tests/test_removal_second_compilation.rs
@@ -1,0 +1,79 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_package::{compilation::package_layout::CompiledPackageLayout, BuildConfig};
+use std::path::Path;
+use tempfile::tempdir;
+
+#[test]
+fn test_that_second_build_artifacts_removed() {
+    let path = Path::new("tests/test_sources/compilation/basic_no_deps_test_mode");
+    let dir = tempdir().unwrap().path().to_path_buf();
+
+    BuildConfig {
+        dev_mode: true,
+        test_mode: true,
+        install_dir: Some(dir.clone()),
+        ..Default::default()
+    }
+    .compile_package(path, &mut Vec::new())
+    .unwrap();
+
+    assert!(
+        std::fs::read_dir(&dir.join(CompiledPackageLayout::Root.path()))
+            .unwrap()
+            .any(|dir| dir.unwrap().path().ends_with("MoveStdlib"))
+    );
+
+    assert!(dir
+        .join(CompiledPackageLayout::Root.path())
+        .join("test")
+        .join(CompiledPackageLayout::CompiledModules.path())
+        .join("MTest.mv")
+        .exists());
+
+    // Now make sure the MoveStdlib still exists, but that the test-only code is removed
+    BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        install_dir: Some(dir.clone()),
+        ..Default::default()
+    }
+    .compile_package(path, &mut Vec::new())
+    .unwrap();
+
+    // The MoveStdlib dep should still exist, but the MTest module should go away
+    assert!(
+        std::fs::read_dir(&dir.join(CompiledPackageLayout::Root.path()))
+            .unwrap()
+            .any(|dir| dir.unwrap().path().ends_with("MoveStdlib"))
+    );
+    assert!(!dir
+        .join(CompiledPackageLayout::Root.path())
+        .join("test")
+        .join(CompiledPackageLayout::CompiledModules.path())
+        .join("MTest.mv")
+        .exists());
+
+    BuildConfig {
+        dev_mode: false,
+        test_mode: false,
+        install_dir: Some(dir.clone()),
+        ..Default::default()
+    }
+    .compile_package(path, &mut Vec::new())
+    .unwrap();
+
+    // The MoveStdlib dep should no longer exist, and the MTest module shouldn't exist either
+    assert!(
+        !std::fs::read_dir(&dir.join(CompiledPackageLayout::Root.path()))
+            .unwrap()
+            .any(|dir| dir.unwrap().path().ends_with("MoveStdlib"))
+    );
+    assert!(!dir
+        .join(CompiledPackageLayout::Root.path())
+        .join("test")
+        .join(CompiledPackageLayout::CompiledModules.path())
+        .join("MTest.mv")
+        .exists());
+}

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.exp
@@ -1,0 +1,93 @@
+CompiledPackageInfo {
+    package_name: "test",
+    address_alias_instantiation: {
+        "Std": 00000000000000000000000000000001,
+    },
+    module_resolution_metadata: {
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "ASCII",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "BCS",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "BitVector",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "Capability",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "Errors",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "Event",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "FixedPoint32",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "GUID",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "Hash",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "Option",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "Signer",
+            ),
+        }: "Std",
+        ModuleId {
+            address: 00000000000000000000000000000001,
+            name: Identifier(
+                "Vector",
+            ),
+        }: "Std",
+    },
+    source_digest: Some(
+        "ELIDED_FOR_TEST",
+    ),
+    build_flags: BuildConfig {
+        dev_mode: true,
+        test_mode: false,
+        generate_docs: false,
+        generate_abis: false,
+        install_dir: Some(
+            "ELIDED_FOR_TEST",
+        ),
+        force_recompilation: false,
+    },
+}

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.toml
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "test"
+version = "0.0.0"
+
+[dev-dependencies]
+MoveStdlib = { local = "../../../../../../move-stdlib", addr_subst = { "Std" = "0x1" } }

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/sources/A.move
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/sources/A.move
@@ -1,0 +1,3 @@
+module 0x1::M {
+    public fun foo() { }
+}

--- a/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/sources/ATest.move
+++ b/language/tools/move-package/tests/test_sources/compilation/basic_no_deps_test_mode/sources/ATest.move
@@ -1,0 +1,4 @@
+#[test_only]
+module 0x1::MTest {
+    public fun foo() { }
+}


### PR DESCRIPTION
This fixes an issue where testing or dev-mode artifacts could still exist on disk if you first compiled a package in dev or test mode and then compiled in non-dev or test mode.

This adds a test to make sure these artifacts are deleted.