### PR TITLE
[State Sync] Reduce the txn emitter time in the performance test.

### DIFF
--- a/testsuite/cluster-test/src/suite.rs
+++ b/testsuite/cluster-test/src/suite.rs
@@ -59,7 +59,7 @@ impl ExperimentSuite {
                 .enable_db_backup()
                 .build(cluster),
         ));
-        experiments.push(Box::new(StateSyncPerformanceParams::new(60).build(cluster)));
+        experiments.push(Box::new(StateSyncPerformanceParams::new(30).build(cluster)));
         experiments.push(Box::new(TwinValidatorsParams { pair: 1 }.build(cluster)));
         // This can't be run before any experiment that requires clean_data.
         experiments.push(Box::new(
@@ -149,7 +149,7 @@ impl ExperimentSuite {
 
     fn new_state_sync_suite(cluster: &Cluster) -> Self {
         let experiments: Vec<Box<dyn Experiment>> =
-            vec![Box::new(StateSyncPerformanceParams::new(60).build(cluster))];
+            vec![Box::new(StateSyncPerformanceParams::new(30).build(cluster))];
         Self { experiments }
     }
 


### PR DESCRIPTION
## Motivation

This PR reduces the amount of time the transaction emitter sends transactions in the state sync performance test. We reduce it from 60 seconds to 30 seconds.

The reason for this change is that the transaction emitter has slowly become more powerful over time, and now it's able to emit 2x the number of transactions per second (compared to several months ago). As a result, state sync is required to synchronize 2x the number of transactions that it was and is now hitting the test timeout. To avoid making the test any longer (i.e., increasing the timeout), we just reduce the transaction emitter time.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

This should already be covered by the performance test.

## Related PRs

None.
