### PR TITLE
[mempool] Cleanup mempool metrics

### DIFF
--- a/mempool/src/counters.rs
+++ b/mempool/src/counters.rs
@@ -7,7 +7,6 @@ use diem_metrics::{
     register_int_gauge_vec, DurationHistogram, HistogramTimer, HistogramVec, IntCounter,
     IntCounterVec, IntGauge, IntGaugeVec,
 };
-use diem_types::PeerId;
 use once_cell::sync::Lazy;
 use short_hex_str::AsShortHexStr;
 use std::time::Duration;
@@ -196,14 +195,20 @@ static PROCESS_TXN_SUBMISSION_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_shared_mempool_request_latency",
         "Latency of mempool processing txn submission requests",
-        &["network", "sender"] // sender of txn(s)
+        &["network"]
     )
     .unwrap()
 });
 
-pub fn process_txn_submit_latency_timer(network: &str, sender: &str) -> HistogramTimer {
+pub fn process_txn_submit_latency_timer(network_id: NetworkId) -> HistogramTimer {
     PROCESS_TXN_SUBMISSION_LATENCY
-        .with_label_values(&[network, sender])
+        .with_label_values(&[network_id.as_str()])
+        .start_timer()
+}
+
+pub fn process_txn_submit_latency_timer_client() -> HistogramTimer {
+    PROCESS_TXN_SUBMISSION_LATENCY
+        .with_label_values(&[CLIENT_LABEL])
         .start_timer()
 }
 
@@ -212,14 +217,14 @@ static PROCESS_GET_TXN_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_shared_mempool_get_txn_request_latency",
         "Latency of mempool processing get txn by hash requests",
-        &["network", "sender"] // sender of txn(s)
+        &["network"]
     )
     .unwrap()
 });
 
-pub fn process_get_txn_latency_timer(network: &str, sender: &str) -> HistogramTimer {
+pub fn process_get_txn_latency_timer_client() -> HistogramTimer {
     PROCESS_GET_TXN_LATENCY
-        .with_label_values(&[network, sender])
+        .with_label_values(&[CLIENT_LABEL])
         .start_timer()
 }
 
@@ -234,21 +239,27 @@ pub static PROCESS_TXN_BREAKDOWN_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
 });
 
 /// Counter for tracking latency for mempool to broadcast to a peer
-pub static SHARED_MEMPOOL_BROADCAST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
+static SHARED_MEMPOOL_BROADCAST_LATENCY: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_broadcast_latency",
         "Latency of mempool executing broadcast to another peer",
-        &["network", "recipient"]
+        &["network"]
     )
     .unwrap()
 });
+
+pub fn shared_mempool_broadcast_latency(network_id: NetworkId, latency: Duration) {
+    SHARED_MEMPOOL_BROADCAST_LATENCY
+        .with_label_values(&[network_id.as_str()])
+        .observe(latency.as_secs_f64());
+}
 
 /// Counter for tracking roundtrip-time from sending a broadcast to receiving ACK for that broadcast
 pub static SHARED_MEMPOOL_BROADCAST_RTT: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_shared_mempool_broadcast_roundtrip_latency",
         "Time elapsed between sending a broadcast and receiving an ACK for that broadcast",
-        &["network", "recipient"]
+        &["network"]
     )
     .unwrap()
 });
@@ -277,54 +288,60 @@ static SHARED_MEMPOOL_TRANSACTIONS_PROCESSED: Lazy<IntCounterVec> = Lazy::new(||
         &[
             "status", // state of transaction processing: "received", "success", status code from failed txn processing
             "network", // state of transaction processing: "received", "success", status code from failed txn processing
-            "sender"   // sender of the txns
         ]
     )
     .unwrap()
 });
 
-pub fn shared_mempool_transactions_processed_inc(status: &str, network: &str, sender: &str) {
+pub fn shared_mempool_transactions_processed_inc(status: &str, network: &str) {
     SHARED_MEMPOOL_TRANSACTIONS_PROCESSED
-        .with_label_values(&[status, network, sender])
+        .with_label_values(&[status, network])
         .inc();
 }
 
 /// Counter for number of transactions in each mempool broadcast sent
-pub static SHARED_MEMPOOL_TRANSACTION_BROADCAST_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
+static SHARED_MEMPOOL_TRANSACTION_BROADCAST_SIZE: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "diem_shared_mempool_transaction_broadcast",
         "Number of transactions in each mempool broadcast sent",
-        &["network", "recipient"]
+        &["network"]
     )
     .unwrap()
 });
 
