### PR TITLE
[move-vm] Expose API for load modules

### DIFF
--- a/diem-move/diem-vm/src/diem_vm.rs
+++ b/diem-move/diem-vm/src/diem_vm.rs
@@ -39,10 +39,12 @@ use diem_types::{
     write_set::{WriteSet, WriteSetMut},
 };
 use fail::fail_point;
+use move_binary_format::errors::VMResult;
 use move_core_types::{
     account_address::AccountAddress,
     gas_schedule::GasAlgebra,
     identifier::IdentStr,
+    language_storage::ModuleId,
     resolver::MoveResolver,
     transaction_argument::convert_txn_args,
     value::{serialize_values, MoveValue},
@@ -85,6 +87,11 @@ impl DiemVM {
     }
     pub fn internals(&self) -> DiemVMInternals {
         DiemVMInternals::new(&self.0)
+    }
+
+    /// Load a module into its internal MoveVM's code cache.
+    pub fn load_module<S: MoveResolver>(&self, module_id: &ModuleId, state: &S) -> VMResult<()> {
+        self.0.load_module(module_id, state)
     }
 
     /// Generates a transaction output for a transaction that encountered errors during the

--- a/diem-move/diem-vm/src/diem_vm_impl.rs
+++ b/diem-move/diem-vm/src/diem_vm_impl.rs
@@ -27,7 +27,7 @@ use diem_types::{
     write_set::{WriteOp, WriteSet, WriteSetMut},
 };
 use fail::fail_point;
-use move_binary_format::errors::Location;
+use move_binary_format::errors::{Location, VMResult};
 use move_core_types::{
     account_address::AccountAddress,
     effects::{ChangeSet as MoveChangeSet, Event as MoveEvent},
@@ -456,6 +456,14 @@ impl DiemVMImpl {
 
     pub fn new_session<'r, R: MoveResolver>(&self, r: &'r R) -> Session<'r, '_, R> {
         self.move_vm.new_session(r)
+    }
+
+    pub fn load_module<'r, R: MoveResolver>(
+        &self,
+        module_id: &ModuleId,
+        remote: &'r R,
+    ) -> VMResult<()> {
+        self.move_vm.load_module(module_id, remote)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is a follow up PR for #9875 as a fix for our performance regression in parallel execution. After adding a block metadata transaction at the beginning of each transaction block, the overall system perf dropped by 2x and causes parallel execution to be slower than the sequential version. The reason was following:

Blockmetadata transaction will modify the timestamp resources that will be read by every transaction's prologue. Thus when parallel executor starts, only one thread get to execute the block metadata transaction, and all other threads are just waiting for that transaction to be executed. This causes a serious issue: the system is now spending 2x time on cold starting the MoveVM (one spent on the first block metadata transaction and one for all the other threads). This explains the serious performance regression we had in our benchmark change introduced in #9875.

To fix this regression, we change the `init` function for `DiemVM` such that when `DiemVM` is constructed, it will try to load `0x1::DiemAccount` into its code cache. By doing so, we are warming up `MoveVM`'s code cache all at once before any parallel execution starts. To make this work, a new api is added to `MoveVM` so that we can force VM to load up a module from a remote storage.

With the fix, the performance number now looks like following:

```
peer_to_peer_parallel   time:   [146.38 ms 151.36 ms 156.38 ms]                                
                        change: [-57.597% -55.812% -54.353%] (p = 0.00 < 0.05)
                        Performance has improved.
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
`cargo bench`
Comparing with main without the fix:

```
peer_to_peer_parallel   time:   [376.31 ms 379.99 ms 383.68 ms]                                
                        change: [+142.47% +151.06% +160.04%] (p = 0.00 < 0.05)
                        Performance has regressed.
```

The speed actually differs by roughly 2x when the transaction block size is 1000.


