### PR TITLE
[move-prover] Upgrade Z3 version

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -25,7 +25,7 @@ KUBECTL_VERSION=1.18.6
 TERRAFORM_VERSION=0.12.26
 HELM_VERSION=3.2.4
 VAULT_VERSION=1.5.0
-Z3_VERSION=4.8.9
+Z3_VERSION=4.8.12
 CVC4_VERSION=aac53f51
 CVC5_VERSION=0.0.3
 DOTNET_VERSION=5.0
@@ -480,9 +480,9 @@ function install_z3 {
      return
   fi
   if [[ "$(uname)" == "Linux" ]]; then
-    Z3_PKG="z3-$Z3_VERSION-x64-ubuntu-16.04"
+    Z3_PKG="z3-$Z3_VERSION-x64-glibc-2.31"
   elif [[ "$(uname)" == "Darwin" ]]; then
-    Z3_PKG="z3-$Z3_VERSION-x64-osx-10.14.6"
+    Z3_PKG="z3-$Z3_VERSION-x64-osx-10.15.7"
   else
     echo "Z3 support not configured for this platform (uname=$(uname))"
     return


### PR DESCRIPTION
- Bump up the Z3 version from 4.8.9 to 4.8.12
  - according to the [release note](https://github.com/Z3Prover/z3/blob/master/RELEASE_NOTES), the newest version has some update on the arithmetic solver, and also has many general bug fixes

- The running time of `MVP_TEST_ON_CI=1 cargo test -p move-prover
--release` almost remains the same (comparing "before" and "after").
  - `MVP_TEST_ON_CI=1` was given in this benchmark test to exclude the cvc4 tests. The cvc4 tests are not related to the Z3 performance, and the cvc4 tests don't work at the moment.

- Commented out an unused line from `diem/shuffle/move/examples/main/context.ts` because the deno linter complains about it in CI
  - See https://github.com/diem/diem/runs/4250122831?check_suite_focus=true#step:7:38

## Motivation

To upgrade the Z3 version

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test
