### PR TITLE
[shuffle] TS transactionSuccess->waitForTransactionCompletion

### DIFF
--- a/shuffle/move/examples/e2e/message.test.ts
+++ b/shuffle/move/examples/e2e/message.test.ts
@@ -15,20 +15,20 @@ Deno.test("Test Assert", () => {
 });
 
 Deno.test("Ability to set message", async () => {
-  const txn = await main.setMessageScriptFunction("hello blockchain");
+  let txn = await main.setMessageScriptFunction("hello blockchain");
+  txn = await devapi.waitForTransactionCompletion(txn.hash);
+  assert(txn.success);
 
-  assert(await devapi.transactionSuccess(txn.hash)); // wait for txn to succeed
-
-  const expected = "\x00hello blockchain"; // prefixed with \x00 bc of bcs encoding
+  const expected = "\x00hello blockchain"; // prefixed with \x00 bc of BCS encoding
   const messages = await main.decodedMessages();
   assertEquals(messages[0], expected);
 });
 
 Deno.test("Ability to set NFTs", async () => {
   const contentUri = "https://placekitten.com/200/300";
-  const txn = await main.createTestNFTScriptFunction(contentUri);
-
-  assert(await devapi.transactionSuccess(txn.hash)); // wait for txn to succeed
+  let txn = await main.createTestNFTScriptFunction(contentUri);
+  txn = await devapi.waitForTransactionCompletion(txn.hash);
+  assert(txn.success);
 
   const uris = await main.decodedNFTs();
   assertEquals(uris[0], "\x00" + contentUri);

--- a/shuffle/move/examples/integration/helpers.test.ts
+++ b/shuffle/move/examples/integration/helpers.test.ts
@@ -16,8 +16,8 @@ Deno.test("invokeScriptFunction", async () => {
     [],
     ["invoked script function"],
   );
-  assert(await devapi.transactionSuccess(txn.hash));
-  txn = await devapi.transaction(txn.hash);
+  txn = await devapi.waitForTransactionCompletion(txn.hash);
+  assert(txn.success);
 
   assertEquals(txn.vm_status, "Executed successfully");
   assertEquals(txn.payload.function, scriptFunction);

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -31,13 +31,12 @@ export async function transaction(versionOrHash: string) {
   );
 }
 
-// Polls for a specific transaction to complete, returning the `success`
-// field when no longer pending.
-export async function transactionSuccess(versionOrHash: string): Promise<boolean> {
+// Polls for a specific transaction to complete, returning the txn object.
+export async function waitForTransactionCompletion(versionOrHash: string): Promise<any> {
   let txn = await transaction(versionOrHash);
   for (let i = 0; i < 20; i++) {
     if (txn.type !== "pending_transaction") {
-      return txn.success;
+      return txn;
     }
     await delay(500);
     txn = await transaction(versionOrHash);


### PR DESCRIPTION


## Motivation

`await transactionSuccess(...)` didn't read well and threw away a lot of useful txn information. Renamed it to `waitForTransactionCompletion` and returned txn instead of `success` bool resulted in a more ergonomic API. Suggested by @bmwill .

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

1. cargo test -p shuffle-integration-tests
2. CI