### PR TITLE
[shuffle] helpers.hexToAscii properly decodes ascii/utf8

### DIFF
--- a/shuffle/move/examples/e2e/message.test.ts
+++ b/shuffle/move/examples/e2e/message.test.ts
@@ -19,7 +19,7 @@ Deno.test("Ability to set message", async () => {
   txn = await devapi.waitForTransactionCompletion(txn.hash);
   assert(txn.success);
 
-  const expected = "\x00hello blockchain"; // prefixed with \x00 bc of BCS encoding
+  const expected = "hello blockchain";
   const messages = await main.decodedMessages();
   assertEquals(messages[0], expected);
 });
@@ -31,5 +31,5 @@ Deno.test("Ability to set NFTs", async () => {
   assert(txn.success);
 
   const uris = await main.decodedNFTs();
-  assertEquals(uris[0], "\x00" + contentUri);
+  assertEquals(uris[0], contentUri);
 });

--- a/shuffle/move/examples/integration/helpers.test.ts
+++ b/shuffle/move/examples/integration/helpers.test.ts
@@ -24,6 +24,6 @@ Deno.test("invokeScriptFunction", async () => {
   assertEquals(txn.payload.function, scriptFunction);
   assertEquals(
     helpers.hexToAscii(txn.payload.arguments[0]),
-    "\x00invoked script function",
+    "invoked script function",
   );
 });

--- a/shuffle/move/examples/main/helpers.ts
+++ b/shuffle/move/examples/main/helpers.ts
@@ -12,6 +12,7 @@ import { bytes, ListTuple, uint8 } from "./generated/serde/types.ts";
 import { createHash } from "https://deno.land/std@0.77.0/hash/mod.ts";
 
 const textEncoder = new util.TextEncoder();
+const textDecoder = new util.TextDecoder();
 
 export async function buildAndSubmitTransaction(
   addressStr: string,
@@ -214,11 +215,7 @@ function hexToBytes(hex: string): Uint8Array {
   return bytes;
 }
 
-export function hexToAscii(hexx: string) {
-  const hex = hexx.toString(); // normalize
-  let str = "";
-  for (let i = 0; i < hex.length; i += 2) {
-    str += String.fromCharCode(parseInt(hex.substr(i, 2), 16));
-  }
-  return str;
+export function hexToAscii(hex: string) {
+  const bytes = hexToBytes(hex);
+  return textDecoder.decode(bytes);
 }


### PR DESCRIPTION
## Motivation

Previously, our byte decoding from an onchain resource was incorrect in shuffle e2e tests:
https://github.com/diem/diem/blob/f4a0b8eb69633ed360d8d4022e3dabf6e8dc8896/shuffle/move/examples/e2e/message.test.ts#L22

We now rely on `utils.TextDecoder`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

cargo xtest -p shuffle-integration-tests