### PR TITLE
[api] use boxed filter to improve compile perf

### DIFF
--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -16,19 +16,10 @@ use diem_types::{
 use anyhow::Result;
 use move_core_types::{identifier::Identifier, language_storage::StructTag, value::MoveValue};
 use std::convert::TryInto;
-use warp::{Filter, Rejection, Reply};
-
-pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    get_account_resources(context.clone())
-        .or(get_account_resources_by_ledger_version(context.clone()))
-        .or(get_account_modules(context.clone()))
-        .or(get_account_modules_by_ledger_version(context))
-}
+use warp::{filters::BoxedFilter, Filter, Rejection, Reply};
 
 // GET /accounts/<address>/resources
-pub fn get_account_resources(
-    context: Context,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn get_account_resources(context: Context) -> BoxedFilter<(impl Reply,)> {
     warp::path!("accounts" / AddressParam / "resources")
         .and(warp::get())
         .and(context.filter())
@@ -36,12 +27,11 @@ pub fn get_account_resources(
         .untuple_one()
         .and_then(handle_get_account_resources)
         .with(metrics("get_account_resources"))
+        .boxed()
 }
 
 // GET /ledger/<version>/accounts/<address>/resources
-pub fn get_account_resources_by_ledger_version(
-    context: Context,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn get_account_resources_by_ledger_version(context: Context) -> BoxedFilter<(impl Reply,)> {
     warp::path!("ledger" / LedgerVersionParam / "accounts" / AddressParam / "resources")
         .and(warp::get())
         .and(context.filter())
@@ -49,12 +39,11 @@ pub fn get_account_resources_by_ledger_version(
         .untuple_one()
         .and_then(handle_get_account_resources)
         .with(metrics("get_account_resources_by_ledger_version"))
+        .boxed()
 }
 
 // GET /accounts/<address>/modules
-pub fn get_account_modules(
-    context: Context,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn get_account_modules(context: Context) -> BoxedFilter<(impl Reply,)> {
     warp::path!("accounts" / AddressParam / "modules")
         .and(warp::get())
         .and(context.filter())
@@ -62,12 +51,11 @@ pub fn get_account_modules(
         .untuple_one()
         .and_then(handle_get_account_modules)
         .with(metrics("get_account_modules"))
+        .boxed()
 }
 
 // GET /ledger/<version>/accounts/<address>/modules
-pub fn get_account_modules_by_ledger_version(
-    context: Context,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn get_account_modules_by_ledger_version(context: Context) -> BoxedFilter<(impl Reply,)> {
     warp::path!("ledger" / LedgerVersionParam / "accounts" / AddressParam / "modules")
         .and(warp::get())
         .and(context.filter())
@@ -75,6 +63,7 @@ pub fn get_account_modules_by_ledger_version(
         .untuple_one()
         .and_then(handle_get_account_modules)
         .with(metrics("get_account_modules_by_ledger_version"))
+        .boxed()
 }
 
 async fn handle_get_account_resources(

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -25,7 +25,7 @@ use std::{
     convert::{Infallible, TryFrom},
     sync::Arc,
 };
-use warp::{Filter, Rejection, Reply};
+use warp::{filters::BoxedFilter, Filter, Reply};
 
 // Context holds application scope context
 #[derive(Clone)]
@@ -228,13 +228,11 @@ impl Context {
             .collect::<Vec<_>>())
     }
 
-    pub fn health_check_route(
-        &self,
-    ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    pub fn health_check_route(&self) -> BoxedFilter<(impl Reply,)> {
         diem_json_rpc::runtime::health_check_route(self.db.clone())
     }
 
-    pub fn jsonrpc_routes(&self) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+    pub fn jsonrpc_routes(&self) -> BoxedFilter<(impl Reply,)> {
         diem_json_rpc::runtime::jsonrpc_routes(
             self.db.clone(),
             self.mp_sender.clone(),

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -13,34 +13,28 @@ use diem_api_types::{Error, LedgerInfo, Response};
 
 use anyhow::Result;
 use diem_types::event::EventKey;
-use warp::{Filter, Rejection, Reply};
-
-pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
-    get_events_by_event_key(context.clone()).or(get_events_by_event_handle(context))
-}
+use warp::{filters::BoxedFilter, Filter, Rejection, Reply};
 
 // GET /events/<event_key>
-pub fn get_events_by_event_key(
-    context: Context,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn get_events_by_event_key(context: Context) -> BoxedFilter<(impl Reply,)> {
     warp::path!("events" / EventKeyParam)
         .and(warp::get())
         .and(warp::query::<Page>())
         .and(context.filter())
         .and_then(handle_get_events_by_event_key)
         .with(metrics("get_events_by_event_key"))
+        .boxed()
 }
 
 // GET /accounts/<address>/events/<event_handle_struct>/<field_name>
-pub fn get_events_by_event_handle(
-    context: Context,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn get_events_by_event_handle(context: Context) -> BoxedFilter<(impl Reply,)> {
     warp::path!("accounts" / AddressParam / "events" / MoveStructTagParam / MoveIdentifierParam)
         .and(warp::get())
         .and(warp::query::<Page>())
         .and(context.filter())
         .and_then(handle_get_events_by_event_handle)
         .with(metrics("get_events_by_event_handle"))
+        .boxed()
 }
 
 async fn handle_get_events_by_event_key(


### PR DESCRIPTION
#9193 

`warp` compile perf becomes very slow when there are multiple routes (right, not even some, just couple routes can make things really bad) that are not boxed.

So switch all routes definitions to boxed filter, which make compile perf a lot better, but will lost a little bit on runtime performance according `warp` doc.

Also flattened the api routes definition, the more `or` defined, the slower for compilation.

See the following tickets for more details
* https://github.com/seanmonstar/warp/issues/507
* https://github.com/seanmonstar/warp/issues/619
    * I also tested the `balanced_or_tree` macro mentioned in this ticket, it's a little worse than what I got in this PR.

For the performance test result (`cargo +nightly build -Z timings -p diem-api`) at my laptop:
* diem-json-rpc pakcage: 35.4s => 7s
* diem-api package: x minutes (didn't wait long enough to know how many minutes required for running the test) => ~30s