### PR TITLE
[data-client] Refactoring and Adding More Tests for Data Client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8421,6 +8421,7 @@ name = "storage-service-types"
 version = "0.1.0"
 dependencies = [
  "claim",
+ "diem-config",
  "diem-crypto",
  "diem-types",
  "diem-workspace-hack",

--- a/state-sync/storage-service/types/Cargo.toml
+++ b/state-sync/storage-service/types/Cargo.toml
@@ -14,6 +14,7 @@ num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0.124", default-features = false }
 thiserror = "1.0.24"
 
+diem-config = { path = "../../../config" }
 diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-types = { path = "../../../types" }
 diem-workspace-hack = { path = "../../../common/workspace-hack" }


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR aims to clean up, refactor, and add more tests for data client (#9833). Specifically,

- Add a test verifying that a bad peer would eventually be added back if it keeps responding to `StorageServerSummary` 
- Add additional tests that check if data summary can service `AccountStatesChunkWithProofRequest`and `TransactionOutputsWithProofRequest` requests
- Clean up duplication in the test `bad_peer_is_eventually_banned_callback`
-  Initialize defaults for `ProtocolMetadata` using `StorageServiceConfig`'s defaults
- Add bound/overflow checks inside `len()` for data range

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan
Run all tests under `state-sync/diem-data-client` and `state-sync/storage-service`

![Screen Shot 2021-11-24 at 10 40 12 PM](https://user-images.githubusercontent.com/10539152/143397980-4f6989ae-c3a3-428b-8391-0da2ef62454e.png)
![Screen Shot 2021-11-24 at 10 39 33 PM](https://user-images.githubusercontent.com/10539152/143397986-0c8bf701-2d2f-41c3-baeb-eeddea662119.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
