### PR TITLE
[diem-transaction-bench] Insert blockmetadata transaction for benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "criterion-cpu-time",
+ "diem-crypto",
  "diem-framework-releases",
  "diem-types",
  "diem-vm",

--- a/diem-move/diem-transaction-benchmarks/Cargo.toml
+++ b/diem-move/diem-transaction-benchmarks/Cargo.toml
@@ -17,6 +17,7 @@ criterion-cpu-time = "0.1.0"
 diem-types = { path = "../../types", features = ["fuzzing"] }
 language-e2e-tests = { path = "../../language/testing-infra/e2e-tests" }
 diem-workspace-hack = { path = "../../common/workspace-hack" }
+diem-crypto = { path = "../../crates/diem-crypto" }
 
 read-write-set = { path = "../../language/tools/read-write-set" }
 read-write-set-dynamic = { path = "../../language/tools/read-write-set/dynamic" }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Change the transaction bencher for parallel execution to include a blockmetadata transaction at the beginning. This would better simulate the traffic in the production.

In our current implementation, there was a significant regression after adding such blockmetadata transaction, which I would fix shortly in a later PR. The current benchmark results are as following:

```
peer_to_peer            time:   [308.86 ms 312.06 ms 315.56 ms]                       
                        change: [-6.0021% -3.3703% -1.3783%] (p = 0.01 < 0.05)
                        Performance has improved.

Benchmarking peer_to_peer_parallel: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 10.7s.
peer_to_peer_parallel   time:   [376.31 ms 379.99 ms 383.68 ms]                                
                        change: [+142.47% +151.06% +160.04%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

As demonstrated by the benchmark, after adding this extra block metadata transaction, the parallel execution actually behaves worse than the sequential version.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
`cargo bench`