### PR TITLE
[README] fix broken links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ To begin contributing, [sign the CLA](https://diem.com/en-US/cla-sign/). You can
 
 ### Learn About Diem
 * [Welcome](https://developers.diem.com/docs/welcome-to-diem)
-* [Diem Protocol: Key Concepts](https://developers.diem.com/docs/core/diem-protocol)
-* [Life of a Transaction](https://developers.diem.com/docs/core/life-of-a-transaction)
+* [Basic Concepts](https://developers.diem.com/docs/basics/basics-txns-states)
+* [Life of a Transaction](https://developers.diem.com/docs/transactions/basics-life-of-txn)
 * [JSON-RPC SPEC](json-rpc/json-rpc-spec.md)
 
 ### Try Diem Core
-* [My First Transaction](https://developers.diem.com/docs/core/my-first-transaction)
-* [Getting Started With Move](https://developers.diem.com/docs/move/move-introduction)
+* [My First Transaction](https://developers.diem.com/docs/tutorials/tutorial-my-first-transaction)
+* [Getting Started With Move](https://diem.github.io/move/introduction.html)
 
 ### Technical Papers
 * [The Diem Blockchain](https://developers.diem.com/docs/technical-papers/the-diem-blockchain-paper)


### PR DESCRIPTION
There are some broken links to documentation in the top-level README file. Three of them can be directly replaced with updated URLs, but I don't see a direct equivalent of "Diem Protocol: Key Concepts". This replaces that with a "Basic Concepts" link to the start of the "Basics" section in the developer guides.

Fixes: #9803

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes