### PR TITLE
[shuffle] create account via faucet

### DIFF
--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -41,13 +41,14 @@ pub async fn main() -> Result<()> {
             )
             .await
         }
-
-        Subcommand::Account { root, network } => account::handle(
-            &home,
-            root,
-            home.get_network_struct_from_toml(normalized_network_name(network).as_str())?,
-        ),
-
+        Subcommand::Account { root, network } => {
+            account::handle(
+                &home,
+                root,
+                home.get_network_struct_from_toml(normalized_network_name(network).as_str())?,
+            )
+            .await
+        }
         Subcommand::Test { cmd } => test::handle(&home, cmd).await,
         Subcommand::Console {
             project_path,

--- a/shuffle/cli/src/test.rs
+++ b/shuffle/cli/src/test.rs
@@ -75,7 +75,7 @@ fn create_account(
     let public_key = account_key.public_key();
     let derived_address = AuthenticationKey::ed25519(&public_key).derived_address();
     let new_account = LocalAccount::new(derived_address, account_key, 0);
-    account::create_account_onchain(&mut treasury_account, &new_account, factory, client)?;
+    account::create_account_via_dev_api(&mut treasury_account, &new_account, factory, client)?;
     Ok(new_account)
 }
 

--- a/shuffle/integration-tests/src/helper.rs
+++ b/shuffle/integration-tests/src/helper.rs
@@ -86,7 +86,7 @@ impl ShuffleTestHelper {
         self.network_home().save_key_as_latest(private_key)?;
         self.network_home()
             .generate_latest_address_file(new_account.public_key())?;
-        account::create_account_onchain(treasury_account, new_account, &factory, &client)
+        account::create_account_via_dev_api(treasury_account, new_account, &factory, &client)
     }
 
     pub fn create_project(&self) -> Result<()> {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

The final piece that we need to connect to trove testnet is by using a faucet to create an account onto the network. This PR achieves this. 

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

Note: To mimic creating an account on trove testnet using the faucet, I set the contents of trove_testnet in the Networks.toml to the localhost information with the faucet url matching the faucet url, I used when spinning up a local faucet.

Also I changed line 247 to `let faucet_account_creation_endpoint = network.get_faucet_url()?;` for my testing.

When creating an account for the first time on trove testnet, I ran `cargo run -p shuffle -- account --network trove_testnet`. I'm prompted with this message: 

<img width="775" alt="Screen Shot 2021-11-15 at 6 23 20 PM" src="https://user-images.githubusercontent.com/55404786/141892610-cf49db09-6b85-4501-8883-c5656d9fd44a.png">

I then add the proper trove testnet information into my Networks.toml file:

<img width="836" alt="Screen Shot 2021-11-15 at 6 24 40 PM" src="https://user-images.githubusercontent.com/55404786/141894194-e15ebbba-e804-43a4-b249-e3745426bcf7.png">

Since I am mimicking account creation on trove testnet with a local faucet, I first spin up a local node using `cargo run -p shuffle -- node`. Then I spin up a faucet in another terminal using this command: `cargo run -p diem-faucet -- --address 127.0.0.1 --port 8082 --chain-id TESTING --mint-key-file-path /Users/avinash00/.shuffle/nodeconfig/mint.key --server-url http://127.0.0.1:8080`. Here is what it looks like:

![image](https://user-images.githubusercontent.com/55404786/141894515-00ed0c6b-bb80-46a6-9a4b-63004f69b8fc.png)

Then I rerun cargo run `cargo run -p shuffle -- account --network trove_testnet` and get this output:

![image](https://user-images.githubusercontent.com/55404786/141929640-aba38670-465f-4360-924c-98053f2bb64e.png)

To test if this actually created an account using the faucet, I opened up console using `cargo run -p shuffle -- console -p project_path --network trove_testnet` and typed `await devapi.accountTransactions()` and got this: 

![image](https://user-images.githubusercontent.com/55404786/141928223-8b6869a4-6a1f-4a72-82f5-30179e736ad0.png)

Luckily this didn't error out. To continue testing the usability of my fauceted account, I deployed a module using `cargo run -p shuffle -- deploy -p project_path --network trove_testnet` and all the usual modules deployed:

![image](https://user-images.githubusercontent.com/55404786/141928371-7422aa45-e63f-45b0-b599-c7e335c2c84a.png)

The last thing we have to check is if the modules appear in console. I reran `await devapi.accountTransactions()` in console and got 3 transactions in my terminal:

![image](https://user-images.githubusercontent.com/55404786/141928512-7462dbe2-be33-4045-8ada-0460f86ac8b6.png)

This was all done using the local faucet but I've proven that I can create an account using a faucet. Hopefully we can use the same code to connect to trove testnet!

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
