### PR TITLE
[move-prover] create a choice boogie function on unique `ExpData`

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -379,7 +379,7 @@ pub enum ExpData {
         Vec<Vec<Exp>>,
         /// Optional `where` clause
         Option<Exp>,
-        // Body
+        /// Body
         Exp,
     ),
     /// Represents a block which contains a set of variable bindings and an expression

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -170,7 +170,7 @@ impl BoogieOptions {
         add(DEFAULT_BOOGIE_FLAGS);
         if self.use_cvc4 {
             add(&[
-                "-proverOpt:SOLVER=cvc4",
+                "-proverOpt:SOLVER=cvc5",
                 &format!("-proverOpt:PROVER_PATH={}", &self.cvc4_exe),
             ]);
         } else {

--- a/language/move-prover/tests/sources/functional/choice.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/choice.cvc4_exp
@@ -48,6 +48,26 @@ error: post-condition does not hold
    =         `TRACE(choose y: u64 where y > x)` = <redacted>
 
 error: post-condition does not hold
+    ┌─ tests/sources/functional/choice.move:156:9
+    │
+156 │         ensures evidence1 == evidence2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/choice.move:154
+    =     at tests/sources/functional/choice.move:155
+    =     at tests/sources/functional/choice.move:152: test_different_choice_via_let
+    =     at tests/sources/functional/choice.move:156
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/choice.move:180:9
+    │
+180 │         ensures choose_some_positive_u64() == choose_another_positive_u64();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/choice.move:178: test_different_choice_via_spec_fun
+    =     at tests/sources/functional/choice.move:180
+
+error: post-condition does not hold
    ┌─ tests/sources/functional/choice.move:70:9
    │
 70 │         ensures (choose min i in 0..len(result) where result[i] == 2) == 1;
@@ -86,3 +106,29 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:82: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:85
    =         `TRACE(choose i in 0..len(result) where result[i] == 2)` = <redacted>
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/choice.move:217:9
+    │
+217 │         ensures result != (choose i: u64 where i >= k);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/choice.move:234: test_same_choice_different_args_via_schema_2
+    =         result = <redacted>
+    =     at tests/sources/functional/choice.move:235: test_same_choice_different_args_via_schema_2
+    =     at tests/sources/functional/choice.move:217
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/choice.move:208:9
+    │
+208 │         ensures evidence1 == evidence2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/choice.move:204: test_same_choice_different_args_via_spec_fun
+    =     at tests/sources/functional/choice.move:206
+    =     at tests/sources/functional/choice.move:207
+    =     at tests/sources/functional/choice.move:204: test_same_choice_different_args_via_spec_fun
+    =         x = <redacted>
+    =         y = <redacted>
+    =         result = <redacted>
+    =     at tests/sources/functional/choice.move:208

--- a/language/move-prover/tests/sources/functional/choice.exp
+++ b/language/move-prover/tests/sources/functional/choice.exp
@@ -48,6 +48,26 @@ error: post-condition does not hold
    =         `TRACE(choose y: u64 where y > x)` = <redacted>
 
 error: post-condition does not hold
+    ┌─ tests/sources/functional/choice.move:156:9
+    │
+156 │         ensures evidence1 == evidence2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/choice.move:154
+    =     at tests/sources/functional/choice.move:155
+    =     at tests/sources/functional/choice.move:152: test_different_choice_via_let
+    =     at tests/sources/functional/choice.move:156
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/choice.move:180:9
+    │
+180 │         ensures choose_some_positive_u64() == choose_another_positive_u64();
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/choice.move:178: test_different_choice_via_spec_fun
+    =     at tests/sources/functional/choice.move:180
+
+error: post-condition does not hold
    ┌─ tests/sources/functional/choice.move:85:9
    │
 85 │         ensures TRACE(choose i in 0..len(result) where result[i] == 2) == 1;
@@ -67,3 +87,29 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:82: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:85
    =         `TRACE(choose i in 0..len(result) where result[i] == 2)` = <redacted>
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/choice.move:217:9
+    │
+217 │         ensures result != (choose i: u64 where i >= k);
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/choice.move:234: test_same_choice_different_args_via_schema_2
+    =         result = <redacted>
+    =     at tests/sources/functional/choice.move:235: test_same_choice_different_args_via_schema_2
+    =     at tests/sources/functional/choice.move:217
+
+error: post-condition does not hold
+    ┌─ tests/sources/functional/choice.move:208:9
+    │
+208 │         ensures evidence1 == evidence2;
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    =     at tests/sources/functional/choice.move:204: test_same_choice_different_args_via_spec_fun
+    =     at tests/sources/functional/choice.move:206
+    =     at tests/sources/functional/choice.move:207
+    =     at tests/sources/functional/choice.move:204: test_same_choice_different_args_via_spec_fun
+    =         x = <redacted>
+    =         y = <redacted>
+    =         result = <redacted>
+    =     at tests/sources/functional/choice.move:208


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The choice operator is currently implemented with a property that
if the same choice operator is referred multiple times, the chosen
evidence should stay the same.

This semantics is captured in the newly added
`// Semantics when the same-choice operator is referred`
section in the `choice.move` test case.

This property is implemented by converting a choice operator into
an uninterpreted function in Boogie followed by an axiom to constrain
this uninterpreted function.

However, in this translation process, there is an implicit assumption
that one choice operator will only be called with a one and only one set
of variables (e.g., function arguments/locals, free vars, and memories).
This assumption is valid in the verification of DPN given the limited
uses of the choice operator, but there are violations.

One case is documented in the following example:

```move
    struct S has drop {
        x: u64
    }

    fun test_less_than_1(x: u64): u64 {
        x - 1
    }

    fun test_less_than_2(s: S): u64 {
        s.x - 1
    }

    spec test_less_than_1 {
        include EnsuresLessThan;
    }

    spec test_less_than_2 {
        include EnsuresLessThan { x: s.x };
    }

    spec schema EnsuresLessThan {
        x: u64;
        result: u64;
        ensures result != (choose i: u64 where i >= x);
    }
```

This choice operator is referred to in two contexts:
- in `test_less_than_1`, it is called with an argument `$t0` of type `u64`
- in `test_less_than_2`, it is called with an argument `$t0` of type `S`

Before this commit, the translation will produce a Boogie type error,
which is due to the fact that the choice operator is only translated
once with `$t0: u64` as its first argument.

Changes in this commit is simple in concept but might not be obvious
from the code:

Before this commit, we are already creating different functions for
the same choice operator if they are specialized with different types.
This is evident in
`lifted_choice_infos: Rc<RefCell<BTreeMap<NodeId, LiftedChoiceInfo>>>`
as `NodeId` being the key.

The change is:
`lifted_choice_infos: Rc<RefCell<HashMap<ExpData, LiftedChoiceInfo>>>`.
So, instead of just using `NodeId`, we use the whole `ExpData`, which
includes the `NodeId` but also the range and body `Exp` as well. If
two choice expressions share exactly the same `Exp` for range and body,
(i.e., their ASTs are exactly the same). We point them to the same
uninterpreted function in Boogie. Otherwise, we create a new
uninterpreted function for each reference to the same choice operator.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

The `choice.move` test case is updated for the changes.
