### PR TITLE
[move] Add move-ir-compiler-transactional-tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5204,6 +5204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-ir-compiler-transactional-tests"
+version = "0.1.0"
+dependencies = [
+ "datatest-stable",
+ "diem-workspace-hack",
+ "move-transactional-test-runner",
+]
+
+[[package]]
 name = "move-ir-types"
 version = "0.1.0"
 dependencies = [
@@ -5463,16 +5472,19 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytecode-interpreter",
+ "bytecode-source-map",
  "colored",
  "datatest-stable",
  "diem-workspace-hack",
  "difference",
+ "disassembler",
  "move-binary-format",
  "move-bytecode-utils",
  "move-cli",
  "move-command-line-common",
  "move-core-types",
  "move-ir-compiler",
+ "move-ir-types",
  "move-lang",
  "move-stdlib",
  "move-symbol-pool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ members = [
     "language/move-ir-compiler/bytecode-source-map",
     "language/move-ir-compiler/ir-to-bytecode",
     "language/move-ir-compiler/ir-to-bytecode/syntax",
+    "language/move-ir-compiler/transactional-tests",
     "language/move-lang",
     "language/move-lang/functional-tests",
     "language/move-lang/transactional-tests",

--- a/language/move-ir-compiler/src/unit_tests/expression_tests.rs
+++ b/language/move-ir-compiler/src/unit_tests/expression_tests.rs
@@ -11,33 +11,6 @@ use move_binary_format::{
 };
 
 #[test]
-fn compile_script_expr_addition() {
-    let code = String::from(
-        "
-        main() {
-            let x: u64;
-            let y: u64;
-            let z: u64;
-            x = 3;
-            y = 5;
-            z = move(x) + move(y);
-            return;
-        }
-        ",
-    );
-    let compiled_script_res = compile_script_string(&code);
-    let compiled_script = compiled_script_res.unwrap();
-    assert_eq!(count_locals(&compiled_script), 3);
-    assert_eq!(compiled_script.code().code.len(), 9);
-    assert!(compiled_script.struct_handles().is_empty());
-    assert_eq!(compiled_script.function_handles().len(), 0);
-    assert_eq!(compiled_script.signatures().len(), 2);
-    assert_eq!(compiled_script.module_handles().len(), 0);
-    assert_eq!(compiled_script.identifiers().len(), 0);
-    assert_eq!(compiled_script.address_identifiers().len(), 0);
-}
-
-#[test]
 fn compile_script_expr_combined() {
     let code = String::from(
         "

--- a/language/move-ir-compiler/transactional-tests/Cargo.toml
+++ b/language/move-ir-compiler/transactional-tests/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "move-ir-compiler-transactional-tests"
+version = "0.1.0"
+authors = ["Diem Association <opensource@diem.com>"]
+publish = false
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
+
+[dev-dependencies]
+datatest-stable = "0.1.1"
+move-transactional-test-runner = { path = "../../testing-infra/transactional-test-runner" }
+
+[[test]]
+name = "tests"
+harness = false

--- a/language/move-ir-compiler/transactional-tests/tests/expressions/binary_add.exp
+++ b/language/move-ir-compiler/transactional-tests/tests/expressions/binary_add.exp
@@ -1,0 +1,23 @@
+processed 1 task
+
+task 0 'print-bytecode'. lines 1-12:
+// Move bytecode v4
+module e.Expressions {
+
+
+binary_add() {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: LdU64(3)
+	1: StLoc[0](loc0: u64)
+	2: LdU64(5)
+	3: StLoc[1](loc1: u64)
+	4: MoveLoc[0](loc0: u64)
+	5: MoveLoc[1](loc1: u64)
+	6: Add
+	7: StLoc[2](loc2: u64)
+	8: Ret
+}
+}

--- a/language/move-ir-compiler/transactional-tests/tests/expressions/binary_add.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/expressions/binary_add.mvir
@@ -1,0 +1,12 @@
+//# print-bytecode
+module 0xE.Expressions {
+    binary_add() {
+        let x: u64;
+        let y: u64;
+        let z: u64;
+        x = 3;
+        y = 5;
+        z = move(x) + move(y);
+        return;
+    }
+}

--- a/language/move-ir-compiler/transactional-tests/tests/tests.rs
+++ b/language/move-ir-compiler/transactional-tests/tests/tests.rs
@@ -1,0 +1,7 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+pub const TEST_DIR: &str = "tests";
+use move_transactional_test_runner::vm_test_harness::run_test;
+
+datatest_stable::harness!(run_test, TEST_DIR, r".*\.mvir$");

--- a/language/testing-infra/transactional-test-runner/Cargo.toml
+++ b/language/testing-infra/transactional-test-runner/Cargo.toml
@@ -21,12 +21,15 @@ tempfile = "3.2.0"
 diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 bytecode-interpreter = { path = "../../move-prover/interpreter" }
+bytecode-source-map = { path = "../../move-ir-compiler/bytecode-source-map" }
+disassembler = { path = "../../tools/disassembler" }
 move-binary-format = { path = "../../move-binary-format" }
 move-bytecode-utils = { path = "../../tools/move-bytecode-utils" }
 move-cli = { path = "../../tools/move-cli" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-compiler = { path = "../../move-ir-compiler" }
+move-ir-types = { path = "../../move-ir/types" }
 move-lang = { path = "../../move-lang" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 move-symbol-pool = { path = "../../move-symbol-pool" }

--- a/language/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/language/testing-infra/transactional-test-runner/src/tasks.rs
@@ -218,6 +218,11 @@ pub enum SyntaxChoice {
     IR,
 }
 
+/// Translates the given Move IR module into bytecode, then prints a textual representation of that
+/// bytecode.
+#[derive(Debug, StructOpt)]
+pub struct PrintBytecodeCommand {}
+
 #[derive(Debug, StructOpt)]
 pub struct InitCommand {
     #[structopt(
@@ -262,6 +267,7 @@ pub struct ViewCommand {
 #[derive(Debug)]
 pub enum TaskCommand<ExtraInitArgs, ExtraPublishArgs, ExtraRunArgs, SubCommands> {
     Init(InitCommand, ExtraInitArgs),
+    PrintBytecode(PrintBytecodeCommand),
     Publish(PublishCommand, ExtraPublishArgs),
     Run(RunCommand, ExtraRunArgs),
     View(ViewCommand),
@@ -299,6 +305,8 @@ where
             ExtraInitArgs::augment_clap(subcommand)
         });
 
+        let app = app.subcommand(PrintBytecodeCommand::clap().name("print-bytecode"));
+
         let app = app.subcommand({
             let subcommand = PublishCommand::clap().name("publish");
             ExtraPublishArgs::augment_clap(subcommand)
@@ -317,6 +325,9 @@ where
         match matches.subcommand() {
             ("init", Some(matches)) => {
                 TaskCommand::Init(StructOpt::from_clap(matches), StructOpt::from_clap(matches))
+            }
+            ("print-bytecode", Some(matches)) => {
+                TaskCommand::PrintBytecode(StructOpt::from_clap(matches))
             }
             ("publish", Some(matches)) => {
                 TaskCommand::Publish(StructOpt::from_clap(matches), StructOpt::from_clap(matches))

--- a/x.toml
+++ b/x.toml
@@ -215,6 +215,7 @@ members = [
     "memsocket",
     "mirai-dataflow-analysis",
     "module-generation",
+    "move-ir-compiler-transactional-tests",
     "move-lang-functional-tests",
     "move-lang-transactional-tests",
     "move-oncall-trainer",


### PR DESCRIPTION
Add a transactional test harness for the move-ir-compiler. To test the compiler's ability to translate Move IR into bytecode, add a "print-bytecode" command to the transactional test runner.
    
Some implementation notes:
    
* This commit just migrates one test from the move-ir-compiler unit tests to the new transactional tests. I'd like to migrate the rest in a future commit, to keep this commit granular.
* The disassembler crate contains a bug, in which it only prints bytecode instructions in functions defined in modules -- it does not print bytecode in scripts' main functions. This commit doesn't address this bug, instead it uses the portion of the disassembler that does work.
* This commit contains the first test of the disassembler's output (no other tests exist, which is probably why the disassembler's script output bug went unnoticed). I have opinions about the output, but I believe changing the output format is outside of the scope of this commit, which is focused just on adding a means to migrate move-ir-compiler unit tests.