-pub static SHARED_MEMPOOL_BROADCAST_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
+pub fn shared_mempool_broadcast_size(network_id: NetworkId, num_txns: usize) {
+    SHARED_MEMPOOL_TRANSACTION_BROADCAST_SIZE
+        .with_label_values(&[network_id.as_str()])
+        .observe(num_txns as f64);
+}
+
+static SHARED_MEMPOOL_BROADCAST_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_shared_mempool_rebroadcast_count",
         "Number of various types of broadcasts executed by shared mempool",
-        &["network", "recipient", "type"]
+        &["network", "type"]
     )
     .unwrap()
 });
+
+pub fn shared_mempool_broadcast_type_inc(network_id: NetworkId, label: &str) {
+    SHARED_MEMPOOL_BROADCAST_TYPE_COUNT
+        .with_label_values(&[network_id.as_str(), label])
+        .inc();
+}
 
 static SHARED_MEMPOOL_ACK_TYPE_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_shared_mempool_ack_count",
         "Number of various types of ACKs sent/received by shared mempool",
-        &["network", "recipient", "direction", "type"]
+        &["network", "direction", "type"]
     )
     .unwrap()
 });
 
-pub fn shared_mempool_ack_inc(peer: &PeerNetworkId, direction: &str, label: &'static str) {
+pub fn shared_mempool_ack_inc(network_id: NetworkId, direction: &str, label: &'static str) {
     SHARED_MEMPOOL_ACK_TYPE_COUNT
-        .with_label_values(&[
-            peer.network_id().as_str(),
-            peer.peer_id().short_str().as_str(),
-            direction,
-            label,
-        ])
+        .with_label_values(&[network_id.as_str(), direction, label])
         .inc();
 }
 
@@ -377,14 +394,14 @@ static UNEXPECTED_NETWORK_MSG_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_mempool_unexpected_network_count",
         "Number of unexpected network msgs received",
-        &["network", "peer"]
+        &["network"]
     )
     .unwrap()
 });
 
-pub fn unexpected_msg_count_inc(network_id: &NetworkId, peer_id: &PeerId) {
+pub fn unexpected_msg_count_inc(network_id: &NetworkId) {
     UNEXPECTED_NETWORK_MSG_COUNT
-        .with_label_values(&[network_id.as_str(), peer_id.short_str().as_str()])
+        .with_label_values(&[network_id.as_str()])
         .inc();
 }
 
@@ -403,18 +420,14 @@ static INVALID_ACK_RECEIVED_COUNT: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
         "diem_mempool_unrecognized_ack_received_count",
         "Number of ACK messages received with an invalid request_id that this node's mempool did not send",
-        &["network", "sender", "type"]
+        &["network", "type"]
     )
         .unwrap()
 });
 
-pub fn invalid_ack_inc(peer: &PeerNetworkId, label: &'static str) {
+pub fn invalid_ack_inc(network_id: NetworkId, label: &'static str) {
     INVALID_ACK_RECEIVED_COUNT
-        .with_label_values(&[
-            peer.network_id().as_str(),
-            peer.peer_id().short_str().as_str(),
-            label,
-        ])
+        .with_label_values(&[network_id.as_str(), label])
         .inc();
 }
 

--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -315,7 +315,7 @@ async fn handle_network_event<V>(
             }
         }
         Event::RpcRequest(peer_id, _msg, _, _res_tx) => {
-            counters::unexpected_msg_count_inc(&network_id, &peer_id);
+            counters::unexpected_msg_count_inc(&network_id);
             sample!(
                 SampleRate::Duration(Duration::from_secs(60)),
                 warn!(LogSchema::new(LogEntry::UnexpectedNetworkMsg)


### PR DESCRIPTION
## Motivation

Removing PeerId from mempool metrics, since they're not very useful.  There is one metric that I left that uses PeerId, and that's to keep track of the number of pending broadcasts.  This is a harder metric to collect across multiple peers (in it's current form)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

### Related PRs
Built upon https://github.com/diem/diem/pull/9870 first two commits are from that PR