### PR TITLE
[move-bytecode-util] Relax api for GetModule

### DIFF
--- a/language/tools/move-bytecode-utils/src/layout.rs
+++ b/language/tools/move-bytecode-utils/src/layout.rs
@@ -13,7 +13,7 @@ use move_core_types::{
     language_storage::{ModuleId, StructTag, TypeTag},
     value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
 };
-use std::fmt::Debug;
+use std::{borrow::Borrow, fmt::Debug};
 
 pub enum TypeLayoutBuilder {}
 pub enum StructLayoutBuilder {}
@@ -199,10 +199,11 @@ impl StructLayoutBuilder {
         resolver: &impl GetModule,
         layout_type: LayoutType,
     ) -> Result<MoveStructLayout> {
-        let m = resolver
+        let module = resolver
             .get_module_by_id(declaring_module)
             .map_err(|_| anyhow!("Error while resolving module {}", declaring_module))?
             .ok_or_else(|| anyhow!("Failed to get module {}", declaring_module))?;
+        let m = module.borrow();
         let def = m
             .struct_defs
             .iter()
@@ -217,7 +218,7 @@ impl StructLayoutBuilder {
                     declaring_module
                 )
             })?;
-        Self::build_from_definition(&m, def, type_arguments, resolver, layout_type)
+        Self::build_from_definition(m, def, type_arguments, resolver, layout_type)
     }
 
     fn build_from_handle_idx(

--- a/language/tools/move-bytecode-utils/src/module_cache.rs
+++ b/language/tools/move-bytecode-utils/src/module_cache.rs
@@ -5,18 +5,20 @@ use anyhow::{anyhow, Result};
 use move_binary_format::CompiledModule;
 use move_core_types::{language_storage::ModuleId, resolver::ModuleResolver};
 use std::{
+    borrow::Borrow,
     cell::RefCell,
     collections::{btree_map::Entry, BTreeMap},
     fmt::Debug,
-    sync::RwLock,
+    sync::{Arc, RwLock},
 };
 
 /// A persistent storage that can fetch the bytecode for a given module id
 /// TODO: do we want to implement this in a way that allows clients to cache struct layouts?
 pub trait GetModule {
     type Error: Debug;
+    type Item: Borrow<CompiledModule>;
 
-    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error>;
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Self::Item>, Self::Error>;
 }
 
 /// Simple in-memory module cache
@@ -40,6 +42,7 @@ impl<R: ModuleResolver> ModuleCache<R> {
 
 impl<R: ModuleResolver> GetModule for ModuleCache<R> {
     type Error = anyhow::Error;
+    type Item = CompiledModule;
 
     fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error> {
         Ok(Some(match self.cache.borrow_mut().entry(id.clone()) {
@@ -61,7 +64,7 @@ impl<R: ModuleResolver> GetModule for ModuleCache<R> {
 
 /// Simple in-memory module cache that implements Sync
 pub struct SyncModuleCache<R: ModuleResolver> {
-    cache: RwLock<BTreeMap<ModuleId, CompiledModule>>,
+    cache: RwLock<BTreeMap<ModuleId, Arc<CompiledModule>>>,
     resolver: R,
 }
 
@@ -74,14 +77,15 @@ impl<R: ModuleResolver> SyncModuleCache<R> {
     }
 
     pub fn add(&self, id: ModuleId, m: CompiledModule) {
-        self.cache.write().unwrap().insert(id, m);
+        self.cache.write().unwrap().insert(id, Arc::new(m));
     }
 }
 
 impl<R: ModuleResolver> GetModule for SyncModuleCache<R> {
     type Error = anyhow::Error;
+    type Item = Arc<CompiledModule>;
 
-    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error> {
+    fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<Arc<CompiledModule>>, Self::Error> {
         if let Some(compiled_module) = self.cache.read().unwrap().get(id) {
             return Ok(Some(compiled_module.clone()));
         }
@@ -91,8 +95,10 @@ impl<R: ModuleResolver> GetModule for SyncModuleCache<R> {
             .get_module(id)
             .map_err(|_| anyhow!("Failed to get module {:?}", id))?
         {
-            let module = CompiledModule::deserialize(&module_bytes)
-                .map_err(|_| anyhow!("Failure deserializing module {:?}", id))?;
+            let module = Arc::new(
+                CompiledModule::deserialize(&module_bytes)
+                    .map_err(|_| anyhow!("Failure deserializing module {:?}", id))?,
+            );
 
             self.cache
                 .write()

--- a/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
+++ b/language/tools/move-cli/src/sandbox/utils/on_disk_state_view.rs
@@ -554,6 +554,7 @@ impl ResourceResolver for OnDiskStateView {
 
 impl GetModule for OnDiskStateView {
     type Error = anyhow::Error;
+    type Item = CompiledModule;
 
     fn get_module_by_id(&self, id: &ModuleId) -> Result<Option<CompiledModule>, Self::Error> {
         if let Some(bytes) = self.get_module_bytes(id)? {

--- a/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
+++ b/language/tools/read-write-set/dynamic/src/dynamic_analysis.rs
@@ -16,6 +16,7 @@ use move_core_types::{
 };
 use move_read_write_set_types::{Access, AccessPath, Offset, ReadWriteSet, RootAddress};
 use std::{
+    borrow::Borrow,
     fmt::{self, Formatter},
     ops::Deref,
 };
@@ -263,7 +264,7 @@ pub fn bind_formals<R: GetModule>(
         .map_err(|_| anyhow!("Failed to get module from storage"))?
         .ok_or_else(|| anyhow!("Failed to get module"))?;
 
-    let func_sig = Function::new_from_name(&compiled_module, fun)
+    let func_sig = Function::new_from_name(compiled_module.borrow(), fun)
         .ok_or_else(|| anyhow!("Failed to find function"))?;
 
     // Check arity before binding. Otherwise we might get out-of-bound errors.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Relax the api for `GetModule` so that the implementer can choose freely to whether return a reference or a value. This will significantly increase the inference time for read write set estimator as we can avoid copying the entire `CompiledModule`.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
`cargo check`