### PR TITLE
[move-package] Only hash Move and package-specific files

### DIFF
--- a/diem-move/diem-framework/DPN/releases/artifacts/current/build/DPNFramework/BuildInfo.yaml
+++ b/diem-move/diem-framework/DPN/releases/artifacts/current/build/DPNFramework/BuildInfo.yaml
@@ -165,7 +165,7 @@ compiled_package_info:
     ? address: "00000000000000000000000000000001"
       name: XUS
     : DiemFramework
-  source_digest: 6CD98BF93B0DD3287029A2EF9C788D5C7871FF13B79D2F17256BB42885A39C3C
+  source_digest: 7DA6FB50576D6D1C277228DD430480010DCE130D7E1F2CFDC35AF0135D8E4F06
   build_flags:
     dev_mode: false
     test_mode: false

--- a/language/tools/move-package/src/resolution/digest.rs
+++ b/language/tools/move-package/src/resolution/digest.rs
@@ -2,28 +2,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use move_command_line_common::files::MOVE_EXTENSION;
 use sha2::{Digest, Sha256};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use crate::source_package::parsed_manifest::PackageDigest;
+use crate::source_package::{layout::SourcePackageLayout, parsed_manifest::PackageDigest};
 
 pub fn compute_digest(paths: &[PathBuf]) -> Result<PackageDigest> {
     let mut hashed_files = Vec::new();
+    let mut hash = |path: &Path| {
+        let contents = std::fs::read(path)?;
+        hashed_files.push(format!("{:X}", Sha256::digest(&contents)));
+        Ok(())
+    };
+    let mut maybe_hash_file = |path: &Path| -> Result<()> {
+        match path.extension() {
+            Some(x) if MOVE_EXTENSION == x => hash(path),
+            _ if path.ends_with(SourcePackageLayout::Manifest.path()) => hash(path),
+            _ => Ok(()),
+        }
+    };
 
     for path in paths {
         if path.is_file() {
-            let contents = std::fs::read(path)?;
-            hashed_files.push(format!("{:X}", Sha256::digest(&contents)));
+            maybe_hash_file(path)?;
         } else {
             for entry in walkdir::WalkDir::new(path)
                 .follow_links(true)
                 .into_iter()
                 .filter_map(|e| e.ok())
             {
-                let path = entry.path();
                 if entry.file_type().is_file() {
-                    let contents = std::fs::read(path)?;
-                    hashed_files.push(format!("{:X}", Sha256::digest(&contents)));
+                    maybe_hash_file(entry.path())?
                 }
             }
         }

--- a/language/tools/move-package/tests/package_hash_skips_non_move_files.rs
+++ b/language/tools/move-package/tests/package_hash_skips_non_move_files.rs
@@ -1,0 +1,41 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use move_package::BuildConfig;
+use std::{io::Write, path::Path};
+use tempfile::tempdir;
+
+#[test]
+fn package_hash_skips_non_move_files() {
+    let path = Path::new("tests/test_sources/resolution/dep_good_digest");
+
+    let pkg1 = BuildConfig {
+        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+        ..Default::default()
+    }
+    .resolution_graph_for_package(path)
+    .unwrap();
+
+    let dummy_path = path.join("deps_only/other_dep/sources/dummy_text");
+    std::fs::File::create(&dummy_path)
+        .unwrap()
+        .write_all("hello".as_bytes())
+        .unwrap();
+
+    let pkg2 = BuildConfig {
+        install_dir: Some(tempdir().unwrap().path().to_path_buf()),
+        ..Default::default()
+    }
+    .resolution_graph_for_package(path)
+    .unwrap();
+
+    std::fs::remove_file(&dummy_path).unwrap();
+    for (pkg, res_pkg) in pkg1.package_table {
+        let other_res_pkg = pkg2.get_package(&pkg);
+        assert_eq!(
+            res_pkg.source_digest, other_res_pkg.source_digest,
+            "source digests differ for {}",
+            pkg
+        )
+    }
+}


### PR DESCRIPTION
This PR updates the source digest creation for Move packages to only hash Move files and the `Move.toml` file. Before we were hashing all contents of certain directories of the package, and this lead to issues where hidden and/or git ignored files could be present and result in a different package hash even though the repository/package would appear in a "clean" state.

