### PR TITLE
[move-prover] update cvc4 to cvc5 as boogie solver option

### DIFF
--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -170,7 +170,7 @@ impl BoogieOptions {
         add(DEFAULT_BOOGIE_FLAGS);
         if self.use_cvc4 {
             add(&[
-                "-proverOpt:SOLVER=cvc4",
+                "-proverOpt:SOLVER=cvc5",
                 &format!("-proverOpt:PROVER_PATH={}", &self.cvc4_exe),
             ]);
         } else {


### PR DESCRIPTION
Boogie 2.9.6 does not recognize CVC4, used CVC5 instead.

The cvc4 tests start to fail when I run `scripts/dev_setup.sh` recently. These failures do not show up in the CI because CVC4 tests aren't running there.

This also means that once this PR lands, prover users should re-run `dev_setup.sh`, otherwise, local tests will start to fail as well.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Consistency

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Tested locally with `cargo test` in `move-prover` crate.
