### PR TITLE
[move-prover][tests] rust tests for extended verification

### DIFF
--- a/diem-move/diem-framework/tests/move_verification_test.rs
+++ b/diem-move/diem-framework/tests/move_verification_test.rs
@@ -9,11 +9,29 @@ fn prove_core() {
 }
 
 #[test]
+#[ignore]
+fn prove_core_extended() {
+    ProverTest::run_extended_tests_for("core");
+}
+
+#[test]
 fn prove_experimental() {
     ProverTest::create("experimental").run()
 }
 
 #[test]
+#[ignore]
+fn prove_experimental_extended() {
+    ProverTest::run_extended_tests_for("experimental");
+}
+
+#[test]
 fn prove_dpn() {
     ProverTest::create("DPN").run()
+}
+
+#[test]
+#[ignore]
+fn prove_dpn_extended() {
+    ProverTest::run_extended_tests_for("DPN");
 }

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -129,6 +129,10 @@ pub fn run_model_builder_with_options_and_compilation_flags(
     for (fhash, (fname, fsrc)) in &files {
         env.add_source(*fhash, fname.as_str(), fsrc, dep_files.contains(fhash));
     }
+    // Add named addresses
+    for (address_name, address_value) in &named_address_mapping {
+        env.add_named_address(address_name.clone(), *address_value);
+    }
 
     // Add any documentation comments found by the Move compiler to the env.
     for (fhash, documentation) in comment_map {

--- a/language/move-model/src/model.rs
+++ b/language/move-model/src/model.rs
@@ -55,6 +55,7 @@ use move_binary_format::{
 use move_core_types::{
     account_address::AccountAddress, identifier::Identifier, language_storage, value::MoveValue,
 };
+use move_lang::shared::NumericalAddress;
 
 use crate::{
     ast::{
@@ -462,6 +463,8 @@ pub struct GlobalEnv {
     file_idx_to_id: BTreeMap<u16, FileId>,
     /// A set indicating whether a file id is a target or a dependency.
     file_id_is_dep: BTreeSet<FileId>,
+    /// A map of named addresses used in building the global environment
+    named_addresses: BTreeMap<String, NumericalAddress>,
     /// A special constant location representing an unknown location.
     /// This uses a pseudo entry in `source_files` to be safely represented.
     unknown_loc: Loc,
@@ -534,6 +537,7 @@ impl GlobalEnv {
             file_id_to_idx,
             file_idx_to_id,
             file_id_is_dep: BTreeSet::new(),
+            named_addresses: BTreeMap::new(),
             diags: RefCell::new(vec![]),
             symbol_pool: SymbolPool::new(),
             next_free_node_id: Default::default(),
@@ -641,6 +645,16 @@ impl GlobalEnv {
             self.file_id_is_dep.insert(file_id);
         }
         file_id
+    }
+
+    /// Add a pair of named address to this environment
+    pub fn add_named_address(&mut self, name: String, address: NumericalAddress) {
+        self.named_addresses.insert(name, address);
+    }
+
+    /// Return the mapping of named addresses
+    pub fn get_named_address_map(&self) -> &BTreeMap<String, NumericalAddress> {
+        &self.named_addresses
     }
 
     /// Find all target modules and return in a vector

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -71,6 +71,8 @@ pub struct Options {
     pub experimental_pipeline: bool,
     /// Options for printing out modules and functions reachable by script functions
     pub script_reach: bool,
+    /// Run modular verification in addition to the normal verification flow
+    pub modular_verification: bool,
 
     /// BEGIN OF STRUCTURED OPTIONS. DO NOT ADD VALUE FIELDS AFTER THIS
     /// Options for the model builder.
@@ -110,6 +112,7 @@ impl Default for Options {
             errmapgen: ErrmapOptions::default(),
             experimental_pipeline: false,
             script_reach: false,
+            modular_verification: false,
         }
     }
 }
@@ -329,6 +332,11 @@ impl Options {
                     .value_name("SCOPE")
                     .help("default scope of verification \
                     (can be overridden by `pragma verify=true|false`)"),
+            )
+            .arg(
+                Arg::with_name("modular")
+                    .long("modular")
+                    .help("run modular verification after whole-package verification")
             )
             .arg(
                 Arg::with_name("bench-repeat")
@@ -645,6 +653,9 @@ impl Options {
                 "none" => VerificationScope::None,
                 _ => unreachable!("should not happen"),
             }
+        }
+        if matches.is_present("modular") {
+            options.modular_verification = true;
         }
         if matches.is_present("bench-repeat") {
             options.backend.bench_repeat =

--- a/language/move-prover/tools/check_pr.sh
+++ b/language/move-prover/tools/check_pr.sh
@@ -12,7 +12,7 @@ BUILD_MODE=--release
 BASE=$(git rev-parse --show-toplevel)
 echo "*************** [check-pr] Assuming diem root at $BASE"
 
-while getopts "hcxtdgmea" opt; do
+while getopts "hcxtdgmnea" opt; do
   case $opt in
     h)
       cat <<EOF
@@ -30,6 +30,8 @@ Flags:
     -g   Run the Diem git checks script (whitespace check). This works
          only for committed clients.
     -m   Run the Move unit and verification tests.
+    -n   Like -m, but also run with extended verification configurations
+         (e.g., modular verification, inconsistency, etc)
     -e   Run the Move e2e tests
     -a   Run all of the above
 EOF
@@ -54,6 +56,10 @@ EOF
     m)
       MOVE_TESTS=1
       ;;
+    n)
+      MOVE_TESTS=1
+      MOVE_TESTS_EXTENDED=1
+      ;;
     e)
       MOVE_E2E_TESTS=1
       ;;
@@ -64,6 +70,7 @@ EOF
       GIT_CHECKS=1
       ALSO_TEST=1
       MOVE_TESTS=1
+      MOVE_TESTS_EXTENDED=1
       MOVE_E2E_TESTS=1
       ;;
   esac
@@ -161,6 +168,10 @@ if [ ! -z "$MOVE_TESTS" ]; then
     (
       cd $dir
       cargo test $BUILD_MODE
+      if [ ! -z "$MOVE_TESTS_EXTENDED" ]; then
+        echo "*************** [check-pr] Move tests $dir"
+        cargo test $BUILD_MODE -- --ignored
+      fi
     )
   done
 fi

--- a/language/move-stdlib/tests/move_verification_test.rs
+++ b/language/move-stdlib/tests/move_verification_test.rs
@@ -9,6 +9,18 @@ fn prove_stdlib() {
 }
 
 #[test]
+#[ignore]
+fn prove_stdlib_extended() {
+    ProverTest::run_extended_tests_for(".");
+}
+
+#[test]
 fn prove_nursery() {
     ProverTest::create("nursery").run()
+}
+
+#[test]
+#[ignore]
+fn prove_nursery_extended() {
+    ProverTest::run_extended_tests_for("nursery");
 }

--- a/language/tools/move-cli/src/package/prover.rs
+++ b/language/tools/move-cli/src/package/prover.rs
@@ -28,9 +28,9 @@ pub struct ProverTest {
 
 impl ProverTest {
     /// Creates a new prover test for the Move package at path relative to crate root.
-    pub fn create(path: impl Into<String>) -> Self {
+    pub fn create<S: AsRef<str>>(path: S) -> Self {
         ProverTest {
-            path: path.into(),
+            path: path.as_ref().to_string(),
             options: vec![],
             local_only: false,
         }
@@ -73,6 +73,18 @@ impl ProverTest {
             vec![], // prover does not need natives
         )
         .unwrap()
+    }
+
+    /// Creates a series of prover tests for the Move package at path relative to crate root.
+    /// Each test covers a different configuration of the Move prover.
+    pub fn run_extended_tests_for<S: AsRef<str>>(path: S) {
+        let tests = vec![
+            Self::create(path.as_ref()).with_options(&["--modular"]),
+            Self::create(path.as_ref()).with_options(&["--check-inconsistency"]),
+        ];
+        for test in tests {
+            test.run();
+        }
     }
 }
 


### PR DESCRIPTION
This PR has two commits that attempt to restore some testing
functionalities for the Move Prover back without burdening the CI
and without re-introducing move-to-diem dependencies in the
language directory.

**Commit 1: [move-prover] embed the modular verification logic in prover driver**
The modular verification logic can be reached by specifying `--modular`
in the move-prover command line.

If this `--modular` flag is set, the verification is splitted into two
parts:
- whole package verification
- modular verification per input Move file.

Let's use the following case as an example:
`mvp --modular --dependency stdlib/ my-sources/`
And suppose `my-sources` has two move files, A.move and B.move.

It is equivalent to invoking a series of verification:

- step 1: package verification
  which is to verify A.move and B.move together (i.e., both are target modules)

- step 2: modular verificaiton, which is essentially similar to
  - `mvp --dependency stdlib/ --dependency my-sources/ my-sources/A.move`
  - `mvp --dependency stdlib/ --dependency my-sources/ my-sources/B.move`

This commit also adds modular verification to existing verification
tests (as part of unit tests). But these verification tests are marked
with `#[ignore]` so that they won't be invoked in CI by default. These
additional tests can be invoked with `cargo test -- --ignored`.

**Commit 2: [move-prover] entry point to the extended tests in check_pr.sh**
This commit extends the first commit by also adding `--check-inconsistency`
as an extended verification test. Similar to the `--modular` case, the
`--check-inconsistency` test is ignored on CI but can be invoked locally.

This commit also updates the `check_pr.sh` script with an `-n` flag.
`check_pr.sh -n` will invoke these extended verification tests, in addition to
the current CI-enabled tests.

## Motivation

Present one possible extension of the testing infra for the move prover

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`check_pr.sh -n`

Note that currently, the inconsistency check for the experimental code fails (see following).
This is a known issue and has been identified in #9827.

```
running 3 tests
SUCCESS proving 0 modules from package `DPN` in 0.520s
SUCCESS proving 0 modules from package `DPN` in 0.523s
test prove_dpn_extended ... ok
test prove_core_extended has been running for over 60 seconds
test prove_experimental_extended has been running for over 60 seconds
SUCCESS proving 47 modules from package `experimental` in 112.281s
SUCCESS proving 41 modules from package `core` in 159.788s
error: there is an inconsistent assumption in the function, which may allow any post-condition (including false) to be proven
    ┌─ experimental/sources/AccountCreationScripts.move:524:5
    │
524 │ ╭     public(script) fun create_account<CoinType>(
525 │ │         _account: signer,
526 │ │         new_account_address: address,
527 │ │         auth_key_prefix: vector<u8>,
    · │
532 │ │         );
533 │ │     }
    │ ╰─────^

FAILURE proving 47 modules from package `experimental` in 78.204s
test prove_experimental_extended ... FAILED
SUCCESS proving 41 modules from package `core` in 60.360s
test prove_core_extended ... ok

failures:

---- prove_experimental_extended stdout ----
thread 'prove_experimental_extended' panicked at 'called `Result::unwrap()` on an `Err` value: exiting with verification errors', language/tools/move-cli/src/package/prover.rs:75:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    prove_experimental_extended

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 3 filtered out; finished in 220.36s

error: test failed, to rerun pass '--test move_verification_test'
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
