### PR TITLE
[api] inject fail points to each endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,6 +1616,7 @@ dependencies = [
  "diemdb",
  "executor",
  "executor-types",
+ "fail",
  "futures",
  "hex",
  "hyper",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 anyhow = "1.0.38"
 bcs = "0.1.2"
 bytes = "1.0.1"
+fail = "0.4.0"
 futures = "0.3.12"
 hex = "0.4.3"
 hyper = "0.14.4"
@@ -54,3 +55,6 @@ vm-validator = { path = "../vm-validator" }
 diem-vm = { path = "../diem-move/diem-vm" }
 executor = { path = "../execution/executor" }
 executor-types = { path = "../execution/executor-types" }
+
+[features]
+failpoints = ["fail/failpoints"]

--- a/api/README.md
+++ b/api/README.md
@@ -100,6 +100,25 @@ cargo test --test "forge" "api::"
 * Run `scripts/dev_setup.sh -a` to setup tools.
 * Run `make test` inside the `api` directory.
 
+### [Failpoint](https://docs.rs/fail/latest/fail/) setup
+
+Failpoint configuration example:
+
+```
+failpoints
+  api::endpoint_index: 1%return
+  api::endpoint_get_account_resources: 1%return
+  api::endpoint_get_account_modules: 1%return
+  api::endpoint_get_transaction: 1%return
+  api::endpoint_get_transactions: 1%return
+  api::endpoint_get_account_transactions: 1%return
+  api::endpoint_submit_json_transactions: 1%return
+  api::endpoint_submit_bcs_transactions: 1%return
+  api::endpoint_create_signing_message: 1%return
+  api::endpoint_get_events_by_event_key: 1%return
+  api::endpoint_get_events_by_event_handle: 1%return
+```
+
 ## Diem Node Operation
 
 Please refer to [Operation](Operation.md) document for details, including configuration, logging, metrics etc.

--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     context::Context,
+    failpoint::fail_point,
     metrics::metrics,
     param::{AddressParam, LedgerVersionParam, MoveIdentifierParam, MoveStructTagParam},
 };
@@ -71,6 +72,7 @@ async fn handle_get_account_resources(
     address: AddressParam,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_get_account_resources")?;
     Ok(Account::new(ledger_version, address, context)?.resources()?)
 }
 
@@ -79,6 +81,7 @@ async fn handle_get_account_modules(
     address: AddressParam,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_get_account_modules")?;
     Ok(Account::new(ledger_version, address, context)?.modules()?)
 }
 

