### PR TITLE
[shuffle] Account creation on network with faucet

### DIFF
--- a/shuffle/cli/src/account.rs
+++ b/shuffle/cli/src/account.rs
@@ -1,9 +1,8 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{send_transaction, Home};
-use anyhow::{anyhow, Context, Result};
-use diem_config::config::NodeConfig;
+use crate::shared::{send_transaction, Home, Network, NetworkHome, LOCALHOST_NAME};
+use anyhow::{anyhow, Result};
 use diem_crypto::PrivateKey;
 
 use diem_infallible::duration_since_epoch;
@@ -29,122 +28,127 @@ use std::{
 };
 
 // Creates new account from randomly generated private/public key pair.
-pub fn handle(home: &Home, root: Option<PathBuf>) -> Result<()> {
-    if !home.get_shuffle_path().is_dir() {
-        return Err(anyhow!(
-            "A node hasn't been created yet! Run shuffle node first"
-        ));
-    }
+pub fn handle(home: &Home, root: Option<PathBuf>, network: Network) -> Result<()> {
+    let network_home =
+        NetworkHome::new(home.get_networks_path().join(network.get_name()).as_path());
+    check_nodeconfig_exists_if_localhost_used(home, &network)?;
 
-    if home.get_latest_path().exists() {
-        let wants_another_key = confirm_user_decision(home);
-        if wants_another_key {
-            let time = duration_since_epoch();
-            let archive_dir = home.create_archive_dir(time)?;
-            home.archive_old_key(&archive_dir)?;
-            home.archive_old_address(&archive_dir)?;
-        } else {
-            return Ok(());
+    if network_home.get_latest_account_path().exists() {
+        match user_wants_another_key(&network_home) {
+            true => archive_current_files_in_latest(&network_home)?,
+            false => return Ok(()),
         }
     }
 
-    let config = NodeConfig::load(&home.get_validator_config_path()).with_context(|| {
-        format!(
-            "Failed to load NodeConfig from file: {:?}",
-            home.get_validator_config_path()
-        )
-    })?;
-    let json_rpc_url = format!("http://0.0.0.0:{}", config.json_rpc.address.port());
-    println!("Connecting to {}...", json_rpc_url);
-    let client = BlockingClient::new(json_rpc_url);
-    if root.is_some() {
-        home.save_root_key(
-            root.ok_or_else(|| anyhow::anyhow!("Invalid root key path"))?
-                .as_path(),
-        )?;
-    }
-    let mut treasury_account = get_treasury_account(&client, home.get_root_key_path());
+    network_home.generate_network_base_path_if_nonexistent()?;
 
-    create_local_accounts(home, client, &mut treasury_account)
-}
-
-pub fn create_local_accounts(
-    home: &Home,
-    client: BlockingClient,
-    treasury_account: &mut LocalAccount,
-) -> Result<()> {
+    println!("Connecting to {}...", network.get_json_rpc_url()?);
+    let client = BlockingClient::new(network.get_json_rpc_url()?);
     let factory = TransactionFactory::new(ChainId::test());
 
-    home.generate_shuffle_accounts_path()?;
-    home.generate_shuffle_latest_path()?;
+    if let Some(input_root_key) = root {
+        network_home.save_root_key(input_root_key.as_path())?
+    }
 
-    let new_account_key = home.generate_key_file()?;
-    let public_key = new_account_key.public_key();
-    home.generate_address_file(&public_key)?;
-    let new_account = LocalAccount::new(
-        AuthenticationKey::ed25519(&public_key).derived_address(),
-        new_account_key,
-        0,
-    );
+    network_home.generate_network_accounts_path_if_nonexistent()?;
+    network_home.generate_network_latest_account_path_if_nonexistent()?;
 
-    // Create a new account.
-    create_account_onchain(treasury_account, &new_account, &factory, &client)?;
+    let mut treasury_account = get_treasury_account(&client, home.get_root_key_path())?;
+    let new_account = generate_new_account(&network_home)?;
+    create_local_account(&mut treasury_account, &new_account, &factory, &client)?;
 
-    home.generate_shuffle_test_path()?;
-    let test_key = home.generate_testkey_file()?;
-    let public_test_key = test_key.public_key();
-    home.generate_testkey_address_file(&test_key.public_key())?;
-    let test_account = LocalAccount::new(
-        AuthenticationKey::ed25519(&public_test_key).derived_address(),
-        test_key,
-        0,
-    );
-
-    create_account_onchain(treasury_account, &test_account, &factory, &client)
+    network_home.generate_shuffle_test_path_if_nonexistent()?;
+    let test_account = generate_test_account(&network_home)?;
+    create_local_account(&mut treasury_account, &test_account, &factory, &client)
 }
 
-pub fn confirm_user_decision(home: &Home) -> bool {
-    let key_path = home.get_latest_key_path();
-    let prev_key = generate_key::load_key(&key_path);
+fn check_nodeconfig_exists_if_localhost_used(home: &Home, network: &Network) -> Result<()> {
+    match network.get_name().as_str() {
+        LOCALHOST_NAME => match home.get_node_config_path().is_dir() {
+            true => Ok(()),
+            false => Err(anyhow!(
+                "A node hasn't been created yet! Run shuffle node first"
+            )),
+        },
+        _ => Ok(()),
+    }
+}
+
+fn user_wants_another_key(network_home: &NetworkHome) -> bool {
+    let key_path = network_home.get_latest_account_key_path();
+    let prev_public_key = generate_key::load_key(&key_path).public_key();
     println!(
-        "Private Key already exists: {}",
-        ::hex::encode(prev_key.to_bytes())
+        "Public Key already exists: {}",
+        ::hex::encode(prev_public_key.to_bytes())
     );
     println!("Are you sure you want to generate a new key? [y/n]");
 
-    let mut user_response = String::new();
+    let user_response = ask_user_if_they_want_key(String::new());
+    delegate_user_response(user_response.as_str())
+}
+
+fn ask_user_if_they_want_key(mut user_response: String) -> String {
     io::stdin()
         .read_line(&mut user_response)
         .expect("Failed to read line");
-    let user_response = user_response.trim().to_owned();
-
-    if user_response != "y" && user_response != "n" {
-        println!("Please restart and enter either y or n");
-        return false;
-    } else if user_response == "n" {
-        return false;
-    }
-
-    true
+    user_response.trim().to_owned()
 }
 
-pub fn get_treasury_account(client: &BlockingClient, root_key_path: &Path) -> LocalAccount {
-    let root_account_key = load_key(root_key_path);
+fn delegate_user_response(user_response: &str) -> bool {
+    match user_response {
+        "y" => true,
+        "n" => false,
+        _ => {
+            println!("Please restart and enter either y or n");
+            false
+        }
+    }
+}
 
+fn archive_current_files_in_latest(network_home: &NetworkHome) -> Result<()> {
+    let time = duration_since_epoch();
+    let archive_dir = network_home.create_archive_dir(time)?;
+    network_home.archive_old_key(&archive_dir)?;
+    network_home.archive_old_address(&archive_dir)
+}
+
+fn generate_new_account(network_home: &NetworkHome) -> Result<LocalAccount> {
+    let new_account_key = network_home.generate_key_file()?;
+    let public_key = new_account_key.public_key();
+    network_home.generate_address_file(&public_key)?;
+    Ok(LocalAccount::new(
+        AuthenticationKey::ed25519(&public_key).derived_address(),
+        new_account_key,
+        0,
+    ))
+}
+
+fn generate_test_account(network_home: &NetworkHome) -> Result<LocalAccount> {
+    let test_key = network_home.generate_testkey_file()?;
+    let public_test_key = test_key.public_key();
+    network_home.generate_testkey_address_file(&test_key.public_key())?;
+    Ok(LocalAccount::new(
+        AuthenticationKey::ed25519(&public_test_key).derived_address(),
+        test_key,
+        0,
+    ))
+}
+
+pub fn get_treasury_account(client: &BlockingClient, root_key_path: &Path) -> Result<LocalAccount> {
+    let treasury_account_key = load_key(root_key_path);
     let treasury_seq_num = client
-        .get_account(account_config::treasury_compliance_account_address())
-        .unwrap()
+        .get_account(account_config::treasury_compliance_account_address())?
         .into_inner()
         .unwrap()
         .sequence_number;
-    LocalAccount::new(
+    Ok(LocalAccount::new(
         account_config::treasury_compliance_account_address(),
-        root_account_key,
+        treasury_account_key,
         treasury_seq_num,
-    )
+    ))
 }
 
-pub fn create_account_onchain(
+pub fn create_local_account(
     treasury_account: &mut LocalAccount,
     new_account: &LocalAccount,
     factory: &TransactionFactory,
@@ -172,10 +176,6 @@ pub fn create_account_onchain(
         send_transaction(client, create_new_account_txn)?;
         println!("Successfully created account {}", new_account.address());
     }
-    println!(
-        "Private key: {}",
-        ::hex::encode(new_account.private_key().to_bytes())
-    );
     println!("Public key: {}", new_account.public_key());
     Ok(())
 }
@@ -203,4 +203,43 @@ fn encode_create_parent_vasp_account_script_function(
             bcs::to_bytes(&add_all_currencies).unwrap(),
         ],
     ))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::shared;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_check_nodeconfig_exists_if_localhost_used() {
+        let tmpdir = tempdir().unwrap();
+        let dir_path = tmpdir.path();
+        let home = Home::new(dir_path).unwrap();
+        assert_eq!(
+            check_nodeconfig_exists_if_localhost_used(&home, &shared::Network::default()).is_err(),
+            true
+        );
+        fs::create_dir_all(dir_path.join(".shuffle/nodeconfig")).unwrap();
+        assert_eq!(
+            check_nodeconfig_exists_if_localhost_used(&home, &shared::Network::default()).is_err(),
+            false
+        );
+    }
+
+    #[test]
+    fn test_delegate_user_response() {
+        assert_eq!(delegate_user_response("a"), false);
+        assert_eq!(delegate_user_response("n"), false);
+        assert_eq!(delegate_user_response("y"), true);
+    }
+
+    #[test]
+    fn test_ask_user_if_they_want_key() {
+        assert_eq!(ask_user_if_they_want_key("y".to_string()), "y".to_string());
+        assert_eq!(ask_user_if_they_want_key("y ".to_string()), "y".to_string());
+        assert_eq!(ask_user_if_they_want_key("n".to_string()), "n".to_string());
+        assert_eq!(ask_user_if_they_want_key("n ".to_string()), "n".to_string());
+    }
 }

--- a/shuffle/cli/src/console.rs
+++ b/shuffle/cli/src/console.rs
@@ -1,18 +1,17 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared;
+use crate::{shared, shared::Network};
 use anyhow::Result;
 use diem_types::account_address::AccountAddress;
 use std::{path::Path, process::Command};
-use url::Url;
 
 /// Launches a Deno REPL for the shuffle project, generating transaction
 /// builders and loading them into the REPL namespace for easy on chain interaction.
 pub fn handle(
     home: &shared::Home,
     project_path: &Path,
-    network: Url,
+    network: Network,
     key_path: &Path,
     sender_address: AccountAddress,
 ) -> Result<()> {
@@ -50,7 +49,7 @@ pub fn handle(
             .to_string_lossy()
     );
     let filtered_envs =
-        shared::get_filtered_envs_for_deno(home, project_path, &network, key_path, sender_address);
+        shared::get_filtered_envs_for_deno(home, project_path, &network, key_path, sender_address)?;
     Command::new("deno")
         .args(["repl", "--unstable", "--eval", deno_bootstrap.as_str()])
         .envs(&filtered_envs)

--- a/shuffle/cli/src/deploy.rs
+++ b/shuffle/cli/src/deploy.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::{build_move_package, DevApiClient, Home, MAIN_PKG_PATH};
+use crate::shared::{build_move_package, DevApiClient, NetworkHome, MAIN_PKG_PATH};
 use anyhow::{anyhow, Result};
 use diem_crypto::PrivateKey;
 use diem_sdk::{
@@ -24,14 +24,14 @@ use std::{
 use url::Url;
 
 /// Deploys shuffle's main Move Package to the sender's address.
-pub async fn handle(home: &Home, project_path: &Path, network: Url) -> Result<()> {
+pub async fn handle(network_home: &NetworkHome, project_path: &Path, network: Url) -> Result<()> {
     let client = DevApiClient::new(reqwest::Client::new(), network)?;
-    if !home.get_latest_key_path().exists() {
+    if !network_home.get_latest_account_key_path().exists() {
         return Err(anyhow!(
             "An account hasn't been created yet! Run shuffle account first."
         ));
     }
-    let new_account_key = load_key(home.get_latest_key_path());
+    let new_account_key = load_key(network_home.get_latest_account_key_path());
     println!("Using Public Key {}", &new_account_key.public_key());
     let derived_address =
         AuthenticationKey::ed25519(&new_account_key.public_key()).derived_address();

--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -42,11 +42,14 @@ pub async fn main() -> Result<()> {
             .await
         }
 
-        Subcommand::Account { root, network } => account::handle(
-            &home,
-            root,
-            home.get_network_struct_from_toml(normalized_network_name(network).as_str())?,
-        ),
+        Subcommand::Account { root, network } => {
+            account::handle(
+                &home,
+                root,
+                home.get_network_struct_from_toml(normalized_network_name(network).as_str())?,
+            )
+            .await
+        }
 
         Subcommand::Test { cmd } => test::handle(&home, cmd).await,
         Subcommand::Console {

--- a/shuffle/cli/src/node.rs
+++ b/shuffle/cli/src/node.rs
@@ -5,15 +5,12 @@ use crate::{shared, shared::Home};
 use anyhow::Result;
 use diem_config::config::NodeConfig;
 use diem_types::{chain_id::ChainId, on_chain_config::VMPublishingOption};
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 const LAZY_ENABLED: bool = true;
 
 pub fn handle(home: &Home, genesis: Option<String>) -> Result<()> {
-    if !home.get_shuffle_path().is_dir() {
+    if !home.get_node_config_path().is_dir() {
         println!(
             "Creating node config in {}",
             home.get_shuffle_path().display()
@@ -38,8 +35,6 @@ pub fn handle(home: &Home, genesis: Option<String>) -> Result<()> {
 }
 
 fn create_node(home: &Home, genesis: Option<String>) -> Result<()> {
-    fs::create_dir_all(home.get_shuffle_path())?;
-    home.write_default_networks_config_into_toml()?;
     let publishing_option = VMPublishingOption::open();
     let genesis_modules = genesis_modules_from_path(&genesis)?;
     diem_node::load_test_environment(

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -30,7 +30,7 @@ pub const MAIN_PKG_PATH: &str = "main";
 const NEW_KEY_FILE_CONTENT: &[u8] = include_bytes!("../new_account.key");
 const DIEM_ACCOUNT_TYPE: &str = "0x1::DiemAccount::DiemAccount";
 
-const LOCALHOST_NAME: &str = "localhost";
+pub const LOCALHOST_NAME: &str = "localhost";
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "kebab-case")]
@@ -100,18 +100,18 @@ pub fn get_shuffle_project_path(cwd: &Path) -> Result<PathBuf> {
 pub fn get_filtered_envs_for_deno(
     home: &Home,
     project_path: &Path,
-    dev_api_url: &Url,
+    network: &Network,
     key_path: &Path,
     sender_address: AccountAddress,
-) -> HashMap<String, String> {
+) -> Result<HashMap<String, String>> {
     let mut filtered_envs: HashMap<String, String> = HashMap::new();
     filtered_envs.insert(
         String::from("PROJECT_PATH"),
         project_path.to_string_lossy().to_string(),
     );
     filtered_envs.insert(
-        String::from("SHUFFLE_HOME"),
-        home.get_shuffle_path().to_string_lossy().to_string(),
+        String::from("SHUFFLE_BASE_NETWORKS_PATH"),
+        home.get_networks_path().to_string_lossy().to_string(),
     );
     filtered_envs.insert(
         String::from("SENDER_ADDRESS"),
@@ -122,8 +122,12 @@ pub fn get_filtered_envs_for_deno(
         key_path.to_string_lossy().to_string(),
     );
 
-    filtered_envs.insert(String::from("SHUFFLE_NETWORK"), dev_api_url.to_string());
-    filtered_envs
+    filtered_envs.insert(String::from("SHUFFLE_NETWORK_NAME"), network.get_name());
+    filtered_envs.insert(
+        String::from("SHUFFLE_NETWORK_DEV_API_URL"),
+        network.get_dev_api_url()?.to_string(),
+    );
+    Ok(filtered_envs)
 }
 
 pub struct DevApiClient {
@@ -211,76 +215,45 @@ impl DevApiClient {
     }
 }
 
-// Contains all the commonly used paths in shuffle/cli
-pub struct Home {
-    account_path: PathBuf,
-    latest_address_path: PathBuf,
-    latest_key_path: PathBuf,
-    latest_path: PathBuf,
-    networks_config_path: PathBuf,
-    node_config_path: PathBuf,
-    root_key_path: PathBuf,
-    shuffle_path: PathBuf,
-    test_key_address_path: PathBuf,
-    test_key_path: PathBuf,
+pub struct NetworkHome {
+    network_base_path: PathBuf,
+    accounts_path: PathBuf,
+    latest_account_path: PathBuf,
+    latest_account_key_path: PathBuf,
+    latest_account_address_path: PathBuf,
     test_path: PathBuf,
-    validator_config_path: PathBuf,
-    validator_log_path: PathBuf,
+    test_key_path: PathBuf,
+    test_key_address_path: PathBuf,
 }
 
-impl Home {
-    pub fn new(home_path: &Path) -> Result<Self> {
-        Ok(Self {
-            account_path: home_path.join(".shuffle/accounts"),
-            latest_address_path: home_path.join(".shuffle/accounts/latest/address"),
-            latest_key_path: home_path.join(".shuffle/accounts/latest/dev.key"),
-            latest_path: home_path.join(".shuffle/accounts/latest"),
-            networks_config_path: home_path.join(".shuffle/Networks.toml"),
-            node_config_path: home_path.join(".shuffle/nodeconfig"),
-            root_key_path: home_path.join(".shuffle/nodeconfig/mint.key"),
-            shuffle_path: home_path.join(".shuffle"),
-            test_key_address_path: home_path.join(".shuffle/accounts/test/address"),
-            test_key_path: home_path.join(".shuffle/accounts/test/dev.key"),
-            test_path: home_path.join(".shuffle/accounts/test"),
-            validator_config_path: home_path.join(".shuffle/nodeconfig/0/node.yaml"),
-            validator_log_path: home_path.join(".shuffle/nodeconfig/validator.log"),
-        })
+impl NetworkHome {
+    pub fn new(network_base_path: &Path) -> Self {
+        NetworkHome {
+            network_base_path: network_base_path.to_path_buf(),
+            accounts_path: network_base_path.join("accounts"),
+            latest_account_path: network_base_path.join("accounts/latest"),
+            latest_account_key_path: network_base_path.join("accounts/latest/dev.key"),
+            latest_account_address_path: network_base_path.join("accounts/latest/address"),
+            test_path: network_base_path.join("accounts/test"),
+            test_key_path: network_base_path.join("accounts/test/dev.key"),
+            test_key_address_path: network_base_path.join("accounts/test/address"),
+        }
     }
 
-    pub fn get_shuffle_path(&self) -> &Path {
-        &self.shuffle_path
+    pub fn get_latest_account_path(&self) -> &Path {
+        &self.latest_account_path
     }
 
-    pub fn get_root_key_path(&self) -> &Path {
-        &self.root_key_path
+    pub fn get_latest_account_key_path(&self) -> &Path {
+        &self.latest_account_key_path
     }
 
-    pub fn get_node_config_path(&self) -> &Path {
-        &self.node_config_path
+    pub fn get_latest_account_address_path(&self) -> &Path {
+        &self.latest_account_address_path
     }
 
-    pub fn get_validator_config_path(&self) -> &Path {
-        &self.validator_config_path
-    }
-
-    pub fn get_validator_log_path(&self) -> &Path {
-        &self.validator_log_path
-    }
-
-    pub fn get_latest_path(&self) -> &Path {
-        &self.latest_path
-    }
-
-    pub fn get_latest_key_path(&self) -> &Path {
-        &self.latest_key_path
-    }
-
-    pub fn get_latest_address_path(&self) -> &Path {
-        &self.latest_address_path
-    }
-
-    pub fn get_account_path(&self) -> &Path {
-        &self.account_path
+    pub fn get_accounts_path(&self) -> &Path {
+        &self.accounts_path
     }
 
     pub fn get_test_key_path(&self) -> &Path {
@@ -294,35 +267,42 @@ impl Home {
     }
 
     pub fn create_archive_dir(&self, time: Duration) -> Result<PathBuf> {
-        let archived_dir = self.account_path.join(time.as_secs().to_string());
-        fs::create_dir_all(&archived_dir)?;
+        let archived_dir = self.accounts_path.join(time.as_secs().to_string());
+        fs::create_dir(&archived_dir)?;
         Ok(archived_dir)
     }
 
     pub fn archive_old_key(&self, archived_dir: &Path) -> Result<()> {
-        let old_key_path = self.latest_key_path.as_path();
+        let old_key_path = self.latest_account_key_path.as_path();
         let archived_key_path = archived_dir.join("dev.key");
         fs::copy(old_key_path, archived_key_path)?;
         Ok(())
     }
 
     pub fn archive_old_address(&self, archived_dir: &Path) -> Result<()> {
-        let old_address_path = self.latest_address_path.as_path();
+        let old_address_path = self.latest_account_address_path.as_path();
         let archived_address_path = archived_dir.join("address");
         fs::copy(old_address_path, archived_address_path)?;
         Ok(())
     }
 
-    pub fn generate_shuffle_accounts_path(&self) -> Result<()> {
-        if !self.account_path.is_dir() {
-            fs::create_dir_all(self.account_path.as_path())?;
+    pub fn generate_network_accounts_path_if_nonexistent(&self) -> Result<()> {
+        if !self.accounts_path.is_dir() {
+            fs::create_dir(self.accounts_path.as_path())?;
         }
         Ok(())
     }
 
-    pub fn generate_shuffle_latest_path(&self) -> Result<()> {
-        if !self.latest_path.is_dir() {
-            fs::create_dir_all(self.latest_path.as_path())?;
+    pub fn generate_network_latest_account_path_if_nonexistent(&self) -> Result<()> {
+        if !self.latest_account_path.is_dir() {
+            fs::create_dir(self.latest_account_path.as_path())?;
+        }
+        Ok(())
+    }
+
+    pub fn generate_network_base_path_if_nonexistent(&self) -> Result<()> {
+        if !self.network_base_path.is_dir() {
+            fs::create_dir_all(self.network_base_path.as_path())?;
         }
         Ok(())
     }
@@ -330,19 +310,21 @@ impl Home {
     pub fn generate_key_file(&self) -> Result<Ed25519PrivateKey> {
         // Using NEW_KEY_FILE for now due to hard coded address in
         // /diem/shuffle/move/examples/main/sources/move.toml
-        fs::write(self.latest_key_path.as_path(), NEW_KEY_FILE_CONTENT)?;
-        Ok(generate_key::load_key(self.latest_key_path.as_path()))
+        fs::write(self.latest_account_key_path.as_path(), NEW_KEY_FILE_CONTENT)?;
+        Ok(generate_key::load_key(
+            self.latest_account_key_path.as_path(),
+        ))
     }
 
     pub fn generate_address_file(&self, public_key: &Ed25519PublicKey) -> Result<()> {
         let address = AuthenticationKey::ed25519(public_key).derived_address();
-        let address_filepath = self.latest_address_path.as_path();
+        let address_filepath = self.latest_account_address_path.as_path();
         let mut file = File::create(address_filepath)?;
         file.write_all(address.to_string().as_ref())?;
         Ok(())
     }
 
-    pub fn generate_shuffle_test_path(&self) -> Result<()> {
+    pub fn generate_shuffle_test_path_if_nonexistent(&self) -> Result<()> {
         if !self.test_path.is_dir() {
             fs::create_dir_all(self.test_path.as_path())?;
         }
@@ -365,42 +347,125 @@ impl Home {
 
     pub fn save_root_key(&self, root_key_path: &Path) -> Result<()> {
         let new_root_key = generate_key::load_key(root_key_path);
-        generate_key::save_key(new_root_key, self.latest_key_path.as_path());
+        generate_key::save_key(new_root_key, self.latest_account_key_path.as_path());
         Ok(())
     }
 
-    pub fn read_networks_toml(&self) -> Result<NetworksConfig> {
-        let network_toml_contents = fs::read_to_string(self.networks_config_path.as_path())?;
-        let network_toml: NetworksConfig = toml::from_str(network_toml_contents.as_str())?;
-        Ok(network_toml)
-    }
-
-    pub fn read_genesis_waypoint(&self) -> Result<String> {
-        fs::read_to_string(self.get_node_config_path().join("waypoint.txt"))
-            .map_err(anyhow::Error::new)
-    }
-
     pub fn check_account_path_exists(&self) -> Result<()> {
-        match self.account_path.is_dir() {
+        match self.accounts_path.is_dir() {
             true => Ok(()),
             false => Err(anyhow!(
                 "An account hasn't been created yet! Run shuffle account first"
             )),
         }
     }
+}
 
-    pub fn write_default_networks_config_into_toml(&self) -> Result<()> {
-        let networks_config_path = self.shuffle_path.join("Networks.toml");
-        let networks_config_string = toml::to_string_pretty(&NetworksConfig::default())?;
-        fs::write(networks_config_path, networks_config_string)?;
+// Contains all the commonly used paths in shuffle/cli
+pub struct Home {
+    shuffle_path: PathBuf,
+    networks_path: PathBuf,
+    networks_config_path: PathBuf,
+    node_config_path: PathBuf,
+    root_key_path: PathBuf,
+    validator_config_path: PathBuf,
+    validator_log_path: PathBuf,
+}
+
+impl Home {
+    pub fn new(home_path: &Path) -> Result<Self> {
+        Ok(Self {
+            shuffle_path: home_path.join(".shuffle"),
+            networks_path: home_path.join(".shuffle/networks"),
+            networks_config_path: home_path.join(".shuffle/Networks.toml"),
+            node_config_path: home_path.join(".shuffle/nodeconfig"),
+            root_key_path: home_path.join(".shuffle/nodeconfig/mint.key"),
+            validator_log_path: home_path.join(".shuffle/nodeconfig/validator.log"),
+            validator_config_path: home_path.join(".shuffle/nodeconfig/0/node.yaml"),
+        })
+    }
+
+    pub fn get_shuffle_path(&self) -> &Path {
+        &self.shuffle_path
+    }
+
+    pub fn get_networks_path(&self) -> &Path {
+        &self.networks_path
+    }
+
+    pub fn get_root_key_path(&self) -> &Path {
+        &self.root_key_path
+    }
+
+    pub fn get_node_config_path(&self) -> &Path {
+        &self.node_config_path
+    }
+
+    pub fn get_validator_config_path(&self) -> &Path {
+        &self.validator_config_path
+    }
+
+    pub fn get_validator_log_path(&self) -> &Path {
+        &self.validator_log_path
+    }
+
+    pub fn get_network_home(&self, network_name: &str) -> NetworkHome {
+        NetworkHome::new(self.networks_path.join(network_name).as_path())
+    }
+
+    pub fn read_networks_toml(&self) -> Result<NetworksConfig> {
+        self.check_networks_toml_exists()?;
+        let network_toml_contents = fs::read_to_string(self.networks_config_path.as_path())?;
+        let network_toml: NetworksConfig = toml::from_str(network_toml_contents.as_str())?;
+        Ok(network_toml)
+    }
+
+    fn check_networks_toml_exists(&self) -> Result<()> {
+        match self.networks_config_path.exists() {
+            true => Ok(()),
+            false => Err(anyhow!(
+                "A project hasn't been created yet. Run shuffle new first"
+            )),
+        }
+    }
+
+    pub fn read_genesis_waypoint(&self) -> Result<String> {
+        fs::read_to_string(self.node_config_path.join("waypoint.txt")).map_err(anyhow::Error::new)
+    }
+
+    pub fn write_default_networks_config_into_toml_if_nonexistent(&self) -> Result<()> {
+        if !&self.networks_config_path.exists() {
+            let networks_config_string = toml::to_string_pretty(&NetworksConfig::default())?;
+            fs::write(&self.networks_config_path, networks_config_string)?;
+        }
         Ok(())
+    }
+
+    pub fn generate_shuffle_path_if_nonexistent(&self) -> Result<()> {
+        if !self.shuffle_path.exists() {
+            // creates .shuffle folder which will contain localhost nodeconfig,
+            // Networks.toml, and account key/address pairs of each network
+            fs::create_dir(&self.shuffle_path)?;
+        }
+        Ok(())
+    }
+
+    pub fn get_network_struct_from_toml(&self, network: &str) -> Result<Network> {
+        self.read_networks_toml()?.get(network)
     }
 }
 
-pub fn normalized_network(home: &Home, network: Option<String>) -> Result<Url> {
+pub fn normalized_network_url(home: &Home, network: Option<String>) -> Result<Url> {
     match network {
         Some(input) => Ok(home.read_networks_toml()?.get(input.as_str())?.dev_api_url),
         None => Ok(home.read_networks_toml()?.get(LOCALHOST_NAME)?.dev_api_url),
+    }
+}
+
+pub fn normalized_network_name(network: Option<String>) -> String {
+    match network {
+        Some(net) => net,
+        None => String::from(LOCALHOST_NAME),
     }
 }
 
@@ -435,6 +500,20 @@ pub struct Network {
     json_rpc_url: Url,
     dev_api_url: Url,
     faucet_url: Option<Url>,
+}
+
+impl Network {
+    pub fn get_name(&self) -> String {
+        String::from(&self.name)
+    }
+
+    pub fn get_json_rpc_url(&self) -> Result<Url> {
+        Ok(Url::from_str(self.json_rpc_url.as_str())?)
+    }
+
+    pub fn get_dev_api_url(&self) -> Result<Url> {
+        Ok(Url::from_str(self.dev_api_url.as_str())?)
+    }
 }
 
 impl Default for Network {
@@ -543,34 +622,34 @@ mod test {
     }
 
     #[test]
-    fn test_home_create_archive_dir() {
+    fn test_network_home_create_archive_dir() {
         let dir = tempdir().unwrap();
-        fs::create_dir_all(dir.path().join(".shuffle/accounts")).unwrap();
+        fs::create_dir_all(dir.path().join("localhost/accounts")).unwrap();
 
-        let home = Home::new(dir.path()).unwrap();
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
         let time = duration_since_epoch();
-        home.create_archive_dir(time).unwrap();
+        network_home.create_archive_dir(time).unwrap();
         let test_archive_dir = dir
             .path()
-            .join(".shuffle/accounts")
+            .join("localhost/accounts")
             .join(time.as_secs().to_string());
         assert_eq!(test_archive_dir.is_dir(), true);
     }
 
     #[test]
-    fn test_home_archive_old_key() {
+    fn test_network_home_archive_old_key() {
         let dir = tempdir().unwrap();
-        fs::create_dir_all(dir.path().join(".shuffle/accounts/latest")).unwrap();
+        fs::create_dir_all(dir.path().join("localhost/accounts/latest")).unwrap();
 
-        let home = Home::new(dir.path()).unwrap();
-        let private_key = home.generate_key_file().unwrap();
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        let private_key = network_home.generate_key_file().unwrap();
 
         let time = duration_since_epoch();
-        let archived_dir = home.create_archive_dir(time).unwrap();
-        home.archive_old_key(&archived_dir).unwrap();
+        let archived_dir = network_home.create_archive_dir(time).unwrap();
+        network_home.archive_old_key(&archived_dir).unwrap();
         let test_archive_key_path = dir
             .path()
-            .join(".shuffle/accounts")
+            .join("localhost/accounts")
             .join(time.as_secs().to_string())
             .join("dev.key");
         let archived_key = generate_key::load_key(test_archive_key_path);
@@ -579,22 +658,23 @@ mod test {
     }
 
     #[test]
-    fn test_home_archive_old_address() {
+    fn test_network_home_archive_old_address() {
         let dir = tempdir().unwrap();
-        fs::create_dir_all(dir.path().join(".shuffle/accounts/latest")).unwrap();
+        fs::create_dir_all(dir.path().join("localhost/accounts/latest")).unwrap();
 
-        let home = Home::new(dir.path()).unwrap();
-        let private_key = home.generate_key_file().unwrap();
-        home.generate_address_file(&private_key.public_key())
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        let private_key = network_home.generate_key_file().unwrap();
+        network_home
+            .generate_address_file(&private_key.public_key())
             .unwrap();
-        let address_path = dir.path().join(".shuffle/accounts/latest/address");
+        let address_path = dir.path().join("localhost/accounts/latest/address");
 
         let time = duration_since_epoch();
-        let archived_dir = home.create_archive_dir(time).unwrap();
-        home.archive_old_address(&archived_dir).unwrap();
+        let archived_dir = network_home.create_archive_dir(time).unwrap();
+        network_home.archive_old_address(&archived_dir).unwrap();
         let test_archive_address_path = dir
             .path()
-            .join(".shuffle/accounts")
+            .join("localhost/accounts")
             .join(time.as_secs().to_string())
             .join("address");
 
@@ -605,48 +685,56 @@ mod test {
     }
 
     #[test]
-    fn test_home_generate_shuffle_accounts_path() {
+    fn test_network_generate_network_accounts_path_if_nonexistent() {
         let dir = tempdir().unwrap();
-        fs::create_dir_all(dir.path().join(".shuffle")).unwrap();
+        fs::create_dir_all(dir.path().join("localhost")).unwrap();
 
-        let home = Home::new(dir.path()).unwrap();
-        home.generate_shuffle_accounts_path().unwrap();
-        assert_eq!(dir.path().join(".shuffle/accounts").is_dir(), true);
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        network_home
+            .generate_network_accounts_path_if_nonexistent()
+            .unwrap();
+        assert_eq!(dir.path().join("localhost/accounts").is_dir(), true);
     }
 
     #[test]
-    fn test_home_generate_shuffle_latest_path() {
+    fn test_network_home_generate_network_latest_account_path_if_nonexistent() {
         let dir = tempdir().unwrap();
-        fs::create_dir_all(dir.path().join(".shuffle/accounts")).unwrap();
+        fs::create_dir_all(dir.path().join("localhost/accounts")).unwrap();
 
-        let home = Home::new(dir.path()).unwrap();
-        home.generate_shuffle_latest_path().unwrap();
-        assert_eq!(dir.path().join(".shuffle/accounts/latest").is_dir(), true);
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        network_home
+            .generate_network_latest_account_path_if_nonexistent()
+            .unwrap();
+        assert_eq!(dir.path().join("localhost/accounts/latest").is_dir(), true);
     }
 
     #[test]
-    fn test_home_generate_key_file() {
+    fn test_network_home_generate_key_file() {
         let dir = tempdir().unwrap();
-        fs::create_dir_all(dir.path().join(".shuffle/accounts/latest")).unwrap();
+        fs::create_dir_all(dir.path().join("localhost/accounts/latest")).unwrap();
 
-        let home = Home::new(dir.path()).unwrap();
-        home.generate_key_file().unwrap();
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        network_home.generate_key_file().unwrap();
         assert_eq!(
-            dir.path().join(".shuffle/accounts/latest/dev.key").exists(),
+            dir.path()
+                .join("localhost/accounts/latest/dev.key")
+                .exists(),
             true
         );
     }
 
     #[test]
-    fn test_home_generate_address_file() {
+    fn test_network_home_generate_address_file() {
         let dir = tempdir().unwrap();
-        fs::create_dir_all(dir.path().join(".shuffle/accounts/latest")).unwrap();
+        fs::create_dir_all(dir.path().join("localhost/accounts/latest")).unwrap();
 
-        let home = Home::new(dir.path()).unwrap();
-        let public_key = home.generate_key_file().unwrap().public_key();
-        home.generate_address_file(&public_key).unwrap();
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        let public_key = network_home.generate_key_file().unwrap().public_key();
+        network_home.generate_address_file(&public_key).unwrap();
         assert_eq!(
-            dir.path().join(".shuffle/accounts/latest/address").exists(),
+            dir.path()
+                .join("localhost/accounts/latest/address")
+                .exists(),
             true
         );
     }
@@ -683,19 +771,19 @@ mod test {
     }
 
     #[test]
-    fn test_home_get_latest_path() {
+    fn test_network_home_get_latest_path() {
         let dir = tempdir().unwrap();
-        let home = Home::new(dir.path()).unwrap();
-        let correct_dir = dir.path().join(".shuffle/accounts/latest");
-        assert_eq!(correct_dir, home.get_latest_path());
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        let correct_dir = dir.path().join("localhost/accounts/latest");
+        assert_eq!(correct_dir, network_home.get_latest_account_path());
     }
 
     #[test]
-    fn test_home_get_account_path() {
+    fn test_network_home_get_accounts_path() {
         let dir = tempdir().unwrap();
-        let home = Home::new(dir.path()).unwrap();
-        let correct_dir = dir.path().join(".shuffle/accounts");
-        assert_eq!(correct_dir, home.get_account_path());
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        let correct_dir = dir.path().join("localhost/accounts");
+        assert_eq!(correct_dir, network_home.get_accounts_path());
     }
 
     #[test]
@@ -707,6 +795,15 @@ mod test {
     }
 
     #[test]
+    fn test_home_generate_shuffle_path_if_nonexistent() {
+        let dir = tempdir().unwrap();
+        let home = Home::new(dir.path()).unwrap();
+        assert_eq!(dir.path().join(".shuffle").exists(), false);
+        home.generate_shuffle_path_if_nonexistent().unwrap();
+        assert_eq!(dir.path().join(".shuffle").exists(), true);
+    }
+
+    #[test]
     fn test_home_get_root_key_path() {
         let dir = tempdir().unwrap();
         let home = Home::new(dir.path()).unwrap();
@@ -715,23 +812,23 @@ mod test {
     }
 
     #[test]
-    fn test_home_get_latest_key_path() {
+    fn test_network_home_get_latest_key_path() {
         let dir = tempdir().unwrap();
-        let home = Home::new(dir.path()).unwrap();
-        let correct_dir = dir.path().join(".shuffle/accounts/latest/dev.key");
-        assert_eq!(correct_dir, home.get_latest_key_path());
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        let correct_dir = dir.path().join("localhost/accounts/latest/dev.key");
+        assert_eq!(correct_dir, network_home.get_latest_account_key_path());
     }
 
     #[test]
-    fn test_save_root_key() {
+    fn test_network_home_save_root_key() {
         let dir = tempdir().unwrap();
-        fs::create_dir_all(dir.path().join(".shuffle/accounts/latest")).unwrap();
+        fs::create_dir_all(dir.path().join("localhost/accounts/latest")).unwrap();
         let user_root_key_path = dir.path().join("root.key");
         let user_root_key = generate_key::generate_and_save_key(&user_root_key_path);
 
-        let home = Home::new(dir.path()).unwrap();
-        home.save_root_key(&user_root_key_path).unwrap();
-        let new_root_key = generate_key::load_key(home.latest_key_path);
+        let network_home = NetworkHome::new(dir.path().join("localhost").as_path());
+        network_home.save_root_key(&user_root_key_path).unwrap();
+        let new_root_key = generate_key::load_key(network_home.get_latest_account_key_path());
 
         assert_eq!(new_root_key, user_root_key);
     }
@@ -741,10 +838,11 @@ mod test {
         let dir = tempdir().unwrap();
         fs::create_dir_all(dir.path().join(".shuffle")).unwrap();
         let home = Home::new(dir.path()).unwrap();
-        home.write_default_networks_config_into_toml().unwrap();
+        home.write_default_networks_config_into_toml_if_nonexistent()
+            .unwrap();
 
-        let url_from_some = normalized_network(&home, Some("localhost".to_string())).unwrap();
-        let url_from_none = normalized_network(&home, None).unwrap();
+        let url_from_some = normalized_network_url(&home, Some("localhost".to_string())).unwrap();
+        let url_from_none = normalized_network_url(&home, None).unwrap();
 
         let correct_url = Url::from_str("http://127.0.0.1:8080").unwrap();
 
@@ -753,15 +851,15 @@ mod test {
     }
 
     #[test]
-    fn test_check_account_dir_exists() {
+    fn test_network_home_check_account_dir_exists() {
         let bad_dir = tempdir().unwrap();
-        let home = Home::new(bad_dir.path()).unwrap();
-        assert_eq!(home.check_account_path_exists().is_err(), true);
+        let network_home = NetworkHome::new(bad_dir.path().join("localhost").as_path());
+        assert_eq!(network_home.check_account_path_exists().is_err(), true);
 
         let good_dir = tempdir().unwrap();
-        fs::create_dir_all(good_dir.path().join(".shuffle/accounts")).unwrap();
-        let home = Home::new(good_dir.path()).unwrap();
-        assert_eq!(home.check_account_path_exists().is_err(), false);
+        fs::create_dir_all(good_dir.path().join("localhost/accounts")).unwrap();
+        let network_home = NetworkHome::new(good_dir.path().join("localhost").as_path());
+        assert_eq!(network_home.check_account_path_exists().is_err(), false);
     }
 
     #[test]
@@ -769,7 +867,8 @@ mod test {
         let dir = tempdir().unwrap();
         let home = Home::new(dir.path()).unwrap();
         fs::create_dir_all(dir.path().join(".shuffle")).unwrap();
-        home.write_default_networks_config_into_toml().unwrap();
+        home.write_default_networks_config_into_toml_if_nonexistent()
+            .unwrap();
         let networks_cfg = home.read_networks_toml().unwrap();
         assert_eq!(networks_cfg, NetworksConfig::default());
     }
@@ -814,19 +913,19 @@ mod test {
         let dir = tempdir().unwrap();
         let home = Home::new(dir.path()).unwrap();
         let project_path = Path::new("/Users/project_path");
-        let network = Url::from_str("http://127.0.0.1:8080").unwrap();
+        let network = get_test_localhost_network();
         let key_path = Path::new("/Users/private_key_path/dev.key");
         let address = AccountAddress::random();
         let filtered_envs =
-            get_filtered_envs_for_deno(&home, project_path, &network, key_path, address);
+            get_filtered_envs_for_deno(&home, project_path, &network, key_path, address).unwrap();
 
         assert_eq!(
             filtered_envs.get("PROJECT_PATH").unwrap(),
             &project_path.to_string_lossy().to_string()
         );
         assert_eq!(
-            filtered_envs.get("SHUFFLE_HOME").unwrap(),
-            home.get_shuffle_path().to_string_lossy().as_ref(),
+            filtered_envs.get("SHUFFLE_BASE_NETWORKS_PATH").unwrap(),
+            home.get_networks_path().to_string_lossy().as_ref(),
         );
         assert_eq!(
             filtered_envs.get("SENDER_ADDRESS").unwrap(),
@@ -837,8 +936,12 @@ mod test {
             &key_path.to_string_lossy().to_string()
         );
         assert_eq!(
-            filtered_envs.get("SHUFFLE_NETWORK").unwrap(),
-            &network.to_string()
+            filtered_envs.get("SHUFFLE_NETWORK_NAME").unwrap(),
+            &network.name
+        );
+        assert_eq!(
+            filtered_envs.get("SHUFFLE_NETWORK_DEV_API_URL").unwrap(),
+            &network.dev_api_url.to_string()
         )
     }
 
@@ -884,5 +987,16 @@ mod test {
             .is_err(),
             true
         );
+    }
+
+    #[test]
+    fn test_home_check_networks_toml_exists() {
+        let dir = tempdir().unwrap();
+        let home = Home::new(dir.path()).unwrap();
+        assert_eq!(home.check_networks_toml_exists().is_err(), true);
+        fs::create_dir_all(dir.path().join(".shuffle")).unwrap();
+        home.write_default_networks_config_into_toml_if_nonexistent()
+            .unwrap();
+        assert_eq!(home.check_networks_toml_exists().is_err(), false);
     }
 }

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -3,10 +3,9 @@
 
 use crate::{
     account, deploy,
-    shared::{self, MAIN_PKG_PATH},
+    shared::{self, normalized_network_name, Home, Network, NetworkHome, MAIN_PKG_PATH},
 };
-use anyhow::{anyhow, Context, Result};
-use diem_config::config::NodeConfig;
+use anyhow::{anyhow, Result};
 use diem_crypto::PrivateKey;
 use diem_sdk::{
     client::{AccountAddress, BlockingClient},
@@ -16,49 +15,45 @@ use diem_sdk::{
 use diem_types::{chain_id::ChainId, transaction::authenticator::AuthenticationKey};
 use move_cli::package::cli;
 use move_package::BuildConfig;
-use shared::Home;
 use std::{
     path::{Path, PathBuf},
     process::Command,
-    str::FromStr,
 };
 use structopt::StructOpt;
 use url::Url;
 
-pub async fn run_e2e_tests(home: &Home, project_path: &Path, network: Url) -> Result<()> {
+pub async fn run_e2e_tests(home: &Home, project_path: &Path, network: Network) -> Result<()> {
+    let network_home = NetworkHome::new(
+        home.get_networks_path()
+            .join(shared::LOCALHOST_NAME)
+            .as_path(),
+    );
     let _config = shared::read_project_config(project_path)?;
     shared::generate_typescript_libraries(project_path)?;
 
-    let config = NodeConfig::load(&home.get_validator_config_path()).with_context(|| {
-        format!(
-            "Failed to load NodeConfig from file: {:?}",
-            home.get_validator_config_path()
-        )
-    })?;
-    println!("Connecting to {}...", network.as_str());
-    let client = BlockingClient::new(network.as_str());
+    println!("Connecting to {}...", network.get_json_rpc_url()?);
+    let client = BlockingClient::new(network.get_json_rpc_url()?.as_str());
     let factory = TransactionFactory::new(ChainId::test());
 
     let test_account = create_account(
         home.get_root_key_path(),
-        home.get_test_key_path(),
+        network_home.get_test_key_path(),
         &client,
         &factory,
     )?;
     let _receiver_account = create_account(
         home.get_root_key_path(),
-        home.get_test_key_path(), // TODO: update to a different key to sender
+        network_home.get_test_key_path(), // TODO: update to a different key to sender
         &client,
         &factory,
     )?;
-    deploy::handle(home, project_path, network.clone()).await?;
+    deploy::handle(&network_home, project_path, network.get_dev_api_url()?).await?;
 
     run_deno_test(
         home,
         project_path,
-        &Url::from_str(config.json_rpc.address.to_string().as_str())?,
         &network,
-        home.get_test_key_path(),
+        network_home.get_test_key_path(),
         test_account.address(),
     )
 }
@@ -69,13 +64,13 @@ fn create_account(
     client: &BlockingClient,
     factory: &TransactionFactory,
 ) -> Result<LocalAccount> {
-    let mut treasury_account = account::get_treasury_account(client, root_key_path);
+    let mut treasury_account = account::get_treasury_account(client, root_key_path)?;
     // TODO: generate random key by using let account_key = generate_key::generate_key();
     let account_key = generate_key::load_key(account_key_path);
     let public_key = account_key.public_key();
     let derived_address = AuthenticationKey::ed25519(&public_key).derived_address();
     let new_account = LocalAccount::new(derived_address, account_key, 0);
-    account::create_account_onchain(&mut treasury_account, &new_account, factory, client)?;
+    account::create_local_account(&mut treasury_account, &new_account, factory, client)?;
     Ok(new_account)
 }
 
@@ -83,8 +78,7 @@ fn create_account(
 pub fn run_deno_test(
     home: &Home,
     project_path: &Path,
-    json_rpc_url: &Url,
-    dev_api_url: &Url,
+    network: &Network,
     key_path: &Path,
     sender_address: AccountAddress,
 ) -> Result<()> {
@@ -94,24 +88,19 @@ pub fn run_deno_test(
         .to_string_lossy()
         .to_string();
 
-    let filtered_envs = shared::get_filtered_envs_for_deno(
-        home,
-        project_path,
-        dev_api_url,
-        key_path,
-        sender_address,
-    );
+    let filtered_envs =
+        shared::get_filtered_envs_for_deno(home, project_path, network, key_path, sender_address)?;
     Command::new("deno")
         .args([
             "test",
             "--unstable",
             tests_path_string.as_str(),
-            "--allow-env=PROJECT_PATH,SHUFFLE_HOME,SHUFFLE_NETWORK,PRIVATE_KEY_PATH,SENDER_ADDRESS",
+            "--allow-env=PROJECT_PATH,SHUFFLE_BASE_NETWORKS_PATH,SHUFFLE_NETWORK_NAME,SHUFFLE_NETWORK_DEV_API_URL,PRIVATE_KEY_PATH,SENDER_ADDRESS",
             "--allow-read",
             format!(
                 "--allow-net={},{}",
-                host_and_port(dev_api_url)?,
-                host_and_port(json_rpc_url)?,
+                host_and_port(&network.get_dev_api_url()?)?,
+                host_and_port(&network.get_json_rpc_url()?)?,
             )
             .as_str(),
         ])
@@ -204,7 +193,9 @@ pub async fn handle(home: &Home, cmd: TestCommand) -> Result<()> {
             run_e2e_tests(
                 home,
                 shared::normalized_project_path(project_path)?.as_path(),
-                shared::normalized_network(home, network)?,
+                home.get_network_struct_from_toml(
+                    normalized_network_name(network.clone()).as_str(),
+                )?,
             )
             .await
         }
@@ -220,7 +211,9 @@ pub async fn handle(home: &Home, cmd: TestCommand) -> Result<()> {
             run_e2e_tests(
                 home,
                 normalized_path.as_path(),
-                shared::normalized_network(home, network)?,
+                home.get_network_struct_from_toml(
+                    normalized_network_name(network.clone()).as_str(),
+                )?,
             )
             .await
         }

--- a/shuffle/integration-tests/src/helper.rs
+++ b/shuffle/integration-tests/src/helper.rs
@@ -2,14 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use diem_sdk::{client::BlockingClient, types::LocalAccount};
-use shuffle::{account, deploy, new, shared::Home};
+use diem_sdk::{
+    client::BlockingClient, transaction_builder::TransactionFactory, types::LocalAccount,
+};
+use shuffle::{
+    account, deploy, new,
+    shared::{Home, NetworkHome, LOCALHOST_NAME},
+};
 use std::{path::PathBuf, str::FromStr};
 use tempfile::TempDir;
 use url::Url;
 
 pub struct ShuffleTestHelper {
     home: Home,
+    network_home: NetworkHome,
     tmp_dir: TempDir,
 }
 
@@ -17,11 +23,20 @@ impl ShuffleTestHelper {
     pub fn new() -> Result<Self> {
         let tmp_dir = TempDir::new()?;
         let home = Home::new(tmp_dir.path())?;
-        Ok(Self { tmp_dir, home })
+        let network_home = home.get_network_home(LOCALHOST_NAME);
+        Ok(Self {
+            tmp_dir,
+            home,
+            network_home,
+        })
     }
 
     pub fn home(&self) -> &Home {
         &self.home
+    }
+
+    pub fn network_home(&self) -> NetworkHome {
+        self.home.get_network_home(LOCALHOST_NAME)
     }
 
     pub fn project_path(&self) -> PathBuf {
@@ -31,17 +46,23 @@ impl ShuffleTestHelper {
     pub fn create_accounts(
         &self,
         treasury_account: &mut LocalAccount,
+        new_account: LocalAccount,
+        factory: TransactionFactory,
         client: BlockingClient,
     ) -> Result<()> {
-        account::create_local_accounts(&self.home, client, treasury_account)
+        account::create_local_account(treasury_account, &new_account, &factory, &client)
     }
 
     pub fn create_project(&self) -> Result<()> {
-        new::handle(new::DEFAULT_BLOCKCHAIN.to_string(), self.project_path())
+        new::handle(
+            &self.home,
+            new::DEFAULT_BLOCKCHAIN.to_string(),
+            self.project_path(),
+        )
     }
 
     pub async fn deploy_project(&self, dev_api_url: &str) -> Result<()> {
         let url = Url::from_str(dev_api_url)?;
-        deploy::handle(&self.home, &self.project_path(), url).await
+        deploy::handle(&self.network_home, &self.project_path(), url).await
     }
 }

--- a/shuffle/move/examples/main/context.ts
+++ b/shuffle/move/examples/main/context.ts
@@ -7,10 +7,11 @@ import { BcsDeserializer } from "./generated/bcs/mod.ts";
 import { green } from "https://deno.land/x/nanocolors@0.1.12/mod.ts";
 import { isURL } from "https://deno.land/x/is_url@v1.0.1/mod.ts";
 
-export const shuffleDir = String(Deno.env.get("SHUFFLE_HOME"));
+export const shuffleBaseNetworksPath = String(Deno.env.get("SHUFFLE_BASE_NETWORKS_PATH"));
 export const projectPath = String(Deno.env.get("PROJECT_PATH"));
+export const networkName = String(Deno.env.get("SHUFFLE_NETWORK_NAME"))
 export const nodeUrl = getNetworkEndpoint(
-  String(Deno.env.get("SHUFFLE_NETWORK")),
+  String(Deno.env.get("SHUFFLE_NETWORK_DEV_API_URL")),
 );
 export const senderAddress = String(Deno.env.get("SENDER_ADDRESS"));
 export const privateKeyPath = String(Deno.env.get("PRIVATE_KEY_PATH"));
@@ -19,12 +20,14 @@ const privateKeyBytes = bcsToBytes(
 );
 
 export const receiverPrivateKeyPath = path.join(
-  shuffleDir,
-  "accounts/test/dev.key",
+    shuffleBaseNetworksPath,
+    networkName,
+    "accounts/test/dev.key",
 );
 export const receiverAddressPath = path.join(
-  shuffleDir,
-  "accounts/test/address",
+    shuffleBaseNetworksPath,
+    networkName,
+    "accounts/test/address",
 );
 export const receiverAddress = await Deno.readTextFile(receiverAddressPath);
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The final piece that we need to connect to trove testnet is by using a faucet to create an account onto the network. This PR achieves this. 

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

Note: To mimic creating an account on trove testnet using the faucet, I set the contents of trove_testnet in the Networks.toml to the localhost information with the faucet url matching the faucet url, I used when spinning up a local faucet.

Also I changed line 247 to `let faucet_account_creation_endpoint = network.get_faucet_url()?;` for my testing.

When creating an account for the first time on trove testnet, I ran `cargo run -p shuffle -- account --network trove_testnet`. I'm prompted with this message: 

<img width="775" alt="Screen Shot 2021-11-15 at 6 23 20 PM" src="https://user-images.githubusercontent.com/55404786/141892610-cf49db09-6b85-4501-8883-c5656d9fd44a.png">

I then add the proper trove testnet information into my Networks.toml file:

<img width="836" alt="Screen Shot 2021-11-15 at 6 24 40 PM" src="https://user-images.githubusercontent.com/55404786/141894194-e15ebbba-e804-43a4-b249-e3745426bcf7.png">

Since I am mimicking account creation on trove testnet with a local faucet, I first spin up a local node using `cargo run -p shuffle -- node`. Then I spin up a faucet in another terminal using this command: `cargo run -p diem-faucet -- --address 127.0.0.1 --port 8082 --chain-id TESTING --mint-key-file-path /Users/avinash00/.shuffle/nodeconfig/mint.key --server-url http://127.0.0.1:8080`. Here is what it looks like:

![image](https://user-images.githubusercontent.com/55404786/141894515-00ed0c6b-bb80-46a6-9a4b-63004f69b8fc.png)

Then I rerun cargo run `cargo run -p shuffle -- account --network trove_testnet` and get this output:

![image](https://user-images.githubusercontent.com/55404786/141929640-aba38670-465f-4360-924c-98053f2bb64e.png)

To test if this actually created an account using the faucet, I opened up console using `cargo run -p shuffle -- console -p project_path --network trove_testnet` and typed `await devapi.accountTransactions()` and got this: 

![image](https://user-images.githubusercontent.com/55404786/141928223-8b6869a4-6a1f-4a72-82f5-30179e736ad0.png)

Luckily this didn't error out. To continue testing the usability of my fauceted account, I deployed a module using `cargo run -p shuffle -- deploy -p project_path --network trove_testnet` and all the usual modules deployed:

![image](https://user-images.githubusercontent.com/55404786/141928371-7422aa45-e63f-45b0-b599-c7e335c2c84a.png)

The last thing we have to check is if the modules appear in console. I reran `await devapi.accountTransactions()` in console and got 3 transactions in my terminal:

![image](https://user-images.githubusercontent.com/55404786/141928512-7462dbe2-be33-4045-8ada-0460f86ac8b6.png)

This was all done using the local faucet but I've proven that I can create an account using a faucet. Hopefully we can use the same code to connect to trove testnet!

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
