### PR TITLE
[move-prover] Add elimination of ref in choice operator

### DIFF
--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -358,13 +358,13 @@ impl<'env> SpecTranslator<'env> {
                 .map(|(s, ty)| {
                     (
                         s.display(env.symbol_pool()).to_string(),
-                        boogie_type(env, ty),
+                        boogie_type(env, ty.skip_reference()),
                     )
                 })
                 .chain(
                     info.used_temps
                         .iter()
-                        .map(|(t, ty)| (format!("$t{}", t), boogie_type(env, ty))),
+                        .map(|(t, ty)| (format!("$t{}", t), boogie_type(env, ty.skip_reference()))),
                 )
                 .chain(info.used_memory.iter().map(|(m, l)| {
                     let struct_env = &env.get_struct(m.to_qualified_id());
@@ -381,7 +381,7 @@ impl<'env> SpecTranslator<'env> {
             let mk_decl = |(n, t): &(String, String)| format!("{}: {}", n, t);
             let mk_arg = |(n, _): &(String, String)| n.to_owned();
             let emit_valid = |n: &str, ty: &Type| {
-                let suffix = boogie_type_suffix(env, ty);
+                let suffix = boogie_type_suffix(env, ty.skip_reference());
                 emit!(self.writer, "$IsValid'{}'({})", suffix, n);
             };
             let mk_temp = |t: TempIndex| format!("$t{}", t);

--- a/language/move-prover/tests/sources/functional/choice.move
+++ b/language/move-prover/tests/sources/functional/choice.move
@@ -238,4 +238,11 @@ module 0x42::TestSome {
         include ResultLessThanK { k: 10 };
         // expect to fail
     }
+
+    // A simple test for checking whether the reference has been removed in generated boogie code
+    fun remove_ref<TokenType: store>(_id: &u64) {}
+
+    spec remove_ref {
+        let min_token_id = choose min i: u64 where _id == _id;
+    }
 }


### PR DESCRIPTION
## Motivation

Resolve https://github.com/diem/diem/issues/9731

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

cargo test -v -p move-prover

A new test case Choice_eliminate_reference.move is added to tests/resources/regression. The verifier will not generate an error complaining the syntactic error of the generated Boogie file. 