--- a/api/src/events.rs
+++ b/api/src/events.rs
@@ -4,6 +4,7 @@
 use crate::{
     accounts::Account,
     context::Context,
+    failpoint::fail_point,
     metrics::metrics,
     page::Page,
     param::{AddressParam, EventKeyParam, MoveIdentifierParam, MoveStructTagParam},
@@ -42,6 +43,7 @@ async fn handle_get_events_by_event_key(
     page: Page,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_get_events_by_event_key")?;
     Ok(Events::new(event_key.parse("event key")?.into(), context)?.list(page)?)
 }
 
@@ -52,6 +54,7 @@ async fn handle_get_events_by_event_handle(
     page: Page,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_get_events_by_event_handle")?;
     let key =
         Account::new(None, address, context.clone())?.find_event_key(struct_tag, field_name)?;
     Ok(Events::new(key, context)?.list(page)?)

--- a/api/src/failpoint.rs
+++ b/api/src/failpoint.rs
@@ -1,0 +1,14 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+#[allow(unused_imports)]
+use anyhow::{format_err, Result};
+use diem_api_types::Error;
+
+#[allow(unused_variables)]
+#[inline]
+pub fn fail_point(name: &str) -> Result<(), Error> {
+    Ok(fail::fail_point!(format!("api::{}", name).as_str(), |_| {
+        Err(format_err!("unexpected internal error for {}", name).into())
+    }))
+}

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -4,7 +4,9 @@
 use crate::{
     accounts,
     context::Context,
-    events, log,
+    events,
+    failpoint::fail_point,
+    log,
     metrics::{metrics, status_metrics},
     transactions,
 };
@@ -83,6 +85,7 @@ pub fn index(context: Context) -> BoxedFilter<(impl Reply,)> {
 }
 
 pub async fn handle_index(context: Context) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_index")?;
     let info = context.get_latest_ledger_info()?;
     Ok(Response::new(info.clone(), &info)?)
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -12,5 +12,6 @@ pub(crate) mod param;
 pub mod runtime;
 mod transactions;
 
+mod failpoint;
 #[cfg(any(test))]
 pub(crate) mod tests;

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     context::Context,
+    failpoint::fail_point,
     metrics::metrics,
     page::Page,
     param::{AddressParam, TransactionIdParam},
@@ -111,12 +112,14 @@ async fn handle_get_transaction(
     id: TransactionIdParam,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_get_transaction")?;
     Ok(Transactions::new(context)?
         .get_transaction(id.parse("transaction hash or version")?)
         .await?)
 }
 
 async fn handle_get_transactions(page: Page, context: Context) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_get_transactions")?;
     Ok(Transactions::new(context)?.list(page)?)
 }
 
@@ -125,6 +128,7 @@ async fn handle_get_account_transactions(
     page: Page,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_get_account_transactions")?;
     Ok(Transactions::new(context)?.list_by_account(address, page)?)
 }
 
@@ -132,6 +136,7 @@ async fn handle_submit_json_transactions(
     body: UserTransactionRequest,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_submit_json_transactions")?;
     Ok(Transactions::new(context)?
         .create_from_request(body)
         .await?)
@@ -141,6 +146,7 @@ async fn handle_submit_bcs_transactions(
     body: bytes::Bytes,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_submit_bcs_transactions")?;
     let txn = bcs::from_bytes(&body)
         .map_err(|err| Error::invalid_request_body(format!("deserialize error: {}", err)))?;
     Ok(Transactions::new(context)?.create(txn).await?)
@@ -150,6 +156,7 @@ async fn handle_create_signing_message(
     body: UserTransactionRequest,
     context: Context,
 ) -> Result<impl Reply, Rejection> {
+    fail_point("endpoint_create_signing_message")?;
     Ok(Transactions::new(context)?.signing_message(body)?)
 }
 

--- a/diem-node/Cargo.toml
+++ b/diem-node/Cargo.toml
@@ -59,4 +59,4 @@ storage-service-server = { path = "../state-sync/storage-service/server" }
 [features]
 default = []
 assert-private-keys-not-cloneable = ["diem-crypto/assert-private-keys-not-cloneable"]
-failpoints = ["fail/failpoints", "consensus/failpoints", "executor/failpoints", "diem-json-rpc/failpoints", "diem-mempool/failpoints"]
+failpoints = ["fail/failpoints", "consensus/failpoints", "executor/failpoints", "diem-json-rpc/failpoints", "diem-mempool/failpoints", "diem-api/failpoints"]

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -44,6 +44,17 @@ json_rpc:
 
 # this is only enabled when the binary is compiled with failpoints feature, otherwise no-op
 failpoints:
+  api::endpoint_index: 1%return
+  api::endpoint_get_account_resources: 1%return
+  api::endpoint_get_account_modules: 1%return
+  api::endpoint_get_transaction: 1%return
+  api::endpoint_get_transactions: 1%return
+  api::endpoint_get_account_transactions: 1%return
+  api::endpoint_submit_json_transactions: 1%return
+  api::endpoint_submit_bcs_transactions: 1%return
+  api::endpoint_create_signing_message: 1%return
+  api::endpoint_get_events_by_event_key: 1%return
+  api::endpoint_get_events_by_event_handle: 1%return
   jsonrpc::get_latest_ledger_info: 1%return
   jsonrpc::method::submit::mempool_sender: 1%return
   jsonrpc::method::submit: 1%return


### PR DESCRIPTION
#9193 

API failpoint name pattern: "api::endpoint_<endpoint name>"

Test: 

```
cargo build -p diem-node --all-features
```

update node configuration to enable failpoints:
```
failpoints:
  api::endpoint_index: 100%return
```

Curl the index endpoint should return 500 error
```
curl http://localhost:8080/
{"code":500,"message":"unexpected internal error for endpoint_index"}
```