### PR TITLE
[Configs] Remove deny_unknown_field requirement from the configs.

### DIFF
--- a/config/management/src/config.rs
+++ b/config/management/src/config.rs
@@ -54,7 +54,6 @@ use structopt::StructOpt;
 
 /// Config for diem management tools
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(deserialize_with = "chain_id::deserialize_config_chain_id")]
     pub chain_id: ChainId,

--- a/config/src/config/api_config.rs
+++ b/config/src/config/api_config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct ApiConfig {
     #[serde(default = "default_enabled")]
     pub enabled: bool,

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::PathBuf};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct ConsensusConfig {
     pub contiguous_rounds: u32,
     pub max_block_size: u64,
@@ -77,7 +77,6 @@ pub enum ConsensusProposerType {
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct LeaderReputationConfig {
     pub active_weights: u64,
     pub inactive_weights: u64,

--- a/config/src/config/debug_interface_config.rs
+++ b/config/src/config/debug_interface_config.rs
@@ -5,7 +5,7 @@ use crate::utils;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct DebugInterfaceConfig {
     pub admission_control_node_debug_port: u16,
     pub address: String,

--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -14,7 +14,7 @@ use std::{
 const GENESIS_DEFAULT: &str = "genesis.blob";
 
 #[derive(Clone, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct ExecutionConfig {
     #[serde(skip)]
     pub genesis: Option<Transaction>,
@@ -113,7 +113,6 @@ pub enum ExecutionCorrectnessService {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct RemoteExecutionService {
     pub server_address: SocketAddr,
 }

--- a/config/src/config/json_rpc_config.rs
+++ b/config/src/config/json_rpc_config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct JsonRpcConfig {
     pub address: SocketAddr,
     pub batch_size_limit: u16,
@@ -49,7 +49,7 @@ impl JsonRpcConfig {
 /// This API is experimental and subject to change
 /// Documentation is in /json-rpc/src/stream_rpc/README.md
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct StreamConfig {
     pub enabled: bool,
     pub subscription_fetch_size: u64,

--- a/config/src/config/key_manager_config.rs
+++ b/config/src/config/key_manager_config.rs
@@ -14,7 +14,7 @@ const DEFAULT_SLEEP_PERIOD_SECS: u64 = 600; // 10 minutes
 const DEFAULT_TXN_EXPIRATION_SECS: u64 = 3600; // 1 hour
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct KeyManagerConfig {
     pub logger: LoggerConfig,
     pub json_rpc_endpoint: String,

--- a/config/src/config/logger_config.rs
+++ b/config/src/config/logger_config.rs
@@ -5,7 +5,7 @@ use diem_logger::{Level, CHANNEL_SIZE};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct LoggerConfig {
     // channel size for the asychronous channel for node logging.
     pub chan_size: usize,

--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct MempoolConfig {
     pub capacity: usize,
     pub capacity_per_user: usize,

--- a/config/src/config/mod.rs
+++ b/config/src/config/mod.rs
@@ -56,7 +56,6 @@ pub struct DeprecatedConfig {}
 /// The config file is broken up into sections for each module
 /// so that only that module can be passed around
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct NodeConfig {
     #[serde(default)]
     pub base: BaseConfig,
@@ -91,7 +90,7 @@ pub struct NodeConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct BaseConfig {
     data_dir: PathBuf,
     pub role: RoleType,

--- a/config/src/config/network_config.rs
+++ b/config/src/config/network_config.rs
@@ -47,7 +47,7 @@ pub const IP_BYTE_BUCKET_RATE: usize = 102400 /* 100 KiB */;
 pub const IP_BYTE_BUCKET_SIZE: usize = IP_BYTE_BUCKET_RATE;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct NetworkConfig {
     // Maximum backoff delay for connecting outbound to peers
     pub max_connection_delay_ms: u64,
@@ -332,7 +332,6 @@ impl Identity {
 
 /// The identity is stored within the config.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct IdentityFromConfig {
     #[serde(flatten)]
     pub key: ConfigKey<x25519::PrivateKey>,
@@ -341,7 +340,6 @@ pub struct IdentityFromConfig {
 
 /// This represents an identity in a secure-storage as defined in NodeConfig::secure.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct IdentityFromStorage {
     pub backend: SecureBackend,
     pub key_name: String,

--- a/config/src/config/safety_rules_config.rs
+++ b/config/src/config/safety_rules_config.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct SafetyRulesConfig {
     pub backend: SecureBackend,
     pub logger: LoggerConfig,
@@ -68,7 +68,6 @@ pub enum SafetyRulesService {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct RemoteService {
     pub server_address: NetworkAddress,
 }

--- a/config/src/config/secure_backend_config.rs
+++ b/config/src/config/secure_backend_config.rs
@@ -46,7 +46,6 @@ impl SecureBackend {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct GitHubConfig {
     /// The owner or account that hosts a repository
     pub repository_owner: String,
@@ -63,7 +62,6 @@ pub struct GitHubConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct VaultConfig {
     /// Optional SSL Certificate for the vault host, this is expected to be a full path.
     pub ca_certificate: Option<PathBuf>,
@@ -98,7 +96,6 @@ impl VaultConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct OnDiskStorageConfig {
     // Required path for on disk storage
     pub path: PathBuf,
@@ -129,13 +126,11 @@ impl Token {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct TokenFromConfig {
     token: String,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct TokenFromDisk {
     path: PathBuf,
 }

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -4,7 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct StateSyncConfig {
     // Size of chunk to request for state synchronization
     pub chunk_limit: u64,
@@ -50,7 +50,7 @@ impl Default for StateSyncConfig {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct StorageServiceConfig {
     pub max_account_states_chunk_sizes: u64, // Max num of accounts per chunk
     pub max_concurrent_requests: u64,        // Max num of concurrent storage server tasks
@@ -72,7 +72,7 @@ impl Default for StorageServiceConfig {
 }
 
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct DataStreamingServiceConfig {
     // The interval (milliseconds) at which to refresh the global data summary.
     pub global_summary_refresh_interval_ms: u64,

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -12,7 +12,7 @@ use std::{
 /// see https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h
 /// for detailed explanations.
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct RocksdbConfig {
     pub max_open_files: i32,
     pub max_total_wal_size: u64,
@@ -33,7 +33,7 @@ impl Default for RocksdbConfig {
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct StorageConfig {
     pub address: SocketAddr,
     pub backup_service_address: SocketAddr,

--- a/config/src/config/test_config.rs
+++ b/config/src/config/test_config.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 #[derive(Debug, Default, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
 pub struct TestConfig {
     pub auth_key: Option<AuthenticationKey>,
     pub operator_key: Option<ConfigKey<Ed25519PrivateKey>>,


### PR DESCRIPTION
## Motivation

This PR removes the serde field attribute `deny_unknown_field` from the config files. 

We remove this attribute because it is currently not possible to add new fields to configs. This is because backward compatibility tests currently verify that newer configs (e.g., those generated for a code version `X`) can be run on older code versions (e.g., code version `X-1`). As a result, if a new config field `new_field` is added to code version `X`, it will make the backward compatibility tests fail as `deny_unknown_field` will prevent `new_field` from being deserialized by code version `X-1`. To avoid this issue, we remove the field attribute; `new_field` will simply be ignored when deserialized.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing unit tests and compatibility tests should cover this.

## Related PRs

None.
