### PR TITLE
[State Sync] Support ledger info targets for data streams.

### DIFF
--- a/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
@@ -401,7 +401,7 @@ impl ContinuousTransactionStreamEngine {
     fn get_target_ledger_info(&self) -> &LedgerInfoWithSignatures {
         self.current_target_ledger_info
             .as_ref()
-            .expect("No target ledger info found!")
+            .expect("No current target ledger info found!")
     }
 
     fn create_data_notification(


### PR DESCRIPTION
## Motivation

This PR extends the data streaming service to support syncing to specified targets (ledger infos). This is required by state sync to support synchronization requests from consensus (i.e., syncing to a target). To achieve this, the PR extends the continuous transaction stream engine to take in an optional target and sync towards this target. The stream will terminate once it hits the target.

The PR offers the following commits:
1. Reshuffle the data stream client interface methods to be alphabetical -- nothing changes here logically 😄 
2. Support target synchronization.
3. Add some unit tests to verify the behaviour.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New unit tests have been added.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906