### PR TITLE
[forge][k8s] custom genesis modules 

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -86,6 +86,11 @@ struct K8sSwarm {
     base_image_tag: String,
     #[structopt(long, help = "Name of the EKS cluster")]
     cluster_name: String,
+    #[structopt(
+        long,
+        help = "Path to flattened directory containing compiled Move modules"
+    )]
+    move_modules_dir: Option<String>,
 }
 
 #[derive(StructOpt, Debug)]
@@ -163,6 +168,9 @@ fn main() -> Result<()> {
                 let mut test_suite = k8s_test_suite();
                 if let Some(suite) = args.suite.as_ref() {
                     test_suite = get_test_suite(suite);
+                }
+                if let Some(move_modules_dir) = k8s.move_modules_dir {
+                    test_suite = test_suite.with_genesis_modules_path(move_modules_dir);
                 }
                 run_forge(
                     test_suite,

--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -140,6 +140,11 @@ struct Resize {
     helm_repo: String,
     #[structopt(long, help = "Name of the EKS cluster")]
     cluster_name: String,
+    #[structopt(
+        long,
+        help = "Path to flattened directory containing compiled Move modules"
+    )]
+    move_modules_dir: Option<String>,
 }
 
 fn main() -> Result<()> {
@@ -197,6 +202,7 @@ fn main() -> Result<()> {
                     resize.validator_image_tag,
                     resize.testnet_image_tag,
                     resize.require_validator_healthcheck,
+                    resize.move_modules_dir,
                 )
             }
         },

--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -305,10 +305,10 @@ pub fn clean_k8s_cluster(
 
     // run genesis from the directory in diem/init image
     let move_modules_dir = if let Some(genesis_modules_path) = genesis_modules_path {
-        genesis_modules_path;
+        genesis_modules_path
     } else {
-        GENESIS_MODULES_DIR.to_string();
-    }
+        GENESIS_MODULES_DIR.to_string()
+    };
     let testnet_upgrade_options = [
         "-f",
         &file_path_str,

--- a/testsuite/forge/src/backend/k8s/mod.rs
+++ b/testsuite/forge/src/backend/k8s/mod.rs
@@ -117,6 +117,7 @@ impl Factory for K8sFactory {
             format!("{}", init_version),
             format!("{}", genesis_version),
             false,
+            None,
         )?;
         let rt = Runtime::new().unwrap();
         let swarm = rt

--- a/testsuite/forge/src/interface/factory.rs
+++ b/testsuite/forge/src/interface/factory.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Swarm, Version};
+use super::{GenesisConfig, Swarm, Version};
 use crate::Result;
 use rand::rngs::StdRng;
 use std::num::NonZeroUsize;
@@ -16,6 +16,6 @@ pub trait Factory {
         node_num: NonZeroUsize,
         version: &Version,
         genesis_version: &Version,
-        genesis_modules: Option<&[Vec<u8>]>,
+        genesis_modules: Option<&GenesisConfig>,
     ) -> Result<Box<dyn Swarm>>;
 }

--- a/testsuite/forge/src/interface/mod.rs
+++ b/testsuite/forge/src/interface/mod.rs
@@ -40,3 +40,9 @@ impl std::fmt::Display for Version {
         f.write_str(&self.1)
     }
 }
+
+#[derive(Clone)]
+pub enum GenesisConfig {
+    Bytes(Vec<Vec<u8>>),
+    Path(String),
+}

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -106,7 +106,7 @@ pub struct ForgeConfig<'cfg> {
     initial_version: InitialVersion,
 
     /// The initial genesis modules to use when starting a network
-    genesis_modules: Option<Vec<Vec<u8>>>,
+    genesis_config: Option<GenesisConfig>,
 }
 
 impl<'cfg> ForgeConfig<'cfg> {
@@ -142,8 +142,13 @@ impl<'cfg> ForgeConfig<'cfg> {
         self
     }
 
-    pub fn with_genesis_modules(mut self, genesis_modules: Vec<Vec<u8>>) -> Self {
-        self.genesis_modules = Some(genesis_modules);
+    pub fn with_genesis_modules_bytes(mut self, genesis_modules: Vec<Vec<u8>>) -> Self {
+        self.genesis_config = Some(GenesisConfig::Bytes(genesis_modules));
+        self
+    }
+
+    pub fn with_genesis_modules_path(mut self, genesis_modules: String) -> Self {
+        self.genesis_config = Some(GenesisConfig::Path(genesis_modules));
         self
     }
 
@@ -168,7 +173,7 @@ impl<'cfg> Default for ForgeConfig<'cfg> {
             network_tests: &[],
             initial_validator_count: NonZeroUsize::new(1).unwrap(),
             initial_version: InitialVersion::Newest,
-            genesis_modules: None,
+            genesis_config: None,
         }
     }
 }
@@ -244,7 +249,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 self.tests.initial_validator_count,
                 &initial_version,
                 &genesis_version,
-                self.tests.genesis_modules.as_deref(),
+                self.tests.genesis_config.as_ref(),
             )?;
 
             // Run PublicUsageTests


### PR DESCRIPTION
Create the option for `--move-modules-dir /experimental/move/modules` so we can run genesis on experimental Move modules. This option is available both for tests as well as operator `resize` tool.

### Test plan

Run forge resize option on a test cluster: observe the below logs in the genesis job, and the job completing without failure:

```
+ diem-genesis-tool set-move-modules --shared-backend backend=disk;path=/tmp/genesis.json;namespace=common --dir /experimental/move/modules
Success!
```