### PR TITLE
[move] Add messages to token errors in Move IR

### DIFF
--- a/language/move-ir-compiler/ir-to-bytecode/src/parser.rs
+++ b/language/move-ir-compiler/ir-to-bytecode/src/parser.rs
@@ -56,15 +56,14 @@ pub fn parse_module(modules_str: &str) -> Result<ast::ModuleDefinition> {
 
 fn handle_error<T>(e: syntax::ParseError<Loc, anyhow::Error>, code_str: &str) -> Result<T> {
     let location = match &e {
-        ParseError::InvalidToken { location } => location,
+        ParseError::InvalidToken { location, .. } => location,
         ParseError::User { location, .. } => location,
     };
     let mut files = SimpleFiles::new();
     let id = files.add(location.file_hash(), code_str.to_string());
     let lbl = match &e {
-        ParseError::InvalidToken { .. } => {
-            Label::primary(id, location.usize_range()).with_message("Invalid Token")
-        }
+        ParseError::InvalidToken { message, .. } => Label::primary(id, location.usize_range())
+            .with_message(format!("Invalid Token: {}", message)),
         ParseError::User { error, .. } => {
             Label::primary(id, location.usize_range()).with_message(format!("{}", error))
         }

--- a/language/move-ir-compiler/ir-to-bytecode/syntax/src/lexer.rs
+++ b/language/move-ir-compiler/ir-to-bytecode/syntax/src/lexer.rs
@@ -387,10 +387,13 @@ impl<'input> Lexer<'input> {
             '}' => (Tok::RBrace, 1),
             '[' => (Tok::LSquare, 1), // for vector specs
             ']' => (Tok::RSquare, 1), // for vector specs
-            _ => {
+            c => {
                 let idx = start_offset as u32;
                 let location = Loc::new(self.file_hash(), idx, idx);
-                return Err(ParseError::InvalidToken { location });
+                return Err(ParseError::InvalidToken {
+                    location,
+                    message: format!("unrecognized character for token {:?}", c),
+                });
             }
         };
 


### PR DESCRIPTION
Currently when the Move IR lexer or parser encounter a token they don't expect, they exit with an error message that the token is not valid at its location, but they don't indicate what was expected at that location. Add a required message field to make it clearer to users.

(This falls short of modifying the Move IR lexer and parser to emit diagnostics, which would be a much larger change, in favor of making them slightly more user-friendly with very little changes.)