### PR TITLE
[shuffle] Support for 2nd ephemeral account during console, test

### DIFF
--- a/shuffle/cli/src/account.rs
+++ b/shuffle/cli/src/account.rs
@@ -120,7 +120,7 @@ fn archive_current_files_in_latest(network_home: &NetworkHome) -> Result<()> {
 fn generate_new_account(network_home: &NetworkHome) -> Result<LocalAccount> {
     let private_key = network_home.generate_key_file()?;
     let public_key = private_key.public_key();
-    network_home.generate_latest_address_file(&public_key)?;
+    network_home.generate_address_file("latest", &public_key)?;
     Ok(LocalAccount::new(
         AuthenticationKey::ed25519(&public_key).derived_address(),
         private_key,

--- a/shuffle/cli/src/console.rs
+++ b/shuffle/cli/src/console.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{shared, shared::Network};
+use crate::{context::UserContext, shared, shared::Network};
 use anyhow::Result;
 use diem_types::account_address::AccountAddress;
 use std::{path::Path, process::Command};
@@ -48,8 +48,8 @@ pub fn handle(
             .join("repl_help.ts")
             .to_string_lossy()
     );
-    let filtered_envs =
-        shared::get_filtered_envs_for_deno(home, project_path, &network, key_path, sender_address)?;
+    let user = UserContext::new("latest", sender_address, key_path);
+    let filtered_envs = shared::get_filtered_envs_for_deno(home, project_path, &network, &[&user])?;
     Command::new("deno")
         .args(["repl", "--unstable", "--eval", deno_bootstrap.as_str()])
         .envs(&filtered_envs)

--- a/shuffle/cli/src/console.rs
+++ b/shuffle/cli/src/console.rs
@@ -48,8 +48,17 @@ pub fn handle(
             .join("repl_help.ts")
             .to_string_lossy()
     );
-    let user = UserContext::new("latest", sender_address, key_path);
-    let filtered_envs = shared::get_filtered_envs_for_deno(home, project_path, &network, &[&user])?;
+
+    let network_home = home.new_network_home(&network.get_name());
+
+    let latest_user = UserContext::new("latest", sender_address, key_path);
+    let test_user = network_home.user_context_for("test")?;
+    let filtered_envs = shared::get_filtered_envs_for_deno(
+        home,
+        project_path,
+        &network,
+        &[&latest_user, &test_user],
+    )?;
     Command::new("deno")
         .args(["repl", "--unstable", "--eval", deno_bootstrap.as_str()])
         .envs(&filtered_envs)

--- a/shuffle/cli/src/context.rs
+++ b/shuffle/cli/src/context.rs
@@ -1,0 +1,77 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_sdk::client::AccountAddress;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+/// Encapsulates the fields needed to execute on behalf of a user, especially
+/// in hand offs to typescript for console REPL and end to end testing.
+pub struct UserContext {
+    username: String,
+    address: AccountAddress,
+    private_key_path: PathBuf,
+}
+
+impl UserContext {
+    pub fn new(username: &str, address: AccountAddress, private_key_path: &Path) -> UserContext {
+        UserContext {
+            username: username.to_string(),
+            address,
+            private_key_path: private_key_path.to_owned(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+
+    #[allow(dead_code)]
+    pub fn address(&self) -> &AccountAddress {
+        &self.address
+    }
+
+    #[allow(dead_code)]
+    pub fn private_key_path(&self) -> &Path {
+        &self.private_key_path
+    }
+
+    pub fn to_envs(&self) -> HashMap<String, String> {
+        let mut envs: HashMap<String, String> = HashMap::new();
+        envs.insert(
+            format!("{}_{}", "ADDRESS", self.username.to_uppercase()),
+            self.address.to_hex_literal(),
+        );
+        envs.insert(
+            format!("{}_{}", "PRIVATE_KEY_PATH", self.username.to_uppercase()),
+            self.private_key_path.to_string_lossy().to_string(),
+        );
+        envs
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use diem_sdk::types::LocalAccount;
+
+    #[test]
+    fn test_to_envs() {
+        let mut rng = rand::rngs::OsRng;
+        let account = LocalAccount::generate(&mut rng);
+        let user = UserContext::new("test", account.address(), Path::new("dev.key"));
+        let actual_envs = user.to_envs();
+        let mut actual_keys = actual_envs.keys().cloned().collect::<Vec<String>>();
+        actual_keys.sort();
+
+        assert_eq!(actual_keys, vec!["ADDRESS_TEST", "PRIVATE_KEY_PATH_TEST"],);
+        assert_eq!(
+            actual_envs.get("ADDRESS_TEST").unwrap(),
+            &account.address().to_hex_literal()
+        );
+        assert_eq!(actual_envs.get("PRIVATE_KEY_PATH_TEST").unwrap(), "dev.key");
+    }
+}

--- a/shuffle/cli/src/deploy.rs
+++ b/shuffle/cli/src/deploy.rs
@@ -35,11 +35,11 @@ pub async fn handle(network_home: &NetworkHome, project_path: &Path, url: Url) -
     let seq_number = client.get_account_sequence_number(address).await?;
     let mut account = LocalAccount::new(address, account_key, seq_number);
 
-    deploy(client, &mut account, project_path).await
+    deploy(&client, &mut account, project_path).await
 }
 
 pub async fn deploy(
-    client: DevApiClient,
+    client: &DevApiClient,
     account: &mut LocalAccount,
     project_path: &Path,
 ) -> Result<()> {
@@ -61,7 +61,7 @@ pub async fn deploy(
         let mut binary = vec![];
         module.serialize(&mut binary)?;
 
-        let hash = send_module_transaction(&client, account, binary).await?;
+        let hash = send_module_transaction(client, account, binary).await?;
         client.check_txn_executed_from_hash(hash.as_str()).await?;
     }
 

--- a/shuffle/cli/src/lib.rs
+++ b/shuffle/cli/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod account;
+pub mod context;
 pub mod deploy;
 pub mod dev_api_client;
 pub mod new;

--- a/shuffle/cli/src/lib.rs
+++ b/shuffle/cli/src/lib.rs
@@ -2,9 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod account;
+pub mod build;
+pub mod console;
 pub mod context;
 pub mod deploy;
 pub mod dev_api_client;
 pub mod new;
+pub mod node;
 pub mod shared;
 pub mod test;
+pub mod transactions;

--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -10,17 +10,7 @@ use diem_types::account_address::AccountAddress;
 use std::{fs, path::PathBuf};
 use structopt::StructOpt;
 
-mod account;
-mod build;
-mod console;
-mod context;
-mod deploy;
-mod dev_api_client;
-mod new;
-mod node;
-mod shared;
-mod test;
-mod transactions;
+use shuffle::{account, build, console, deploy, new, node, shared, test, transactions};
 
 #[tokio::main]
 pub async fn main() -> Result<()> {

--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -13,6 +13,7 @@ use structopt::StructOpt;
 mod account;
 mod build;
 mod console;
+mod context;
 mod deploy;
 mod dev_api_client;
 mod new;

--- a/shuffle/cli/src/main.rs
+++ b/shuffle/cli/src/main.rs
@@ -237,7 +237,7 @@ fn normalized_key_path(
                     "An account hasn't been created yet! Run shuffle account first"
                 ));
             }
-            Ok(PathBuf::from(network_home.get_latest_account_key_path()))
+            Ok(network_home.get_latest_account_key_path())
         }
     }
 }

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -138,8 +138,8 @@ impl NetworkHome {
     }
 
     #[allow(dead_code)]
-    pub fn get_latest_address(&self) -> Result<AccountAddress> {
-        let address_str = std::fs::read_to_string(&self.address_path_for("latest"))?;
+    pub fn address_for(&self, username: &str) -> Result<AccountAddress> {
+        let address_str = std::fs::read_to_string(&self.address_path_for(username))?;
         AccountAddress::from_str(address_str.as_str()).map_err(anyhow::Error::new)
     }
 

--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -129,6 +129,14 @@ impl NetworkHome {
         self.accounts_path.join(username).join("address")
     }
 
+    pub fn user_context_for(&self, username: &str) -> Result<UserContext> {
+        Ok(UserContext::new(
+            username,
+            self.address_for(username)?,
+            &self.key_path_for(username),
+        ))
+    }
+
     pub fn get_latest_account_key_path(&self) -> PathBuf {
         self.key_path_for("latest")
     }

--- a/shuffle/cli/tests/common/mod.rs
+++ b/shuffle/cli/tests/common/mod.rs
@@ -8,9 +8,7 @@ use diem_sdk::{
 };
 use forge::{AdminContext, ChainInfo};
 use shuffle::{
-    account,
-    context::UserContext,
-    deploy,
+    account, deploy,
     dev_api_client::DevApiClient,
     new, shared,
     shared::{Home, Network, NetworkHome, NetworksConfig},
@@ -106,15 +104,6 @@ impl ShuffleTestHelper {
         self.network_home()
             .generate_address_file(username, new_account.public_key())?;
         account::create_account_via_dev_api(treasury_account, new_account, factory, client).await
-    }
-
-    #[allow(dead_code)]
-    pub fn user_context_for(&self, username: &str) -> Result<UserContext> {
-        Ok(UserContext::new(
-            username,
-            self.network_home().address_for(username)?,
-            &self.network_home().key_path_for(username),
-        ))
     }
 
     pub fn create_project(&self) -> Result<()> {

--- a/shuffle/cli/tests/common/mod.rs
+++ b/shuffle/cli/tests/common/mod.rs
@@ -8,7 +8,9 @@ use diem_sdk::{
 };
 use forge::{AdminContext, ChainInfo};
 use shuffle::{
-    account, deploy,
+    account,
+    context::UserContext,
+    deploy,
     dev_api_client::DevApiClient,
     new, shared,
     shared::{Home, Network, NetworkHome, NetworksConfig},
@@ -106,6 +108,15 @@ impl ShuffleTestHelper {
         account::create_account_via_dev_api(treasury_account, new_account, factory, client).await
     }
 
+    #[allow(dead_code)]
+    pub fn user_context_for(&self, username: &str) -> Result<UserContext> {
+        Ok(UserContext::new(
+            username,
+            self.network_home().address_for(username)?,
+            &self.network_home().key_path_for(username),
+        ))
+    }
+
     pub fn create_project(&self) -> Result<()> {
         new::handle(
             &self.home,
@@ -121,7 +132,7 @@ impl ShuffleTestHelper {
     ) -> Result<()> {
         let url = Url::from_str(dev_api_url)?;
         let client = DevApiClient::new(reqwest::Client::new(), url)?;
-        deploy::deploy(client, account, &self.project_path()).await
+        deploy::deploy(&client, account, &self.project_path()).await
     }
 
     pub fn codegen_project(&self, account: &LocalAccount) -> Result<()> {

--- a/shuffle/cli/tests/shuffle-forge-cli-tests.rs
+++ b/shuffle/cli/tests/shuffle-forge-cli-tests.rs
@@ -79,7 +79,7 @@ impl AdminTest for TransactionsWithNetworkRawAddressFlags {
                 "--address",
                 helper
                     .network_home()
-                    .get_latest_address()?
+                    .address_for("latest")?
                     .to_hex_literal()
                     .as_str(),
             ])

--- a/shuffle/cli/tests/shuffle-forge-integration-tests.rs
+++ b/shuffle/cli/tests/shuffle-forge-integration-tests.rs
@@ -32,7 +32,7 @@ impl AdminTest for SamplePackageEndToEnd {
             helper.home(),
             &helper.project_path(),
             helper.network(),
-            helper.network_home().get_latest_account_key_path(),
+            &helper.network_home().get_latest_account_key_path(),
             helper.network_home().get_latest_address()?,
         )?;
 
@@ -57,7 +57,7 @@ impl AdminTest for TypescriptSdkIntegration {
             helper.home(),
             &helper.project_path(),
             helper.network(),
-            helper.network_home().get_latest_account_key_path(),
+            &helper.network_home().get_latest_account_key_path(),
             helper.network_home().get_latest_address()?,
             &helper.project_path().join("integration"),
         )?;

--- a/shuffle/cli/tests/shuffle-forge-integration-tests.rs
+++ b/shuffle/cli/tests/shuffle-forge-integration-tests.rs
@@ -8,7 +8,6 @@ use forge::{
     forge_main, AdminContext, AdminTest, ForgeConfig, LocalFactory, Options, Result, Test,
 };
 use move_cli::package::cli::UnitTestResult;
-use shuffle::context::UserContext;
 
 fn main() -> Result<()> {
     let tests = ForgeConfig::default()
@@ -29,16 +28,13 @@ impl AdminTest for SamplePackageEndToEnd {
     fn run<'t>(&self, ctx: &mut AdminContext<'t>) -> Result<()> {
         let helper = bootstrap_shuffle_project(ctx)?;
         let unit_test_result = shuffle::test::run_move_unit_tests(&helper.project_path())?;
-        let user = UserContext::new(
-            "latest",
-            helper.network_home().get_latest_address()?,
-            &helper.network_home().get_latest_account_key_path(),
-        );
+        let latest = helper.user_context_for("latest")?;
+        let test = helper.user_context_for("test")?;
         let exit_status = shuffle::test::run_deno_test(
             helper.home(),
             &helper.project_path(),
             helper.network(),
-            &[&user],
+            &[&latest, &test],
         )?;
 
         assert!(matches!(unit_test_result, UnitTestResult::Success));
@@ -58,16 +54,13 @@ impl Test for TypescriptSdkIntegration {
 impl AdminTest for TypescriptSdkIntegration {
     fn run<'t>(&self, ctx: &mut AdminContext<'t>) -> Result<()> {
         let helper = bootstrap_shuffle_project(ctx)?;
-        let user = UserContext::new(
-            "latest",
-            helper.network_home().get_latest_address()?,
-            &helper.network_home().get_latest_account_key_path(),
-        );
+        let latest = helper.user_context_for("latest")?;
+        let test = helper.user_context_for("test")?;
         let exit_status = shuffle::test::run_deno_test_at_path(
             helper.home(),
             &helper.project_path(),
             helper.network(),
-            &[&user],
+            &[&latest, &test],
             &helper.project_path().join("integration"),
         )?;
         assert!(exit_status.success());

--- a/shuffle/cli/tests/shuffle-forge-integration-tests.rs
+++ b/shuffle/cli/tests/shuffle-forge-integration-tests.rs
@@ -28,8 +28,8 @@ impl AdminTest for SamplePackageEndToEnd {
     fn run<'t>(&self, ctx: &mut AdminContext<'t>) -> Result<()> {
         let helper = bootstrap_shuffle_project(ctx)?;
         let unit_test_result = shuffle::test::run_move_unit_tests(&helper.project_path())?;
-        let latest = helper.user_context_for("latest")?;
-        let test = helper.user_context_for("test")?;
+        let latest = helper.network_home().user_context_for("latest")?;
+        let test = helper.network_home().user_context_for("test")?;
         let exit_status = shuffle::test::run_deno_test(
             helper.home(),
             &helper.project_path(),
@@ -54,8 +54,8 @@ impl Test for TypescriptSdkIntegration {
 impl AdminTest for TypescriptSdkIntegration {
     fn run<'t>(&self, ctx: &mut AdminContext<'t>) -> Result<()> {
         let helper = bootstrap_shuffle_project(ctx)?;
-        let latest = helper.user_context_for("latest")?;
-        let test = helper.user_context_for("test")?;
+        let latest = helper.network_home().user_context_for("latest")?;
+        let test = helper.network_home().user_context_for("test")?;
         let exit_status = shuffle::test::run_deno_test_at_path(
             helper.home(),
             &helper.project_path(),

--- a/shuffle/move/examples/e2e/message.test.ts
+++ b/shuffle/move/examples/e2e/message.test.ts
@@ -40,7 +40,7 @@ Deno.test("Advanced: Ability to set message from nonpublishing account", async (
   const publishingAddress = defaultUserContext.address;
   const scriptFunction = publishingAddress + "::Message::set_message";
 
-  const secondUserContext = await UserContext.fromDisk("test");
+  const secondUserContext = UserContext.fromEnv("test");
 
   let txn = await helpers.invokeScriptFunctionForContext(
     secondUserContext,

--- a/shuffle/move/examples/integration/context.test.ts
+++ b/shuffle/move/examples/integration/context.test.ts
@@ -1,0 +1,21 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { assertEquals } from "https://deno.land/std@0.85.0/testing/asserts.ts";
+import { consoleContext, UserContext } from "../main/context.ts";
+
+Deno.test("UserContext.fromDisk", async () => {
+  // "test" matches username created in rust test harness
+  const username = "test";
+  const testUser = await UserContext.fromDisk(username);
+  assertEquals(testUser.username, username);
+
+  const address = await Deno.readTextFile(
+    consoleContext.accountAddressPath(username),
+  );
+  assertEquals(testUser.address, address);
+  assertEquals(
+    testUser.privateKeyPath,
+    consoleContext.accountKeyPath(username),
+  );
+});

--- a/shuffle/move/examples/integration/helpers.test.ts
+++ b/shuffle/move/examples/integration/helpers.test.ts
@@ -5,13 +5,12 @@ import {
   assert,
   assertEquals,
 } from "https://deno.land/std@0.85.0/testing/asserts.ts";
-import * as context from "../main/context.ts";
+import { defaultUserContext } from "../main/context.ts";
 import * as devapi from "../main/devapi.ts";
 import * as helpers from "../main/helpers.ts";
 
 Deno.test("invokeScriptFunction", async () => {
-  const scriptFunction =
-    context.senderAddress + "::Message::set_message";
+  const scriptFunction = defaultUserContext.address + "::Message::set_message";
   let txn = await helpers.invokeScriptFunction(
     scriptFunction,
     [],

--- a/shuffle/move/examples/main/context.ts
+++ b/shuffle/move/examples/main/context.ts
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import * as path from "https://deno.land/std@0.116.0/path/mod.ts";
 import urlcat from "https://deno.land/x/urlcat@v2.0.4/src/index.ts";
 import { BcsDeserializer } from "./generated/bcs/mod.ts";
 import { isURL } from "https://deno.land/x/is_url@v1.0.1/mod.ts";
@@ -23,22 +24,63 @@ class ConsoleContext {
       ),
     );
   }
+
+  // Returns the address file path for the passed username based on
+  // conventions from shuffle account creation
+  // ie: ~/.shuffle/networks/localhost/accounts/test/address
+  accountAddressPath(username: string): string {
+    return path.join(
+      this.networksPath,
+      this.networkName,
+      "accounts",
+      username,
+      "address",
+    );
+  }
+
+  // Returns the private key file path for the passed username based on
+  // conventions from shuffle account creation
+  // ie: ~/.shuffle/networks/localhost/accounts/test/dev.key
+  accountKeyPath(username: string): string {
+    return path.join(
+      this.networksPath,
+      this.networkName,
+      "accounts",
+      username,
+      "dev.key",
+    );
+  }
 }
 
 export const consoleContext = ConsoleContext.fromEnv();
 
-class UserContext {
+export class UserContext {
   constructor(
     readonly username: string,
     readonly address: string,
     readonly privateKeyPath: string,
   ) {}
 
+  // Creates a UserContext based on parameters set in ENV vars, usually via
+  // shuffle CLI commands `console` and `test`.
   static fromEnv(username: string): UserContext {
     return new UserContext(
       username,
       String(Deno.env.get("SENDER_ADDRESS")),
       String(Deno.env.get("PRIVATE_KEY_PATH")),
+    );
+  }
+
+  // Creates a UserContext based on an account name saved to disk based on
+  // conventions used on the shuffle CLI account command.
+  // ie: ~/.shuffle/networks/localhost/accounts/test
+  static async fromDisk(username: string): Promise<UserContext> {
+    const addressPath = consoleContext.accountAddressPath(username);
+    const privateKeyPath = consoleContext.accountKeyPath(username);
+    return new UserContext(
+      username,
+      await Deno.readTextFile(addressPath),
+      privateKeyPath,
     );
   }
 

--- a/shuffle/move/examples/main/context.ts
+++ b/shuffle/move/examples/main/context.ts
@@ -1,32 +1,61 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import * as _path from "https://deno.land/std@0.110.0/path/mod.ts";
 import urlcat from "https://deno.land/x/urlcat@v2.0.4/src/index.ts";
 import { BcsDeserializer } from "./generated/bcs/mod.ts";
 import { isURL } from "https://deno.land/x/is_url@v1.0.1/mod.ts";
 
-export const shuffleBaseNetworksPath = String(Deno.env.get("SHUFFLE_BASE_NETWORKS_PATH"));
-export const projectPath = String(Deno.env.get("PROJECT_PATH"));
-export const networkName = String(Deno.env.get("SHUFFLE_NETWORK_NAME"))
-export const nodeUrl = getNetworkEndpoint(
-  String(Deno.env.get("SHUFFLE_NETWORK_DEV_API_URL")),
-);
-export const senderAddress = String(Deno.env.get("SENDER_ADDRESS"));
-export const privateKeyPath = String(Deno.env.get("PRIVATE_KEY_PATH"));
-const privateKeyBytes = bcsToBytes(
-  await Deno.readFile(privateKeyPath)
-);
+class ConsoleContext {
+  constructor(
+    readonly projectPath: string,
+    readonly networkName: string,
+    readonly networksPath: string,
+    readonly nodeUrl: string,
+  ) {}
 
-export function privateKey(): Uint8Array {
-  return privateKeyBytes.slice(0);
+  static fromEnv(): ConsoleContext {
+    return new ConsoleContext(
+      String(Deno.env.get("PROJECT_PATH")),
+      String(Deno.env.get("SHUFFLE_NETWORK_NAME")),
+      String(Deno.env.get("SHUFFLE_BASE_NETWORKS_PATH")),
+      getNetworkEndpoint(
+        String(Deno.env.get("SHUFFLE_NETWORK_DEV_API_URL")),
+      ),
+    );
+  }
 }
+
+export const consoleContext = ConsoleContext.fromEnv();
+
+class UserContext {
+  constructor(
+    readonly username: string,
+    readonly address: string,
+    readonly privateKeyPath: string,
+  ) {}
+
+  static fromEnv(username: string): UserContext {
+    return new UserContext(
+      username,
+      String(Deno.env.get("SENDER_ADDRESS")),
+      String(Deno.env.get("PRIVATE_KEY_PATH")),
+    );
+  }
+
+  async readPrivateKey(): Promise<Uint8Array> {
+    return bcsToBytes(
+      await Deno.readFile(this.privateKeyPath),
+    );
+  }
+}
+
+export const defaultUserContext = UserContext.fromEnv("default");
 
 export function addressOrDefault(addr: string | undefined): string {
   if (addr) {
     return addr;
   }
-  return senderAddress;
+  return defaultUserContext.address;
 }
 
 function getNetworkEndpoint(inputNetwork: string) {
@@ -44,9 +73,9 @@ function getNetworkEndpoint(inputNetwork: string) {
 
 function bcsToBytes(bcsBytes: Uint8Array): Uint8Array {
   const bcsDeserializer = new BcsDeserializer(bcsBytes);
-  return bcsDeserializer.deserializeBytes()
+  return bcsDeserializer.deserializeBytes();
 }
 
 export function relativeUrl(tail: string) {
-  return new URL(tail, nodeUrl).href;
+  return new URL(tail, consoleContext.nodeUrl).href;
 }

--- a/shuffle/move/examples/main/context.ts
+++ b/shuffle/move/examples/main/context.ts
@@ -66,8 +66,8 @@ export class UserContext {
   static fromEnv(username: string): UserContext {
     return new UserContext(
       username,
-      String(Deno.env.get("SENDER_ADDRESS")),
-      String(Deno.env.get("PRIVATE_KEY_PATH")),
+      String(Deno.env.get(`ADDRESS_${username.toUpperCase()}`)),
+      String(Deno.env.get(`PRIVATE_KEY_PATH_${username.toUpperCase()}`)),
     );
   }
 
@@ -91,7 +91,7 @@ export class UserContext {
   }
 }
 
-export const defaultUserContext = UserContext.fromEnv("default");
+export const defaultUserContext = UserContext.fromEnv("latest");
 
 export function addressOrDefault(addr: string | undefined): string {
   if (addr) {

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -135,15 +135,18 @@ export async function postTransactionJson(body: string): Promise<any> {
   });
 }
 
-export async function resourceNames(): Promise<string[]> {
-  return (await resources())
+export async function resourceNames(addr?: string): Promise<string[]> {
+  return (await resources(addr))
     .map(
       (entry: any) => entry["type"],
     );
 }
 
-export async function resourcesWithName(resourceName: string): Promise<any[]> {
-  return (await resources())
+export async function resourcesWithName(
+  resourceName: string,
+  addr?: string,
+): Promise<any[]> {
+  return (await resources(addr))
     .filter(
       (entry: any) => entry["type"].split("::").includes(resourceName),
     );

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -32,7 +32,9 @@ export async function transaction(versionOrHash: string) {
 }
 
 // Polls for a specific transaction to complete, returning the txn object.
-export async function waitForTransactionCompletion(versionOrHash: string): Promise<any> {
+export async function waitForTransactionCompletion(
+  versionOrHash: string,
+): Promise<any> {
   let txn = await transaction(versionOrHash);
   for (let i = 0; i < 20; i++) {
     if (txn.type !== "pending_transaction") {

--- a/shuffle/move/examples/main/helpers.ts
+++ b/shuffle/move/examples/main/helpers.ts
@@ -3,7 +3,7 @@
 
 // deno-lint-ignore-file no-explicit-any
 import * as DiemTypes from "./generated/diemTypes/mod.ts";
-import * as context from "./context.ts";
+import { defaultUserContext } from "./context.ts";
 import * as devapi from "./devapi.ts";
 import * as ed from "https://deno.land/x/ed25519@1.0.1/mod.ts";
 import * as util from "https://deno.land/std@0.85.0/node/util.ts";
@@ -65,9 +65,9 @@ export async function invokeScriptFunction(
   args: any[],
 ): Promise<any> {
   return await invokeScriptFunctionWithoutContext(
-    context.senderAddress,
+    defaultUserContext.address,
     await devapi.sequenceNumber(),
-    context.privateKey(),
+    await defaultUserContext.readPrivateKey(),
     scriptFunction,
     typeArguments,
     args,

--- a/shuffle/move/examples/main/helpers.ts
+++ b/shuffle/move/examples/main/helpers.ts
@@ -3,7 +3,7 @@
 
 // deno-lint-ignore-file no-explicit-any
 import * as DiemTypes from "./generated/diemTypes/mod.ts";
-import { defaultUserContext } from "./context.ts";
+import { defaultUserContext, UserContext } from "./context.ts";
 import * as devapi from "./devapi.ts";
 import * as ed from "https://deno.land/x/ed25519@1.0.1/mod.ts";
 import * as util from "https://deno.land/std@0.85.0/node/util.ts";
@@ -64,19 +64,32 @@ export async function invokeScriptFunction(
   typeArguments: string[],
   args: any[],
 ): Promise<any> {
-  return await invokeScriptFunctionWithoutContext(
-    defaultUserContext.address,
-    await devapi.sequenceNumber(),
-    await defaultUserContext.readPrivateKey(),
+  return await invokeScriptFunctionForContext(
+    defaultUserContext,
     scriptFunction,
     typeArguments,
     args,
   );
 }
 
+export async function invokeScriptFunctionForContext(
+  userContext: UserContext,
+  scriptFunction: string,
+  typeArguments: string[],
+  args: any[],
+): Promise<any> {
+  return await invokeScriptFunctionForAddress(
+    userContext.address,
+    await devapi.sequenceNumber(userContext.address),
+    await userContext.readPrivateKey(),
+    scriptFunction,
+    typeArguments,
+    args,
+  );
+}
 // Invokes a script function using the Dev API's signing_message/ JSON endpoint.
-export async function invokeScriptFunctionWithoutContext(
-  addressStr: string,
+export async function invokeScriptFunctionForAddress(
+  senderAddressStr: string,
   sequenceNumber: number,
   privateKeyBytes: Uint8Array,
   scriptFunction: string,
@@ -84,7 +97,7 @@ export async function invokeScriptFunctionWithoutContext(
   args: any[],
 ): Promise<any> {
   const request: any = {
-    "sender": addressStr,
+    "sender": senderAddressStr,
     "sequence_number": `${sequenceNumber}`,
     "max_gas_amount": "1000000",
     "gas_unit_price": "0",

--- a/shuffle/move/examples/main/mod.ts
+++ b/shuffle/move/examples/main/mod.ts
@@ -4,7 +4,7 @@
 import * as DiemHelpers from "./helpers.ts";
 import * as DiemTypes from "./generated/diemTypes/mod.ts";
 import * as codegen from "./generated/diemStdlib/mod.ts";
-import * as context from "./context.ts";
+import { consoleContext, defaultUserContext } from "./context.ts";
 import * as devapi from "./devapi.ts";
 import * as util from "https://deno.land/std@0.85.0/node/util.ts";
 import { green } from "https://deno.land/x/nanocolors@0.1.12/mod.ts";
@@ -18,13 +18,19 @@ function highlight(content: string) {
 }
 
 export async function printWelcome() {
-  console.log(`Loading Project ${highlight(context.projectPath)}`);
-  console.log(`Sender Account Address ${highlight(context.senderAddress)}`);
+  console.log(`Loading Project ${highlight(consoleContext.projectPath)}`);
+  console.log(
+    `Default Account Address ${highlight(defaultUserContext.address)}`,
+  );
   console.log(
     `"helpers", "devapi", "context", "main", "codegen", "help" top level objects available`,
   );
   console.log(`Run "help" for more information on top level objects`);
-  console.log(`Connecting to Node ${highlight(context.nodeUrl)}`);
+  console.log(
+    `Connecting to ${consoleContext.networkName} at ${
+      highlight(consoleContext.nodeUrl)
+    }`,
+  );
   console.log(await devapi.ledgerInfo());
   console.log();
 }
@@ -38,9 +44,9 @@ export async function setMessageScriptFunction(
     textEncoder.encode(message),
   );
   return await DiemHelpers.buildAndSubmitTransaction(
-    context.senderAddress,
+    defaultUserContext.address,
     await devapi.sequenceNumber(),
-    context.privateKey(),
+    await defaultUserContext.readPrivateKey(),
     payload,
   );
 }
@@ -55,9 +61,9 @@ export async function setMessageScript(
   );
   const payload = new DiemTypes.TransactionPayloadVariantScript(script);
   return await DiemHelpers.buildAndSubmitTransaction(
-    context.senderAddress,
+    defaultUserContext.address,
     await devapi.sequenceNumber(),
-    context.privateKey(),
+    await defaultUserContext.readPrivateKey(),
     payload,
   );
 }
@@ -67,7 +73,9 @@ export async function setMessageScript(
 // but with a different address. See main/sources/NFT.move
 // This is optional, as createTestNFTScriptFunction handles init.
 export async function initializeTestNFT() {
-  const nftAddress = DiemHelpers.hexToAccountAddress(context.senderAddress);
+  const nftAddress = DiemHelpers.hexToAccountAddress(
+    defaultUserContext.address,
+  );
 
   // Create the type tag representing TestNFT to pass to the generic
   // script `initialize_nft`
@@ -83,9 +91,9 @@ export async function initializeTestNFT() {
   const script = codegen.Stdlib.encodeInitializeNftScript(testNftType);
   const payload = new DiemTypes.TransactionPayloadVariantScript(script);
   return await DiemHelpers.buildAndSubmitTransaction(
-    context.senderAddress,
+    defaultUserContext.address,
     await devapi.sequenceNumber(),
-    context.privateKey(),
+    await defaultUserContext.readPrivateKey(),
     payload,
   );
 }
@@ -99,9 +107,9 @@ export async function createTestNFTScriptFunction(
     textEncoder.encode(contentUri),
   );
   return await DiemHelpers.buildAndSubmitTransaction(
-    context.senderAddress,
+    defaultUserContext.address,
     await devapi.sequenceNumber(),
-    context.privateKey(),
+    await defaultUserContext.readPrivateKey(),
     payload,
   );
 }

--- a/shuffle/move/examples/main/mod.ts
+++ b/shuffle/move/examples/main/mod.ts
@@ -4,7 +4,11 @@
 import * as DiemHelpers from "./helpers.ts";
 import * as DiemTypes from "./generated/diemTypes/mod.ts";
 import * as codegen from "./generated/diemStdlib/mod.ts";
-import { consoleContext, defaultUserContext } from "./context.ts";
+import {
+  addressOrDefault,
+  consoleContext,
+  defaultUserContext,
+} from "./context.ts";
 import * as devapi from "./devapi.ts";
 import * as util from "https://deno.land/std@0.85.0/node/util.ts";
 import { green } from "https://deno.land/x/nanocolors@0.1.12/mod.ts";
@@ -114,13 +118,15 @@ export async function createTestNFTScriptFunction(
   );
 }
 
-export async function decodedMessages() {
-  return (await devapi.resourcesWithName("MessageHolder"))
+export async function decodedMessages(addr?: string) {
+  addr = addressOrDefault(addr);
+  return (await devapi.resourcesWithName("MessageHolder", addr))
     .map((entry) => DiemHelpers.hexToAscii(entry.data.message));
 }
 
-export async function decodedNFTs() {
-  return (await devapi.resourcesWithName("NFT"))
+export async function decodedNFTs(addr?: string) {
+  addr = addressOrDefault(addr);
+  return (await devapi.resourcesWithName("NFT", addr))
     .filter((entry) => entry.data && entry.data.content_uri)
     .map((entry) => DiemHelpers.hexToAscii(entry.data.content_uri));
 }


### PR DESCRIPTION
## Motivation

1. Introduce support for a 2nd ephemeral account in both `shuffle console` and `shuffle test e2e` to support peer to peer transfer scenarios like TransferNFT.
2. Prepare harness and console typescript SDK to support multiple accounts (ie: alice, bob, charlie) by introducing `UserContext` and `ConsoleContext` in `context.ts` and `context.rs`.

--

### Specifics
1. Introduce UserContexts into both TS and Rust. UserContext { username, address, privateKeyPath }
1. Pass an array of UserContexts to run_deno_tests and console so that ENV variable handoff of users can better support N users, rather than hardcoding to `latest`.
1. Generate ENV vars iteratively following a convention: ADDRESS_\<username>, PRIVATE_KEY_PATH_\<username>. ie: ADDRESS_LATEST, PRIVATE_KEY_PATH_LATEST, ADDRESS_TEST, etc
1. Cleanup: Remove `mod ...` from main.rs and instead pull in from lib via `use ...`. Prevents duplicate running of tests.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

`cargo test -p shuffle` which includes new tests mentioned below and existing tests to prevent regressions.
1. integration/context.text.ts
2. integration/message.test.ts - ability for nonpublishing address to set message