### PR TITLE
[move-prover] Refine error diagnosis

### DIFF
--- a/language/move-model/src/builder/spec_builtins.rs
+++ b/language/move-model/src/builder/spec_builtins.rs
@@ -4,7 +4,7 @@
 //! Defines builtin functions for specifications, adding them to the build
 
 use crate::{
-    ast::{Operation, Value},
+    ast::{Operation, TraceKind, Value},
     builder::model_builder::{ConstEntry, ModelBuilder, SpecFunEntry},
     ty::{PrimitiveType, Type},
 };
@@ -335,7 +335,7 @@ pub(crate) fn declare_spec_builtins(trans: &mut ModelBuilder<'_>) {
             trans.builtin_qualified_symbol("TRACE"),
             SpecFunEntry {
                 loc,
-                oper: Operation::Trace,
+                oper: Operation::Trace(TraceKind::User),
                 type_params: vec![param_t.clone()],
                 arg_types: vec![param_t.clone()],
                 result_type: param_t.clone(),

--- a/language/move-prover/boogie-backend/src/options.rs
+++ b/language/move-prover/boogie-backend/src/options.rs
@@ -15,6 +15,7 @@ const DEFAULT_BOOGIE_FLAGS: &[&str] = &[
     "-printModel:1",
     "-enhancedErrorMessages:1",
     "-monomorphize",
+    "-proverOpt:O:model_validate=true",
 ];
 
 const MIN_BOOGIE_VERSION: &str = "2.9.0";

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -744,7 +744,7 @@ impl<'env> SpecTranslator<'env> {
             Operation::AbortCode => emit!(self.writer, "$abort_code"),
             Operation::AbortFlag => emit!(self.writer, "$abort_flag"),
             Operation::NoOp => { /* do nothing. */ }
-            Operation::Trace => {
+            Operation::Trace(_) => {
                 // An unreduced trace means it has been used in a spec fun or let.
                 // Create an error about this.
                 self.env.error(
@@ -1198,7 +1198,7 @@ impl<'env> SpecTranslator<'env> {
             .filter(|(s, _)| *s != some_var)
             .collect_vec();
         let used_temps = range_and_body
-            .temporaries(self.env)
+            .used_temporaries(self.env)
             .into_iter()
             .collect_vec();
         let used_memory = range_and_body

--- a/language/move-prover/bytecode/src/livevar_analysis.rs
+++ b/language/move-prover/bytecode/src/livevar_analysis.rs
@@ -371,7 +371,7 @@ impl<'a> TransferFunctions for LiveVarAnalysis<'a> {
                 state.insert(&[*src]);
             }
             Prop(_, _, exp) => {
-                for (idx, _) in exp.temporaries(self.func_target.global_env()) {
+                for (idx, _) in exp.used_temporaries(self.func_target.global_env()) {
                     state.insert(&[idx]);
                 }
             }

--- a/language/move-prover/bytecode/src/spec_instrumentation.rs
+++ b/language/move-prover/bytecode/src/spec_instrumentation.rs
@@ -774,8 +774,8 @@ impl<'a> Instrumenter<'a> {
         let traces = spec
             .debug_traces
             .iter()
-            .filter(|(_, exp)| node_ids.contains(&exp.node_id()));
-        for (node_id, exp) in traces {
+            .filter(|(_, _, exp)| node_ids.contains(&exp.node_id()));
+        for (node_id, kind, exp) in traces {
             let loc = self.builder.global_env().get_node_loc(*node_id);
             self.builder.set_loc(loc);
             let temp = if let ExpData::Temporary(_, temp) = exp.as_ref() {
@@ -783,8 +783,15 @@ impl<'a> Instrumenter<'a> {
             } else {
                 self.builder.emit_let(exp.clone()).0
             };
-            self.builder
-                .emit_with(|id| Call(id, vec![], Operation::TraceExp(*node_id), vec![temp], None));
+            self.builder.emit_with(|id| {
+                Call(
+                    id,
+                    vec![],
+                    Operation::TraceExp(*kind, *node_id),
+                    vec![temp],
+                    None,
+                )
+            });
         }
     }
 

--- a/language/move-prover/bytecode/src/stackless_bytecode.rs
+++ b/language/move-prover/bytecode/src/stackless_bytecode.rs
@@ -5,7 +5,7 @@ use crate::function_target::FunctionTarget;
 use itertools::Itertools;
 use move_binary_format::file_format::CodeOffset;
 use move_model::{
-    ast::{Exp, ExpData, MemoryLabel, TempIndex},
+    ast::{Exp, ExpData, MemoryLabel, TempIndex, TraceKind},
     exp_rewriter::{ExpRewriter, ExpRewriterFunctions, RewriteTarget},
     model::{FunId, GlobalEnv, ModuleId, NodeId, QualifiedInstId, SpecVarId, StructId},
     ty::{Type, TypeDisplayContext},
@@ -170,7 +170,7 @@ pub enum Operation {
     TraceLocal(TempIndex),
     TraceReturn(usize),
     TraceAbort,
-    TraceExp(NodeId),
+    TraceExp(TraceKind, NodeId),
 
     // Event
     EmitEvent,
@@ -1052,11 +1052,12 @@ impl<'env> fmt::Display for OperationDisplay<'env> {
             }
             TraceAbort => write!(f, "trace_abort")?,
             TraceReturn(r) => write!(f, "trace_return[{}]", r)?,
-            TraceExp(node_id) => {
+            TraceExp(kind, node_id) => {
                 let loc = self.func_target.global_env().get_node_loc(*node_id);
                 write!(
                     f,
-                    "trace_exp[{}]",
+                    "trace_exp[{}, {}]",
+                    kind,
                     loc.display(self.func_target.global_env())
                 )?
             }

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -508,7 +508,7 @@ impl<'env> Evaluator<'env> {
             Operation::NoOp
             | Operation::Identical
             | Operation::Old
-            | Operation::Trace
+            | Operation::Trace(_)
             | Operation::Tuple
             | Operation::Result(_)
             | Operation::AbortCode

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -476,7 +476,8 @@ impl<'env> FunctionContext<'env> {
                 }
                 return Ok(());
             }
-            Operation::TraceExp(node_id) => {
+            Operation::TraceExp(_kind, node_id) => {
+                // Perhaps do something with kind?
                 if cfg!(debug_assertions) {
                     let env = self.target.global_env();
                     let node_ty =

--- a/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
+++ b/language/move-prover/tests/sources/functional/ModifiesErrorTest.exp
@@ -6,7 +6,7 @@ error: caller does not have permission to modify `B::T` at given address
    │                 ^^^^^^^^^
    │
    =     at tests/sources/functional/ModifiesErrorTest.move:63: move_from_test_incorrect
-   =     at tests/sources/functional/ModifiesErrorTest.move:74
+   =     at tests/sources/functional/ModifiesErrorTest.move:74: move_from_test_incorrect (spec)
    =     at tests/sources/functional/ModifiesErrorTest.move:63: move_from_test_incorrect
    =         addr1 = <redacted>
    =         addr2 = <redacted>
@@ -21,7 +21,7 @@ error: caller does not have permission to modify `B::T` at given address
    │         ^^^^^^^
    │
    =     at tests/sources/functional/ModifiesErrorTest.move:50: move_to_test_incorrect
-   =     at tests/sources/functional/ModifiesErrorTest.move:60
+   =     at tests/sources/functional/ModifiesErrorTest.move:60: move_to_test_incorrect (spec)
    =     at tests/sources/functional/ModifiesErrorTest.move:50: move_to_test_incorrect
    =         account = <redacted>
    =         addr2 = <redacted>
@@ -36,8 +36,8 @@ error: caller does not have permission to modify `A::S` at given address
    │         ^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/ModifiesErrorTest.move:77: mutate_S_test1_incorrect
-   =     at tests/sources/functional/ModifiesErrorTest.move:86
-   =     at tests/sources/functional/ModifiesErrorTest.move:87
+   =     at tests/sources/functional/ModifiesErrorTest.move:86: mutate_S_test1_incorrect (spec)
+   =     at tests/sources/functional/ModifiesErrorTest.move:87: mutate_S_test1_incorrect (spec)
    =     at tests/sources/functional/ModifiesErrorTest.move:77: mutate_S_test1_incorrect
    =         addr1 = <redacted>
    =         addr2 = <redacted>
@@ -52,7 +52,7 @@ error: unknown assertion failed
    │             ^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/ModifiesErrorTest.move:90: mutate_S_test2_incorrect
-   =     at tests/sources/functional/ModifiesErrorTest.move:99
+   =     at tests/sources/functional/ModifiesErrorTest.move:99: mutate_S_test2_incorrect (spec)
    =     at tests/sources/functional/ModifiesErrorTest.move:90: mutate_S_test2_incorrect
    =         addr = <redacted>
    =     at tests/sources/functional/ModifiesErrorTest.move:91: mutate_S_test2_incorrect
@@ -69,7 +69,7 @@ error: caller does not have permission to modify `B::T` at given address
    │                 ^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/ModifiesErrorTest.move:36: mutate_at_test_incorrect
-   =     at tests/sources/functional/ModifiesErrorTest.move:47
+   =     at tests/sources/functional/ModifiesErrorTest.move:47: mutate_at_test_incorrect (spec)
    =     at tests/sources/functional/ModifiesErrorTest.move:36: mutate_at_test_incorrect
    =         addr1 = <redacted>
    =         addr2 = <redacted>

--- a/language/move-prover/tests/sources/functional/aborts_if.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if.exp
@@ -9,7 +9,7 @@ error: function does not abort under this condition
    =         _x = <redacted>
    =         _y = <redacted>
    =     at tests/sources/functional/aborts_if.move:33: abort2_incorrect
-   =     at tests/sources/functional/aborts_if.move:35
+   =     at tests/sources/functional/aborts_if.move:35: abort2_incorrect (spec)
 
 error: function does not abort under this condition
    ┌─ tests/sources/functional/aborts_if.move:52:9
@@ -22,7 +22,7 @@ error: function does not abort under this condition
    =         y = <redacted>
    =     at tests/sources/functional/aborts_if.move:48: abort4_incorrect
    =     at tests/sources/functional/aborts_if.move:49: abort4_incorrect
-   =     at tests/sources/functional/aborts_if.move:52
+   =     at tests/sources/functional/aborts_if.move:52: abort4_incorrect (spec)
 
 error: abort not covered by any of the `aborts_if` clauses
    ┌─ tests/sources/functional/aborts_if.move:59:5
@@ -39,7 +39,6 @@ error: abort not covered by any of the `aborts_if` clauses
    =         x = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/aborts_if.move:57: abort5_incorrect
-   =     at tests/sources/functional/aborts_if.move:57: abort5_incorrect
    =         ABORTED
 
 error: function does not abort under this condition
@@ -53,7 +52,7 @@ error: function does not abort under this condition
    =         y = <redacted>
    =     at tests/sources/functional/aborts_if.move:65: abort6_incorrect
    =     at tests/sources/functional/aborts_if.move:66: abort6_incorrect
-   =     at tests/sources/functional/aborts_if.move:68
+   =     at tests/sources/functional/aborts_if.move:68: abort6_incorrect (spec)
 
 error: function does not abort under this condition
     ┌─ tests/sources/functional/aborts_if.move:151:9
@@ -66,7 +65,7 @@ error: function does not abort under this condition
     =     at tests/sources/functional/aborts_if.move:146: abort_at_2_or_3_spec_incorrect
     =         <redacted> = <redacted>
     =     at tests/sources/functional/aborts_if.move:147: abort_at_2_or_3_spec_incorrect
-    =     at tests/sources/functional/aborts_if.move:151
+    =     at tests/sources/functional/aborts_if.move:151: abort_at_2_or_3_spec_incorrect (spec)
 
 error: abort not covered by any of the `aborts_if` clauses
     ┌─ tests/sources/functional/aborts_if.move:157:5
@@ -118,8 +117,8 @@ error: function does not abort under this condition
    =         y = <redacted>
    =     at tests/sources/functional/aborts_if.move:87: multi_abort2_incorrect
    =     at tests/sources/functional/aborts_if.move:88: multi_abort2_incorrect
-   =     at tests/sources/functional/aborts_if.move:90
-   =     at tests/sources/functional/aborts_if.move:91
+   =     at tests/sources/functional/aborts_if.move:90: multi_abort2_incorrect (spec)
+   =     at tests/sources/functional/aborts_if.move:91: multi_abort2_incorrect (spec)
 
 error: abort not covered by any of the `aborts_if` clauses
     ┌─ tests/sources/functional/aborts_if.move:98:5
@@ -137,7 +136,6 @@ error: abort not covered by any of the `aborts_if` clauses
     =         _x = <redacted>
     =         _y = <redacted>
     =     at tests/sources/functional/aborts_if.move:96: multi_abort3_incorrect
-    =     at tests/sources/functional/aborts_if.move:96: multi_abort3_incorrect
     =         ABORTED
 
 error: function does not abort under this condition
@@ -150,4 +148,4 @@ error: function does not abort under this condition
     =         x = <redacted>
     =     at tests/sources/functional/aborts_if.move:114: multi_abort5_incorrect
     =     at tests/sources/functional/aborts_if.move:117: multi_abort5_incorrect
-    =     at tests/sources/functional/aborts_if.move:119
+    =     at tests/sources/functional/aborts_if.move:119: multi_abort5_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
+++ b/language/move-prover/tests/sources/functional/aborts_if_with_code.exp
@@ -88,5 +88,4 @@ error: abort code not covered by any of the `aborts_if` or `aborts_with` clauses
    =     at tests/sources/functional/aborts_if_with_code.move:45: exec_failure_invalid
    =         x = <redacted>
    =     at tests/sources/functional/aborts_if_with_code.move:46: exec_failure_invalid
-   =     at tests/sources/functional/aborts_if_with_code.move:46: exec_failure_invalid
    =         ABORTED

--- a/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
+++ b/language/move-prover/tests/sources/functional/address_serialization_constant_size.exp
@@ -12,4 +12,4 @@ error: post-condition does not hold
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/address_serialization_constant_size.move:17: serialized_move_values_diff_len_incorrect
-   =     at tests/sources/functional/address_serialization_constant_size.move:19
+   =     at tests/sources/functional/address_serialization_constant_size.move:19: serialized_move_values_diff_len_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/arithm.exp
+++ b/language/move-prover/tests/sources/functional/arithm.exp
@@ -13,7 +13,7 @@ error: post-condition does not hold
     =     at tests/sources/functional/arithm.move:284: distribution_law_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/arithm.move:285: distribution_law_incorrect
-    =     at tests/sources/functional/arithm.move:287
+    =     at tests/sources/functional/arithm.move:287: distribution_law_incorrect (spec)
 
 error: abort not covered by any of the `aborts_if` clauses
     ┌─ tests/sources/functional/arithm.move:128:5
@@ -51,7 +51,7 @@ error: post-condition does not hold
     =     at tests/sources/functional/arithm.move:269: mul5_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/arithm.move:270: mul5_incorrect
-    =     at tests/sources/functional/arithm.move:273
+    =     at tests/sources/functional/arithm.move:273: mul5_incorrect (spec)
 
 error: abort not covered by any of the `aborts_if` clauses
     ┌─ tests/sources/functional/arithm.move:180:5

--- a/language/move-prover/tests/sources/functional/choice.cvc4_exp
+++ b/language/move-prover/tests/sources/functional/choice.cvc4_exp
@@ -6,17 +6,17 @@ error: post-condition does not hold
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/choice.move:44: populate_R
-   =     at tests/sources/functional/choice.move:49
-   =     at tests/sources/functional/choice.move:50
-   =     at tests/sources/functional/choice.move:53
-   =     at tests/sources/functional/choice.move:52
+   =     at tests/sources/functional/choice.move:49: populate_R (spec)
+   =     at tests/sources/functional/choice.move:50: populate_R (spec)
+   =     at tests/sources/functional/choice.move:53: populate_R (spec)
+   =     at tests/sources/functional/choice.move:52: populate_R (spec)
    =     at tests/sources/functional/choice.move:44: populate_R
    =         s1 = <redacted>
    =         s2 = <redacted>
    =     at tests/sources/functional/choice.move:45: populate_R
    =     at tests/sources/functional/choice.move:46: populate_R
    =     at tests/sources/functional/choice.move:47: populate_R
-   =     at tests/sources/functional/choice.move:54
+   =     at tests/sources/functional/choice.move:54: populate_R (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/choice.move:21:9
@@ -30,7 +30,7 @@ error: post-condition does not hold
    =         <redacted> = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:17: simple_incorrect
-   =     at tests/sources/functional/choice.move:21
+   =     at tests/sources/functional/choice.move:21: simple_incorrect (spec)
    =         `TRACE(choose x: u64 where x >= 4 && x <= 5)` = <redacted>
 
 error: post-condition does not hold
@@ -44,7 +44,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:94: test_choice_dup_expected_fail
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:95: test_choice_dup_expected_fail
-   =     at tests/sources/functional/choice.move:98
+   =     at tests/sources/functional/choice.move:98: test_choice_dup_expected_fail (spec)
    =         `TRACE(choose y: u64 where y > x)` = <redacted>
 
 error: post-condition does not hold
@@ -53,10 +53,10 @@ error: post-condition does not hold
 156 │         ensures evidence1 == evidence2;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/choice.move:154
-    =     at tests/sources/functional/choice.move:155
+    =     at tests/sources/functional/choice.move:154: test_different_choice_via_let (spec)
+    =     at tests/sources/functional/choice.move:155: test_different_choice_via_let (spec)
     =     at tests/sources/functional/choice.move:152: test_different_choice_via_let
-    =     at tests/sources/functional/choice.move:156
+    =     at tests/sources/functional/choice.move:156: test_different_choice_via_let (spec)
 
 error: post-condition does not hold
     ┌─ tests/sources/functional/choice.move:180:9
@@ -65,7 +65,7 @@ error: post-condition does not hold
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/choice.move:178: test_different_choice_via_spec_fun
-    =     at tests/sources/functional/choice.move:180
+    =     at tests/sources/functional/choice.move:180: test_different_choice_via_spec_fun (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/choice.move:70:9
@@ -84,7 +84,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:67: test_min
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:68: test_min
-   =     at tests/sources/functional/choice.move:70
+   =     at tests/sources/functional/choice.move:70: test_min (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/choice.move:85:9
@@ -104,7 +104,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:81: test_not_using_min_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:82: test_not_using_min_incorrect
-   =     at tests/sources/functional/choice.move:85
+   =     at tests/sources/functional/choice.move:85: test_not_using_min_incorrect (spec)
    =         `TRACE(choose i in 0..len(result) where result[i] == 2)` = <redacted>
 
 error: post-condition does not hold
@@ -125,10 +125,10 @@ error: post-condition does not hold
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/choice.move:204: test_same_choice_different_args_via_spec_fun
-    =     at tests/sources/functional/choice.move:206
-    =     at tests/sources/functional/choice.move:207
+    =     at tests/sources/functional/choice.move:206: test_same_choice_different_args_via_spec_fun (spec)
+    =     at tests/sources/functional/choice.move:207: test_same_choice_different_args_via_spec_fun (spec)
     =     at tests/sources/functional/choice.move:204: test_same_choice_different_args_via_spec_fun
     =         x = <redacted>
     =         y = <redacted>
     =         result = <redacted>
-    =     at tests/sources/functional/choice.move:208
+    =     at tests/sources/functional/choice.move:208: test_same_choice_different_args_via_spec_fun (spec)

--- a/language/move-prover/tests/sources/functional/choice.exp
+++ b/language/move-prover/tests/sources/functional/choice.exp
@@ -6,17 +6,17 @@ error: post-condition does not hold
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/choice.move:44: populate_R
-   =     at tests/sources/functional/choice.move:49
-   =     at tests/sources/functional/choice.move:50
-   =     at tests/sources/functional/choice.move:53
-   =     at tests/sources/functional/choice.move:52
+   =     at tests/sources/functional/choice.move:49: populate_R (spec)
+   =     at tests/sources/functional/choice.move:50: populate_R (spec)
+   =     at tests/sources/functional/choice.move:53: populate_R (spec)
+   =     at tests/sources/functional/choice.move:52: populate_R (spec)
    =     at tests/sources/functional/choice.move:44: populate_R
    =         s1 = <redacted>
    =         s2 = <redacted>
    =     at tests/sources/functional/choice.move:45: populate_R
    =     at tests/sources/functional/choice.move:46: populate_R
    =     at tests/sources/functional/choice.move:47: populate_R
-   =     at tests/sources/functional/choice.move:54
+   =     at tests/sources/functional/choice.move:54: populate_R (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/choice.move:21:9
@@ -30,7 +30,7 @@ error: post-condition does not hold
    =         <redacted> = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:17: simple_incorrect
-   =     at tests/sources/functional/choice.move:21
+   =     at tests/sources/functional/choice.move:21: simple_incorrect (spec)
    =         `TRACE(choose x: u64 where x >= 4 && x <= 5)` = <redacted>
 
 error: post-condition does not hold
@@ -44,7 +44,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:94: test_choice_dup_expected_fail
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:95: test_choice_dup_expected_fail
-   =     at tests/sources/functional/choice.move:98
+   =     at tests/sources/functional/choice.move:98: test_choice_dup_expected_fail (spec)
    =         `TRACE(choose y: u64 where y > x)` = <redacted>
 
 error: post-condition does not hold
@@ -53,10 +53,10 @@ error: post-condition does not hold
 156 │         ensures evidence1 == evidence2;
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
-    =     at tests/sources/functional/choice.move:154
-    =     at tests/sources/functional/choice.move:155
+    =     at tests/sources/functional/choice.move:154: test_different_choice_via_let (spec)
+    =     at tests/sources/functional/choice.move:155: test_different_choice_via_let (spec)
     =     at tests/sources/functional/choice.move:152: test_different_choice_via_let
-    =     at tests/sources/functional/choice.move:156
+    =     at tests/sources/functional/choice.move:156: test_different_choice_via_let (spec)
 
 error: post-condition does not hold
     ┌─ tests/sources/functional/choice.move:180:9
@@ -65,7 +65,7 @@ error: post-condition does not hold
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/choice.move:178: test_different_choice_via_spec_fun
-    =     at tests/sources/functional/choice.move:180
+    =     at tests/sources/functional/choice.move:180: test_different_choice_via_spec_fun (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/choice.move:85:9
@@ -85,7 +85,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:81: test_not_using_min_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:82: test_not_using_min_incorrect
-   =     at tests/sources/functional/choice.move:85
+   =     at tests/sources/functional/choice.move:85: test_not_using_min_incorrect (spec)
    =         `TRACE(choose i in 0..len(result) where result[i] == 2)` = <redacted>
 
 error: post-condition does not hold
@@ -106,10 +106,10 @@ error: post-condition does not hold
     │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     │
     =     at tests/sources/functional/choice.move:204: test_same_choice_different_args_via_spec_fun
-    =     at tests/sources/functional/choice.move:206
-    =     at tests/sources/functional/choice.move:207
+    =     at tests/sources/functional/choice.move:206: test_same_choice_different_args_via_spec_fun (spec)
+    =     at tests/sources/functional/choice.move:207: test_same_choice_different_args_via_spec_fun (spec)
     =     at tests/sources/functional/choice.move:204: test_same_choice_different_args_via_spec_fun
     =         x = <redacted>
     =         y = <redacted>
     =         result = <redacted>
-    =     at tests/sources/functional/choice.move:208
+    =     at tests/sources/functional/choice.move:208: test_same_choice_different_args_via_spec_fun (spec)

--- a/language/move-prover/tests/sources/functional/consts.exp
+++ b/language/move-prover/tests/sources/functional/consts.exp
@@ -8,5 +8,5 @@ error: post-condition does not hold
    =     at tests/sources/functional/consts.move:24: init_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/consts.move:25: init_incorrect
-   =     at tests/sources/functional/consts.move:28
-   =     at tests/sources/functional/consts.move:29
+   =     at tests/sources/functional/consts.move:28: init_incorrect (spec)
+   =     at tests/sources/functional/consts.move:29: init_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/disable_inv_friends.exp
+++ b/language/move-prover/tests/sources/functional/disable_inv_friends.exp
@@ -6,8 +6,8 @@ error: global memory invariant does not hold
    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/disable_inv_friends.move:85: f5_incorrect
-   =     at tests/sources/functional/disable_inv_friends.move:91
-   =     at tests/sources/functional/disable_inv_friends.move:92
+   =     at tests/sources/functional/disable_inv_friends.move:91: f5_incorrect (spec)
+   =     at tests/sources/functional/disable_inv_friends.move:92: f5_incorrect (spec)
    =     at tests/sources/functional/disable_inv_friends.move:85: f5_incorrect
    =         s = <redacted>
    =     at tests/sources/functional/disable_inv_friends.move:86: f5_incorrect

--- a/language/move-prover/tests/sources/functional/disable_inv_friends.no_opaque_exp
+++ b/language/move-prover/tests/sources/functional/disable_inv_friends.no_opaque_exp
@@ -6,8 +6,8 @@ error: global memory invariant does not hold
    │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/disable_inv_friends.move:85: f5_incorrect
-   =     at tests/sources/functional/disable_inv_friends.move:91
-   =     at tests/sources/functional/disable_inv_friends.move:92
+   =     at tests/sources/functional/disable_inv_friends.move:91: f5_incorrect (spec)
+   =     at tests/sources/functional/disable_inv_friends.move:92: f5_incorrect (spec)
    =     at tests/sources/functional/disable_inv_friends.move:85: f5_incorrect
    =         s = <redacted>
    =     at tests/sources/functional/disable_inv_friends.move:86: f5_incorrect

--- a/language/move-prover/tests/sources/functional/emits.exp
+++ b/language/move-prover/tests/sources/functional/emits.exp
@@ -11,7 +11,7 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:115: conditional_missing_condition_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:118: conditional_missing_condition_incorrect
-    =     at tests/sources/functional/emits.move:120
+    =     at tests/sources/functional/emits.move:120: conditional_missing_condition_incorrect (spec)
 
 error: function does not emit the expected event
     ┌─ tests/sources/functional/emits.move:159:9
@@ -27,9 +27,9 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:152: conditional_multiple_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:155: conditional_multiple_incorrect
-    =     at tests/sources/functional/emits.move:157
-    =     at tests/sources/functional/emits.move:158
-    =     at tests/sources/functional/emits.move:159
+    =     at tests/sources/functional/emits.move:157: conditional_multiple_incorrect (spec)
+    =     at tests/sources/functional/emits.move:158: conditional_multiple_incorrect (spec)
+    =     at tests/sources/functional/emits.move:159: conditional_multiple_incorrect (spec)
 
 error: function does not emit the expected event
     ┌─ tests/sources/functional/emits.move:189:9
@@ -45,9 +45,9 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:182: conditional_multiple_same_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:185: conditional_multiple_same_incorrect
-    =     at tests/sources/functional/emits.move:187
-    =     at tests/sources/functional/emits.move:188
-    =     at tests/sources/functional/emits.move:189
+    =     at tests/sources/functional/emits.move:187: conditional_multiple_same_incorrect (spec)
+    =     at tests/sources/functional/emits.move:188: conditional_multiple_same_incorrect (spec)
+    =     at tests/sources/functional/emits.move:189: conditional_multiple_same_incorrect (spec)
 
 error: function does not emit the expected event
     ┌─ tests/sources/functional/emits.move:111:9
@@ -61,7 +61,7 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:106: conditional_wrong_condition_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:109: conditional_wrong_condition_incorrect
-    =     at tests/sources/functional/emits.move:111
+    =     at tests/sources/functional/emits.move:111: conditional_wrong_condition_incorrect (spec)
 
 error: function does not emit the expected event
    ┌─ tests/sources/functional/emits.move:54:9
@@ -75,9 +75,9 @@ error: function does not emit the expected event
    =     at tests/sources/functional/emits.move:49: multiple_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:50: multiple_incorrect
-   =     at tests/sources/functional/emits.move:52
-   =     at tests/sources/functional/emits.move:53
-   =     at tests/sources/functional/emits.move:54
+   =     at tests/sources/functional/emits.move:52: multiple_incorrect (spec)
+   =     at tests/sources/functional/emits.move:53: multiple_incorrect (spec)
+   =     at tests/sources/functional/emits.move:54: multiple_incorrect (spec)
 
 error: function does not emit the expected event
    ┌─ tests/sources/functional/emits.move:71:9
@@ -90,8 +90,8 @@ error: function does not emit the expected event
    =     at tests/sources/functional/emits.move:67: multiple_same_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:68: multiple_same_incorrect
-   =     at tests/sources/functional/emits.move:70
-   =     at tests/sources/functional/emits.move:71
+   =     at tests/sources/functional/emits.move:70: multiple_same_incorrect (spec)
+   =     at tests/sources/functional/emits.move:71: multiple_same_incorrect (spec)
 
 error: emitted event not covered by any of the `emits` clauses
     ┌─ tests/sources/functional/emits.move:314:5
@@ -110,10 +110,10 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:312: opaque_completeness_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:313: opaque_completeness_incorrect
-    =     at tests/sources/functional/emits.move:315
-    =     at tests/sources/functional/emits.move:316
-    =     at tests/sources/functional/emits.move:317
-    =     at tests/sources/functional/emits.move:314
+    =     at tests/sources/functional/emits.move:315: opaque_completeness_incorrect (spec)
+    =     at tests/sources/functional/emits.move:316: opaque_completeness_incorrect (spec)
+    =     at tests/sources/functional/emits.move:317: opaque_completeness_incorrect (spec)
+    =     at tests/sources/functional/emits.move:314: opaque_completeness_incorrect (spec)
 
 error: function does not emit the expected event
     ┌─ tests/sources/functional/emits.move:296:9
@@ -128,11 +128,11 @@ error: function does not emit the expected event
     =     at tests/sources/functional/emits.move:289: opaque_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:290: opaque_incorrect
-    =     at tests/sources/functional/emits.move:292
-    =     at tests/sources/functional/emits.move:293
-    =     at tests/sources/functional/emits.move:294
-    =     at tests/sources/functional/emits.move:295
-    =     at tests/sources/functional/emits.move:296
+    =     at tests/sources/functional/emits.move:292: opaque_incorrect (spec)
+    =     at tests/sources/functional/emits.move:293: opaque_incorrect (spec)
+    =     at tests/sources/functional/emits.move:294: opaque_incorrect (spec)
+    =     at tests/sources/functional/emits.move:295: opaque_incorrect (spec)
+    =     at tests/sources/functional/emits.move:296: opaque_incorrect (spec)
 
 error: emitted event not covered by any of the `emits` clauses
     ┌─ tests/sources/functional/emits.move:355:5
@@ -153,11 +153,11 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:353: opaque_partial_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:354: opaque_partial_incorrect
-    =     at tests/sources/functional/emits.move:356
-    =     at tests/sources/functional/emits.move:357
-    =     at tests/sources/functional/emits.move:358
-    =     at tests/sources/functional/emits.move:359
-    =     at tests/sources/functional/emits.move:355
+    =     at tests/sources/functional/emits.move:356: opaque_partial_incorrect (spec)
+    =     at tests/sources/functional/emits.move:357: opaque_partial_incorrect (spec)
+    =     at tests/sources/functional/emits.move:358: opaque_partial_incorrect (spec)
+    =     at tests/sources/functional/emits.move:359: opaque_partial_incorrect (spec)
+    =     at tests/sources/functional/emits.move:355: opaque_partial_incorrect (spec)
 
 error: emitted event not covered by any of the `emits` clauses
     ┌─ tests/sources/functional/emits.move:235:5
@@ -173,8 +173,8 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:233: partial_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:234: partial_incorrect
-    =     at tests/sources/functional/emits.move:236
-    =     at tests/sources/functional/emits.move:235
+    =     at tests/sources/functional/emits.move:236: partial_incorrect (spec)
+    =     at tests/sources/functional/emits.move:235: partial_incorrect (spec)
 
 error: function does not emit the expected event
    ┌─ tests/sources/functional/emits.move:30:9
@@ -189,7 +189,7 @@ error: function does not emit the expected event
    =         handle = <redacted>
    =         _handle2 = <redacted>
    =     at tests/sources/functional/emits.move:28: simple_wrong_handle_incorrect
-   =     at tests/sources/functional/emits.move:30
+   =     at tests/sources/functional/emits.move:30: simple_wrong_handle_incorrect (spec)
 
 error: function does not emit the expected event
    ┌─ tests/sources/functional/emits.move:23:9
@@ -202,7 +202,7 @@ error: function does not emit the expected event
    =     at tests/sources/functional/emits.move:20: simple_wrong_msg_incorrect
    =         handle = <redacted>
    =     at tests/sources/functional/emits.move:21: simple_wrong_msg_incorrect
-   =     at tests/sources/functional/emits.move:23
+   =     at tests/sources/functional/emits.move:23: simple_wrong_msg_incorrect (spec)
 
 error: emitted event not covered by any of the `emits` clauses
     ┌─ tests/sources/functional/emits.move:255:5
@@ -218,4 +218,4 @@ error: emitted event not covered by any of the `emits` clauses
     =     at tests/sources/functional/emits.move:253: strict_incorrect
     =         handle = <redacted>
     =     at tests/sources/functional/emits.move:254: strict_incorrect
-    =     at tests/sources/functional/emits.move:255
+    =     at tests/sources/functional/emits.move:255: strict_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/fixed_point_arithm.exp
+++ b/language/move-prover/tests/sources/functional/fixed_point_arithm.exp
@@ -12,7 +12,7 @@ error: post-condition does not hold
     =     at tests/sources/functional/fixed_point_arithm.move:136: mul_2_times_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:137: mul_2_times_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:140
+    =     at tests/sources/functional/fixed_point_arithm.move:140: mul_2_times_incorrect (spec)
 
 error: post-condition does not hold
     ┌─ tests/sources/functional/fixed_point_arithm.move:148:9
@@ -28,7 +28,7 @@ error: post-condition does not hold
     =     at tests/sources/functional/fixed_point_arithm.move:144: mul_3_times_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:145: mul_3_times_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:148
+    =     at tests/sources/functional/fixed_point_arithm.move:148: mul_3_times_incorrect (spec)
 
 error: post-condition does not hold
     ┌─ tests/sources/functional/fixed_point_arithm.move:106:9
@@ -51,7 +51,7 @@ error: post-condition does not hold
     =     at tests/sources/functional/fixed_point_arithm.move:103: mul_div_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:106
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect (spec)
 
 error: post-condition does not hold
     ┌─ tests/sources/functional/fixed_point_arithm.move:108:9
@@ -74,9 +74,9 @@ error: post-condition does not hold
     =     at tests/sources/functional/fixed_point_arithm.move:103: mul_div_incorrect
     =         result = <redacted>
     =     at tests/sources/functional/fixed_point_arithm.move:104: mul_div_incorrect
-    =     at tests/sources/functional/fixed_point_arithm.move:106
-    =     at tests/sources/functional/fixed_point_arithm.move:107
-    =     at tests/sources/functional/fixed_point_arithm.move:108
+    =     at tests/sources/functional/fixed_point_arithm.move:106: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:107: mul_div_incorrect (spec)
+    =     at tests/sources/functional/fixed_point_arithm.move:108: mul_div_incorrect (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/fixed_point_arithm.move:27:9
@@ -89,8 +89,8 @@ error: post-condition does not hold
    =     at tests/sources/functional/fixed_point_arithm.move:23: multiply_0_x_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:24: multiply_0_x_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:26
-   =     at tests/sources/functional/fixed_point_arithm.move:27
+   =     at tests/sources/functional/fixed_point_arithm.move:26: multiply_0_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:27: multiply_0_x_incorrect (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/fixed_point_arithm.move:66:9
@@ -103,8 +103,8 @@ error: post-condition does not hold
    =     at tests/sources/functional/fixed_point_arithm.move:61: multiply_1_x_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:62: multiply_1_x_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:64
-   =     at tests/sources/functional/fixed_point_arithm.move:66
+   =     at tests/sources/functional/fixed_point_arithm.move:64: multiply_1_x_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:66: multiply_1_x_incorrect (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/fixed_point_arithm.move:43:9
@@ -117,8 +117,8 @@ error: post-condition does not hold
    =     at tests/sources/functional/fixed_point_arithm.move:39: multiply_x_0_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:40: multiply_x_0_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:42
-   =     at tests/sources/functional/fixed_point_arithm.move:43
+   =     at tests/sources/functional/fixed_point_arithm.move:42: multiply_x_0_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:43: multiply_x_0_incorrect (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/fixed_point_arithm.move:82:9
@@ -135,5 +135,5 @@ error: post-condition does not hold
    =     at tests/sources/functional/fixed_point_arithm.move:78: multiply_x_1_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/fixed_point_arithm.move:79: multiply_x_1_incorrect
-   =     at tests/sources/functional/fixed_point_arithm.move:81
-   =     at tests/sources/functional/fixed_point_arithm.move:82
+   =     at tests/sources/functional/fixed_point_arithm.move:81: multiply_x_1_incorrect (spec)
+   =     at tests/sources/functional/fixed_point_arithm.move:82: multiply_x_1_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/global_vars.exp
+++ b/language/move-prover/tests/sources/functional/global_vars.exp
@@ -9,15 +9,15 @@ error: post-condition does not hold
    =     at tests/sources/functional/global_vars.move:38: call_add_sub_invalid
    =     at tests/sources/functional/global_vars.move:17: add
    =     at tests/sources/functional/global_vars.move:18: add
-   =     at tests/sources/functional/global_vars.move:20
+   =     at tests/sources/functional/global_vars.move:20: add (spec)
    =     at tests/sources/functional/global_vars.move:24: sub
    =     at tests/sources/functional/global_vars.move:25: sub
-   =     at tests/sources/functional/global_vars.move:27
+   =     at tests/sources/functional/global_vars.move:27: sub (spec)
    =     at tests/sources/functional/global_vars.move:17: add
    =     at tests/sources/functional/global_vars.move:18: add
-   =     at tests/sources/functional/global_vars.move:20
+   =     at tests/sources/functional/global_vars.move:20: add (spec)
    =     at tests/sources/functional/global_vars.move:39: call_add_sub_invalid
-   =     at tests/sources/functional/global_vars.move:41
+   =     at tests/sources/functional/global_vars.move:41: call_add_sub_invalid (spec)
 
 error: precondition does not hold at this call
     ┌─ tests/sources/functional/global_vars.move:101:9
@@ -27,7 +27,7 @@ error: precondition does not hold at this call
     │
     =     at tests/sources/functional/global_vars.move:109: do_privileged_invalid
     =         _s = <redacted>
-    =     at tests/sources/functional/global_vars.move:101
+    =     at tests/sources/functional/global_vars.move:101: requires_access (spec)
 
 error: post-condition does not hold
     ┌─ tests/sources/functional/global_vars.move:137:9
@@ -38,9 +38,9 @@ error: post-condition does not hold
     =     at tests/sources/functional/global_vars.move:133: expect_property_of_u64_invalid
     =     at tests/sources/functional/global_vars.move:134: expect_property_of_u64_invalid
     =     at tests/sources/functional/global_vars.move:121: give_property_to
-    =     at tests/sources/functional/global_vars.move:123
+    =     at tests/sources/functional/global_vars.move:123: give_property_to (spec)
     =     at tests/sources/functional/global_vars.move:135: expect_property_of_u64_invalid
-    =     at tests/sources/functional/global_vars.move:137
+    =     at tests/sources/functional/global_vars.move:137: expect_property_of_u64_invalid (spec)
 
 error: global memory invariant does not hold
     ┌─ tests/sources/functional/global_vars.move:174:5
@@ -56,7 +56,7 @@ error: global memory invariant does not hold
     =     at tests/sources/functional/global_vars.move:177: publish
     =     at tests/sources/functional/global_vars.move:178: publish
     =     at tests/sources/functional/global_vars.move:186: limit_change_invalid
-    =     at tests/sources/functional/global_vars.move:188
+    =     at tests/sources/functional/global_vars.move:188: limit_change_invalid (spec)
     =     at tests/sources/functional/global_vars.move:174
 
 error: post-condition does not hold
@@ -67,13 +67,13 @@ error: post-condition does not hold
    │
    =     at tests/sources/functional/global_vars.move:72: opaque_call_add_sub_invalid
    =     at tests/sources/functional/global_vars.move:73: opaque_call_add_sub_invalid
-   =     at tests/sources/functional/global_vars.move:53
+   =     at tests/sources/functional/global_vars.move:53: opaque_add (spec)
    =     at tests/sources/functional/global_vars.move:73: opaque_call_add_sub_invalid
-   =     at tests/sources/functional/global_vars.move:62
+   =     at tests/sources/functional/global_vars.move:62: opaque_sub (spec)
    =     at tests/sources/functional/global_vars.move:73: opaque_call_add_sub_invalid
-   =     at tests/sources/functional/global_vars.move:53
+   =     at tests/sources/functional/global_vars.move:53: opaque_add (spec)
    =     at tests/sources/functional/global_vars.move:74: opaque_call_add_sub_invalid
-   =     at tests/sources/functional/global_vars.move:76
+   =     at tests/sources/functional/global_vars.move:76: opaque_call_add_sub_invalid (spec)
 
 error: post-condition does not hold
     ┌─ tests/sources/functional/global_vars.move:161:9
@@ -83,9 +83,9 @@ error: post-condition does not hold
     │
     =     at tests/sources/functional/global_vars.move:157: opaque_expect_property_of_u64_invalid
     =     at tests/sources/functional/global_vars.move:158: opaque_expect_property_of_u64_invalid
-    =     at tests/sources/functional/global_vars.move:147
+    =     at tests/sources/functional/global_vars.move:147: opaque_give_property_to (spec)
     =     at tests/sources/functional/global_vars.move:159: opaque_expect_property_of_u64_invalid
-    =     at tests/sources/functional/global_vars.move:161
+    =     at tests/sources/functional/global_vars.move:161: opaque_expect_property_of_u64_invalid (spec)
 
 error: global memory invariant does not hold
     ┌─ tests/sources/functional/global_vars.move:174:5

--- a/language/move-prover/tests/sources/functional/global_vars.no_opaque_exp
+++ b/language/move-prover/tests/sources/functional/global_vars.no_opaque_exp
@@ -9,15 +9,15 @@ error: post-condition does not hold
    =     at tests/sources/functional/global_vars.move:38: call_add_sub_invalid
    =     at tests/sources/functional/global_vars.move:17: add
    =     at tests/sources/functional/global_vars.move:18: add
-   =     at tests/sources/functional/global_vars.move:20
+   =     at tests/sources/functional/global_vars.move:20: add (spec)
    =     at tests/sources/functional/global_vars.move:24: sub
    =     at tests/sources/functional/global_vars.move:25: sub
-   =     at tests/sources/functional/global_vars.move:27
+   =     at tests/sources/functional/global_vars.move:27: sub (spec)
    =     at tests/sources/functional/global_vars.move:17: add
    =     at tests/sources/functional/global_vars.move:18: add
-   =     at tests/sources/functional/global_vars.move:20
+   =     at tests/sources/functional/global_vars.move:20: add (spec)
    =     at tests/sources/functional/global_vars.move:39: call_add_sub_invalid
-   =     at tests/sources/functional/global_vars.move:41
+   =     at tests/sources/functional/global_vars.move:41: call_add_sub_invalid (spec)
 
 error: precondition does not hold at this call
     ┌─ tests/sources/functional/global_vars.move:101:9
@@ -27,7 +27,7 @@ error: precondition does not hold at this call
     │
     =     at tests/sources/functional/global_vars.move:109: do_privileged_invalid
     =         _s = <redacted>
-    =     at tests/sources/functional/global_vars.move:101
+    =     at tests/sources/functional/global_vars.move:101: requires_access (spec)
 
 error: post-condition does not hold
     ┌─ tests/sources/functional/global_vars.move:137:9
@@ -38,9 +38,9 @@ error: post-condition does not hold
     =     at tests/sources/functional/global_vars.move:133: expect_property_of_u64_invalid
     =     at tests/sources/functional/global_vars.move:134: expect_property_of_u64_invalid
     =     at tests/sources/functional/global_vars.move:121: give_property_to
-    =     at tests/sources/functional/global_vars.move:123
+    =     at tests/sources/functional/global_vars.move:123: give_property_to (spec)
     =     at tests/sources/functional/global_vars.move:135: expect_property_of_u64_invalid
-    =     at tests/sources/functional/global_vars.move:137
+    =     at tests/sources/functional/global_vars.move:137: expect_property_of_u64_invalid (spec)
 
 error: global memory invariant does not hold
     ┌─ tests/sources/functional/global_vars.move:174:5
@@ -56,7 +56,7 @@ error: global memory invariant does not hold
     =     at tests/sources/functional/global_vars.move:177: publish
     =     at tests/sources/functional/global_vars.move:178: publish
     =     at tests/sources/functional/global_vars.move:186: limit_change_invalid
-    =     at tests/sources/functional/global_vars.move:188
+    =     at tests/sources/functional/global_vars.move:188: limit_change_invalid (spec)
     =     at tests/sources/functional/global_vars.move:174
 
 error: post-condition does not hold
@@ -69,15 +69,15 @@ error: post-condition does not hold
    =     at tests/sources/functional/global_vars.move:73: opaque_call_add_sub_invalid
    =     at tests/sources/functional/global_vars.move:48: opaque_add
    =     at tests/sources/functional/global_vars.move:49: opaque_add
-   =     at tests/sources/functional/global_vars.move:53
+   =     at tests/sources/functional/global_vars.move:53: opaque_add (spec)
    =     at tests/sources/functional/global_vars.move:57: opaque_sub
    =     at tests/sources/functional/global_vars.move:58: opaque_sub
-   =     at tests/sources/functional/global_vars.move:62
+   =     at tests/sources/functional/global_vars.move:62: opaque_sub (spec)
    =     at tests/sources/functional/global_vars.move:48: opaque_add
    =     at tests/sources/functional/global_vars.move:49: opaque_add
-   =     at tests/sources/functional/global_vars.move:53
+   =     at tests/sources/functional/global_vars.move:53: opaque_add (spec)
    =     at tests/sources/functional/global_vars.move:74: opaque_call_add_sub_invalid
-   =     at tests/sources/functional/global_vars.move:76
+   =     at tests/sources/functional/global_vars.move:76: opaque_call_add_sub_invalid (spec)
 
 error: post-condition does not hold
     ┌─ tests/sources/functional/global_vars.move:161:9
@@ -88,9 +88,9 @@ error: post-condition does not hold
     =     at tests/sources/functional/global_vars.move:157: opaque_expect_property_of_u64_invalid
     =     at tests/sources/functional/global_vars.move:158: opaque_expect_property_of_u64_invalid
     =     at tests/sources/functional/global_vars.move:144: opaque_give_property_to
-    =     at tests/sources/functional/global_vars.move:147
+    =     at tests/sources/functional/global_vars.move:147: opaque_give_property_to (spec)
     =     at tests/sources/functional/global_vars.move:159: opaque_expect_property_of_u64_invalid
-    =     at tests/sources/functional/global_vars.move:161
+    =     at tests/sources/functional/global_vars.move:161: opaque_expect_property_of_u64_invalid (spec)
 
 error: global memory invariant does not hold
     ┌─ tests/sources/functional/global_vars.move:174:5

--- a/language/move-prover/tests/sources/functional/hash_model.exp
+++ b/language/move-prover/tests/sources/functional/hash_model.exp
@@ -16,8 +16,8 @@ error: post-condition does not hold
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/hash_model.move:44: hash_test1_incorrect
-   =     at tests/sources/functional/hash_model.move:46
-   =     at tests/sources/functional/hash_model.move:48
+   =     at tests/sources/functional/hash_model.move:46: hash_test1_incorrect (spec)
+   =     at tests/sources/functional/hash_model.move:48: hash_test1_incorrect (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/hash_model.move:91:9
@@ -36,5 +36,5 @@ error: post-condition does not hold
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/hash_model.move:87: hash_test2_incorrect
-   =     at tests/sources/functional/hash_model.move:89
-   =     at tests/sources/functional/hash_model.move:91
+   =     at tests/sources/functional/hash_model.move:89: hash_test2_incorrect (spec)
+   =     at tests/sources/functional/hash_model.move:91: hash_test2_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/hash_model_invalid.exp
+++ b/language/move-prover/tests/sources/functional/hash_model_invalid.exp
@@ -16,8 +16,8 @@ error: post-condition does not hold
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:16: hash_test1
-   =     at tests/sources/functional/hash_model_invalid.move:18
-   =     at tests/sources/functional/hash_model_invalid.move:22
+   =     at tests/sources/functional/hash_model_invalid.move:18: hash_test1 (spec)
+   =     at tests/sources/functional/hash_model_invalid.move:22: hash_test1 (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/hash_model_invalid.move:35:9
@@ -36,5 +36,5 @@ error: post-condition does not hold
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/hash_model_invalid.move:31: hash_test2
-   =     at tests/sources/functional/hash_model_invalid.move:33
-   =     at tests/sources/functional/hash_model_invalid.move:35
+   =     at tests/sources/functional/hash_model_invalid.move:33: hash_test2 (spec)
+   =     at tests/sources/functional/hash_model_invalid.move:35: hash_test2 (spec)

--- a/language/move-prover/tests/sources/functional/invariants_resources.exp
+++ b/language/move-prover/tests/sources/functional/invariants_resources.exp
@@ -10,4 +10,4 @@ error: post-condition does not hold
    =     at tests/sources/functional/invariants_resources.move:28: get_invalid
    =         result = <redacted>
    =     at tests/sources/functional/invariants_resources.move:29: get_invalid
-   =     at tests/sources/functional/invariants_resources.move:31
+   =     at tests/sources/functional/invariants_resources.move:31: get_invalid (spec)

--- a/language/move-prover/tests/sources/functional/is_txn_signer.exp
+++ b/language/move-prover/tests/sources/functional/is_txn_signer.exp
@@ -38,7 +38,7 @@ error: precondition does not hold at this call
 39 │         requires Signer::is_txn_signer_addr(@0x7); // f5 requires this to be true at its callers' sites
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/is_txn_signer.move:39
+   =     at tests/sources/functional/is_txn_signer.move:39: f5 (spec)
 
 error: unknown assertion failed
    ┌─ tests/sources/functional/is_txn_signer.move:66:13

--- a/language/move-prover/tests/sources/functional/is_txn_signer.no_opaque_exp
+++ b/language/move-prover/tests/sources/functional/is_txn_signer.no_opaque_exp
@@ -38,7 +38,7 @@ error: precondition does not hold at this call
 39 │         requires Signer::is_txn_signer_addr(@0x7); // f5 requires this to be true at its callers' sites
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   =     at tests/sources/functional/is_txn_signer.move:39
+   =     at tests/sources/functional/is_txn_signer.move:39: f5 (spec)
 
 error: unknown assertion failed
    ┌─ tests/sources/functional/is_txn_signer.move:66:13

--- a/language/move-prover/tests/sources/functional/let.exp
+++ b/language/move-prover/tests/sources/functional/let.exp
@@ -5,10 +5,13 @@ error: function does not abort under this condition
 76 │         aborts_if sum != 0;
    │         ^^^^^^^^^^^^^^^^^^^
    │
+   = Related Bindings:
+   =         sum = <redacted>
+   = Execution Trace:
    =     at tests/sources/functional/let.move:68: spec_let_with_abort_incorrect
-   =     at tests/sources/functional/let.move:74
+   =     at tests/sources/functional/let.move:74: spec_let_with_abort_incorrect (spec)
    =         `let sum = a + b;` = <redacted>
-   =     at tests/sources/functional/let.move:75
+   =     at tests/sources/functional/let.move:75: spec_let_with_abort_incorrect (spec)
    =         `let product = a * b;` = <redacted>
    =     at tests/sources/functional/let.move:68: spec_let_with_abort_incorrect
    =         a = <redacted>
@@ -20,9 +23,9 @@ error: function does not abort under this condition
    =         a = <redacted>
    =         b = <redacted>
    =     at tests/sources/functional/let.move:72: spec_let_with_abort_incorrect
-   =     at tests/sources/functional/let.move:79
+   =     at tests/sources/functional/let.move:79: spec_let_with_abort_incorrect (spec)
    =         `let post new_a = old(a) / sum;` = <redacted>
-   =     at tests/sources/functional/let.move:76
+   =     at tests/sources/functional/let.move:76: spec_let_with_abort_incorrect (spec)
    =         `aborts_if sum != 0;` = <redacted>
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -40,10 +43,14 @@ error: abort not covered by any of the `aborts_if` clauses
 82 │ │     }
    │ ╰─────^
    │
+   = Related Bindings:
+   =         a = <redacted>
+   =         b = <redacted>
+   = Execution Trace:
    =     at tests/sources/functional/let.move:68: spec_let_with_abort_incorrect
-   =     at tests/sources/functional/let.move:74
+   =     at tests/sources/functional/let.move:74: spec_let_with_abort_incorrect (spec)
    =         `let sum = a + b;` = <redacted>
-   =     at tests/sources/functional/let.move:75
+   =     at tests/sources/functional/let.move:75: spec_let_with_abort_incorrect (spec)
    =         `let product = a * b;` = <redacted>
    =     at tests/sources/functional/let.move:68: spec_let_with_abort_incorrect
    =         a = <redacted>
@@ -51,11 +58,10 @@ error: abort not covered by any of the `aborts_if` clauses
    =     at tests/sources/functional/let.move:69: spec_let_with_abort_incorrect
    =         saved_a = <redacted>
    =     at tests/sources/functional/let.move:70: spec_let_with_abort_incorrect
-   =     at tests/sources/functional/let.move:70: spec_let_with_abort_incorrect
    =         ABORTED
-   =     at tests/sources/functional/let.move:76
+   =     at tests/sources/functional/let.move:76: spec_let_with_abort_incorrect (spec)
    =         `aborts_if sum != 0;` = <redacted>
-   =     at tests/sources/functional/let.move:77
+   =     at tests/sources/functional/let.move:77: spec_let_with_abort_incorrect (spec)
    =         `aborts_if sum >= MAX_U64;` = <redacted>
-   =     at tests/sources/functional/let.move:78
+   =     at tests/sources/functional/let.move:78: spec_let_with_abort_incorrect (spec)
    =         `aborts_if product >= MAX_U64;` = <redacted>

--- a/language/move-prover/tests/sources/functional/loops.exp
+++ b/language/move-prover/tests/sources/functional/loops.exp
@@ -40,7 +40,7 @@ error: function does not abort under this condition
    =     at tests/sources/functional/loops.move:50: iter10_no_abort_incorrect
    =     at tests/sources/functional/loops.move:51: iter10_no_abort_incorrect
    =     at tests/sources/functional/loops.move:49: iter10_no_abort_incorrect
-   =     at tests/sources/functional/loops.move:58
+   =     at tests/sources/functional/loops.move:58: iter10_no_abort_incorrect (spec)
 
 error: base case of the loop invariant does not hold
     ┌─ tests/sources/functional/loops.move:210:17

--- a/language/move-prover/tests/sources/functional/mono.exp
+++ b/language/move-prover/tests/sources/functional/mono.exp
@@ -8,7 +8,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/mono.move:70: vec_addr
    =         x = <redacted>
    =         result = <redacted>
-   =     at tests/sources/functional/mono.move:71
+   =     at tests/sources/functional/mono.move:71: vec_addr (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/mono.move:73:21
@@ -19,7 +19,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/mono.move:72: vec_bool
    =         x = <redacted>
    =         result = <redacted>
-   =     at tests/sources/functional/mono.move:73
+   =     at tests/sources/functional/mono.move:73: vec_bool (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/mono.move:69:20
@@ -30,7 +30,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/mono.move:68: vec_int
    =         x = <redacted>
    =         result = <redacted>
-   =     at tests/sources/functional/mono.move:69
+   =     at tests/sources/functional/mono.move:69: vec_int (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/mono.move:77:28
@@ -41,7 +41,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/mono.move:76: vec_struct_addr
    =         x = <redacted>
    =         result = <redacted>
-   =     at tests/sources/functional/mono.move:77
+   =     at tests/sources/functional/mono.move:77: vec_struct_addr (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/mono.move:75:27
@@ -52,7 +52,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/mono.move:74: vec_struct_int
    =         x = <redacted>
    =         result = <redacted>
-   =     at tests/sources/functional/mono.move:75
+   =     at tests/sources/functional/mono.move:75: vec_struct_int (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/mono.move:82:20
@@ -65,4 +65,4 @@ error: post-condition does not hold
    =     at tests/sources/functional/mono.move:80: vec_vec
    =         result = <redacted>
    =     at tests/sources/functional/mono.move:81: vec_vec
-   =     at tests/sources/functional/mono.move:82
+   =     at tests/sources/functional/mono.move:82: vec_vec (spec)

--- a/language/move-prover/tests/sources/functional/opaque.exp
+++ b/language/move-prover/tests/sources/functional/opaque.exp
@@ -8,4 +8,4 @@ error: post-condition does not hold
    =     at tests/sources/functional/opaque.move:10: opaque_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/opaque.move:11: opaque_incorrect
-   =     at tests/sources/functional/opaque.move:14
+   =     at tests/sources/functional/opaque.move:14: opaque_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/opaque.no_opaque_exp
+++ b/language/move-prover/tests/sources/functional/opaque.no_opaque_exp
@@ -11,7 +11,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/opaque.move:11: opaque_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/opaque.move:19: opaque_caller
-   =     at tests/sources/functional/opaque.move:22
+   =     at tests/sources/functional/opaque.move:22: opaque_caller (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/opaque.move:14:9
@@ -22,4 +22,4 @@ error: post-condition does not hold
    =     at tests/sources/functional/opaque.move:10: opaque_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/opaque.move:11: opaque_incorrect
-   =     at tests/sources/functional/opaque.move:14
+   =     at tests/sources/functional/opaque.move:14: opaque_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/pragma.exp
+++ b/language/move-prover/tests/sources/functional/pragma.exp
@@ -14,5 +14,4 @@ error: abort not covered by any of the `aborts_if` clauses
    =     at tests/sources/functional/pragma.move:10: always_aborts_with_verify_incorrect
    =         _c = <redacted>
    =     at tests/sources/functional/pragma.move:11: always_aborts_with_verify_incorrect
-   =     at tests/sources/functional/pragma.move:11: always_aborts_with_verify_incorrect
    =         ABORTED

--- a/language/move-prover/tests/sources/functional/references.exp
+++ b/language/move-prover/tests/sources/functional/references.exp
@@ -19,4 +19,4 @@ error: function does not abort under this condition
    =         b = <redacted>
    =     at tests/sources/functional/references.move:73: mut_ref_incorrect
    =     at tests/sources/functional/references.move:74: mut_ref_incorrect
-   =     at tests/sources/functional/references.move:76
+   =     at tests/sources/functional/references.move:76: mut_ref_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/resources.exp
+++ b/language/move-prover/tests/sources/functional/resources.exp
@@ -14,5 +14,5 @@ error: post-condition does not hold
    =         result = <redacted>
    =     at ../move-stdlib/sources/Signer.move:14: address_of
    =     at tests/sources/functional/resources.move:36: create_resource_incorrect
-   =     at tests/sources/functional/resources.move:38
-   =     at tests/sources/functional/resources.move:39
+   =     at tests/sources/functional/resources.move:38: create_resource_incorrect (spec)
+   =     at tests/sources/functional/resources.move:39: create_resource_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/return_values.exp
+++ b/language/move-prover/tests/sources/functional/return_values.exp
@@ -14,7 +14,7 @@ error: post-condition does not hold
    =         result_2 = <redacted>
    =     at tests/sources/functional/return_values.move:32: one_two_wrapper_incorrect
    =     at tests/sources/functional/return_values.move:16
-   =     at tests/sources/functional/return_values.move:34
+   =     at tests/sources/functional/return_values.move:34: one_two_wrapper_incorrect (spec)
    =     at tests/sources/functional/return_values.move:17
 
 error: post-condition does not hold
@@ -31,4 +31,4 @@ error: post-condition does not hold
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/return_values.move:58: true_one_wrapper_incorrect
-   =     at tests/sources/functional/return_values.move:60
+   =     at tests/sources/functional/return_values.move:60: true_one_wrapper_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/schema_exp.exp
+++ b/language/move-prover/tests/sources/functional/schema_exp.exp
@@ -16,7 +16,6 @@ error: abort not covered by any of the `aborts_if` clauses
    =     at tests/sources/functional/schema_exp.move:25: bar_incorrect
    =         c = <redacted>
    =     at tests/sources/functional/schema_exp.move:26: bar_incorrect
-   =     at tests/sources/functional/schema_exp.move:26: bar_incorrect
    =         ABORTED
 
 error: post-condition does not hold

--- a/language/move-prover/tests/sources/functional/serialize_model.exp
+++ b/language/move-prover/tests/sources/functional/serialize_model.exp
@@ -16,5 +16,5 @@ error: post-condition does not hold
    =         result_1 = <redacted>
    =         result_2 = <redacted>
    =     at tests/sources/functional/serialize_model.move:31: bcs_test1_incorrect
-   =     at tests/sources/functional/serialize_model.move:33
-   =     at tests/sources/functional/serialize_model.move:34
+   =     at tests/sources/functional/serialize_model.move:33: bcs_test1_incorrect (spec)
+   =     at tests/sources/functional/serialize_model.move:34: bcs_test1_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/strong_edges.exp
+++ b/language/move-prover/tests/sources/functional/strong_edges.exp
@@ -6,15 +6,15 @@ error: post-condition does not hold
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/strong_edges.move:47: glob_and_field_edges_incorrect
-   =     at tests/sources/functional/strong_edges.move:56
+   =     at tests/sources/functional/strong_edges.move:56: glob_and_field_edges_incorrect (spec)
    =     at tests/sources/functional/strong_edges.move:47: glob_and_field_edges_incorrect
    =         addr = <redacted>
    =     at tests/sources/functional/strong_edges.move:48: glob_and_field_edges_incorrect
    =         s = <redacted>
    =     at tests/sources/functional/strong_edges.move:49: glob_and_field_edges_incorrect
    =     at tests/sources/functional/strong_edges.move:50: glob_and_field_edges_incorrect
-   =     at tests/sources/functional/strong_edges.move:55
-   =     at tests/sources/functional/strong_edges.move:54
+   =     at tests/sources/functional/strong_edges.move:55: glob_and_field_edges_incorrect (spec)
+   =     at tests/sources/functional/strong_edges.move:54: glob_and_field_edges_incorrect (spec)
 
 error: unknown assertion failed
    ┌─ tests/sources/functional/strong_edges.move:64:13

--- a/language/move-prover/tests/sources/functional/trace.exp
+++ b/language/move-prover/tests/sources/functional/trace.exp
@@ -1,0 +1,63 @@
+Move prover returns: exiting with boogie verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/trace.move:17:9
+   │
+17 │         ensures result == a + b;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = Related Bindings:
+   =         a = <redacted>
+   =         b = <redacted>
+   =         result = <redacted>
+   = Execution Trace:
+   =     at tests/sources/functional/trace.move:13: add_invalid
+   =         a = <redacted>
+   =         b = <redacted>
+   =     at tests/sources/functional/trace.move:14: add_invalid
+   =         result = <redacted>
+   =     at tests/sources/functional/trace.move:15: add_invalid
+   =     at tests/sources/functional/trace.move:17: add_invalid (spec)
+   =         `ensures result == a + b;` = <redacted>
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/trace.move:32:9
+   │
+32 │         ensures exists<R>(addr) ==> global<R>(addr).x == x;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = Related Bindings:
+   =         addr = <redacted>
+   =         exists<R>(addr) = <redacted>
+   =         global<R>(addr) = <redacted>
+   =         x = <redacted>
+   = Execution Trace:
+   =     at tests/sources/functional/trace.move:27: publish_invalid
+   =     at tests/sources/functional/trace.move:31: publish_invalid (spec)
+   =         `let addr = Signer::address_of(s);` = <redacted>
+   =     at tests/sources/functional/trace.move:27: publish_invalid
+   =         s = <redacted>
+   =         x = <redacted>
+   =     at tests/sources/functional/trace.move:28: publish_invalid
+   =     at tests/sources/functional/trace.move:29: publish_invalid
+   =     at tests/sources/functional/trace.move:32: publish_invalid (spec)
+   =         `ensures exists<R>(addr) ==> global<R>(addr).x == x;` = <redacted>
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/trace.move:24:9
+   │
+24 │         ensures a == old(a) + b;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = Related Bindings:
+   =         a = <redacted>
+   =         b = <redacted>
+   =         old(a) = <redacted>
+   = Execution Trace:
+   =     at tests/sources/functional/trace.move:20: update_invalid
+   =         a = <redacted>
+   =         b = <redacted>
+   =     at tests/sources/functional/trace.move:21: update_invalid
+   =         a = <redacted>
+   =     at tests/sources/functional/trace.move:22: update_invalid
+   =     at tests/sources/functional/trace.move:24: update_invalid (spec)
+   =         `ensures a == old(a) + b;` = <redacted>

--- a/language/move-prover/tests/sources/functional/trace.move
+++ b/language/move-prover/tests/sources/functional/trace.move
@@ -1,0 +1,34 @@
+// flag: --trace
+module 0x42::TestTracing {
+    use Std::Signer;
+
+    spec module {
+        pragma verify = true;
+    }
+
+    struct R has key {
+        x: u64
+    }
+
+    fun add_invalid(a: u64, b: u64): u64 {
+        a + b -1
+    }
+    spec add_invalid {
+        ensures result == a + b;
+    }
+
+    fun update_invalid(a: &mut u64, b: u64) {
+        *a = *a + b - 1
+    }
+    spec update_invalid {
+        ensures a == old(a) + b;
+    }
+
+    fun publish_invalid(s: &signer, x: u64) {
+        move_to<R>(s, R{x: x - 1})
+    }
+    spec publish_invalid {
+        let addr = Signer::address_of(s);
+        ensures exists<R>(addr) ==> global<R>(addr).x == x;
+    }
+}

--- a/language/move-prover/tests/sources/functional/type_dependent_code.exp
+++ b/language/move-prover/tests/sources/functional/type_dependent_code.exp
@@ -19,7 +19,6 @@ error: abort not covered by any of the `aborts_if` clauses
    =         x = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:7: test1
    =     at tests/sources/functional/type_dependent_code.move:8: test1
-   =     at tests/sources/functional/type_dependent_code.move:8: test1
    =         ABORTED
 
 error: abort not covered by any of the `aborts_if` clauses
@@ -43,7 +42,6 @@ error: abort not covered by any of the `aborts_if` clauses
    =         t2 = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:23: test2
    =     at tests/sources/functional/type_dependent_code.move:24: test2
-   =     at tests/sources/functional/type_dependent_code.move:24: test2
    =         ABORTED
 
 error: post-condition does not hold
@@ -65,7 +63,7 @@ error: post-condition does not hold
    =         r = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:47: test1
    =     at tests/sources/functional/type_dependent_code.move:48: test1
-   =     at tests/sources/functional/type_dependent_code.move:50
+   =     at tests/sources/functional/type_dependent_code.move:50: test1 (spec)
 
 error: post-condition does not hold
    ┌─ tests/sources/functional/type_dependent_code.move:66:9
@@ -87,4 +85,4 @@ error: post-condition does not hold
    =         r = <redacted>
    =     at tests/sources/functional/type_dependent_code.move:63: test2
    =     at tests/sources/functional/type_dependent_code.move:64: test2
-   =     at tests/sources/functional/type_dependent_code.move:66
+   =     at tests/sources/functional/type_dependent_code.move:66: test2 (spec)

--- a/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
+++ b/language/move-prover/tests/sources/regression/type_param_bug_200228.exp
@@ -10,5 +10,5 @@ error: post-condition does not hold
    =     at tests/sources/regression/type_param_bug_200228.move:7: type_param_bug
    =         result = <redacted>
    =     at tests/sources/regression/type_param_bug_200228.move:8: type_param_bug
-   =     at tests/sources/regression/type_param_bug_200228.move:11
-   =     at tests/sources/regression/type_param_bug_200228.move:12
+   =     at tests/sources/regression/type_param_bug_200228.move:11: type_param_bug (spec)
+   =     at tests/sources/regression/type_param_bug_200228.move:12: type_param_bug (spec)

--- a/language/move-prover/tools/spec-flatten/src/ast_print.rs
+++ b/language/move-prover/tools/spec-flatten/src/ast_print.rs
@@ -306,7 +306,7 @@ impl SpecPrinter<'_> {
                     // built-in functions
                     Len => print_call_fun("len"),
                     Old => print_call_fun("old"),
-                    Trace => print_call_fun("TRACE"),
+                    Trace(_) => print_call_fun("TRACE"),
                     Global(_label_opt) => print_call_fun_inst("global"),
                     Exists(_label_opt) => print_call_fun_inst("exists"),
                     EmptyVec => print_call_fun_inst("vec"),


### PR DESCRIPTION
This refines the output we produce on errors if the option `-t` (`--trace`) is set. Specifically, if an assertion fails, we print the values of sub-expressions of the condition in a new section "Related Bindings" in the error output. For examples, see the new test expectations for `trace.move`.

Some changes in baselines come from general improvements to the rendering procedure (e.g. skipping duplicate line traces).


## Motivation

Better diagnosis.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Added test
