### PR TITLE
[api] get core account resource

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -107,6 +107,7 @@ Failpoint configuration example:
 ```
 failpoints
   api::endpoint_index: 1%return
+  api::endpoint_get_account: 1%return
   api::endpoint_get_account_resources: 1%return
   api::endpoint_get_account_modules: 1%return
   api::endpoint_get_transaction: 1%return

--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -59,6 +59,27 @@ paths:
           description: Returns OpenAPI specification YAML document.
         "400":
           description: Bad Request
+  /accounts/{address}:
+    get:
+      summary: Get account
+      operationId: get_account
+      tags:
+        - accounts
+      parameters:
+        - $ref: '#/components/parameters/AccountAddress'
+      responses:
+        "200":
+          description: Returns the latest account core data resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+        "400":
+          $ref: '#/components/responses/400'
+        "404":
+          $ref: '#/components/responses/404'
+        "500":
+          $ref: '#/components/responses/500'
   /accounts/{address}/resources:
     get:
       summary: Get account resources
@@ -470,7 +491,11 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            allOf:
+              - $ref: "#/components/schemas/Error"
+              - example:
+                  code: 400
+                  message: "invalid parameter"
     "404":
       description: |
         Resource or data not found.
@@ -478,28 +503,45 @@ components:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            allOf:
+              - $ref: "#/components/schemas/Error"
+              - example:
+                  code: 404
+                  message: "resource not found"
+                  diem_ledger_version: "37829327"
     "413":
       description: |
         The request payload is too large.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            allOf:
+              - $ref: "#/components/schemas/Error"
+              - example:
+                  code: 413
+                  message: "The request payload is too large"
     "415":
       description: |
         The request's content-type is not supported.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            allOf:
+              - $ref: "#/components/schemas/Error"
+              - example:
+                  code: 415
+                  message: "The request's content-type is not supported"
     "500":
       description: |
         Server internal error, caused by unexpected issues.
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Error"
+            allOf:
+              - $ref: "#/components/schemas/Error"
+              - example:
+                  code: 500
+                  message: "unexpected internal error"
   schemas:
     Error:
       title: Response Error
@@ -603,6 +645,21 @@ components:
           $ref: '#/components/schemas/LedgerVersion'
         ledger_timestamp:
           $ref: '#/components/schemas/TimestampUsec'
+    Account:
+      title: Account
+      description: Core account resource, used for identifying account and transaction execution.
+      type: object
+      required:
+        - sequence_number
+        - authentication_key
+      properties:
+        sequence_number:
+          $ref: '#/components/schemas/Uint64'
+        authentication_key:
+          $ref: '#/components/schemas/HexEncodedBytes'
+      example:
+        sequence_number: "1"
+        authentication_key: "0x5307b5f4bc67829097a8ba9b43dba3b88261eeccd1f709d9bde240fc100fbb69"
     AccountResource:
       title: Account Resource
       description: Account resource is a Move struct value belongs to an account.

--- a/api/src/index.rs
+++ b/api/src/index.rs
@@ -28,6 +28,7 @@ const OPEN_API_SPEC: &str = include_str!("../doc/openapi.yaml");
 pub fn routes(context: Context) -> impl Filter<Extract = impl Reply, Error = Infallible> + Clone {
     index(context.clone())
         .or(openapi_spec())
+        .or(accounts::get_account(context.clone()))
         .or(accounts::get_account_resources(context.clone()))
         .or(accounts::get_account_resources_by_ledger_version(
             context.clone(),

--- a/api/src/tests/accounts_test.rs
+++ b/api/src/tests/accounts_test.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::tests::{assert_json, find_value, new_test_context};
+use diem_api_types::HexEncodedBytes;
 use serde_json::json;
 
 #[tokio::test]
@@ -563,6 +564,34 @@ async fn test_get_account_modules_by_ledger_version() {
         ))
         .await;
     assert_eq!(modules, json!([]));
+}
+
+#[tokio::test]
+async fn test_get_core_account_data() {
+    let context = new_test_context();
+    let auth_key = context.dd_account().authentication_key();
+    let resp = context.get("/accounts/0xdd").await;
+    assert_eq!(
+        json!({
+            "sequence_number": "0",
+            "authentication_key": HexEncodedBytes::from(auth_key.to_vec()).to_string(),
+        }),
+        resp
+    );
+}
+
+#[tokio::test]
+async fn test_get_core_account_data_not_found() {
+    let context = new_test_context();
+    let resp = context.expect_status_code(404).get("/accounts/0xf").await;
+    assert_eq!(
+        json!({
+            "code": 404,
+            "message": "account not found by address(0xf) and ledger version(0)",
+            "diem_ledger_version": "0"
+        }),
+        resp
+    );
 }
 
 fn account_resources(address: &str) -> String {

--- a/api/types/src/account.rs
+++ b/api/types/src/account.rs
@@ -1,0 +1,22 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{HexEncodedBytes, U64};
+
+use diem_types::account_config::AccountResource;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AccountData {
+    pub sequence_number: U64,
+    pub authentication_key: HexEncodedBytes,
+}
+
+impl From<AccountResource> for AccountData {
+    fn from(ar: AccountResource) -> Self {
+        Self {
+            sequence_number: ar.sequence_number().into(),
+            authentication_key: ar.authentication_key().to_vec().into(),
+        }
+    }
+}

--- a/api/types/src/lib.rs
+++ b/api/types/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+mod account;
 mod address;
 mod bytecode;
 mod convert;
@@ -13,6 +14,7 @@ mod move_types;
 mod response;
 mod transaction;
 
+pub use account::AccountData;
 pub use address::Address;
 pub use bytecode::Bytecode;
 pub use convert::MoveConverter;

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -170,9 +170,16 @@ impl FromStr for HexEncodedBytes {
     }
 }
 
+impl fmt::Display for HexEncodedBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "0x{}", hex::encode(&self.0))?;
+        Ok(())
+    }
+}
+
 impl Serialize for HexEncodedBytes {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        format!("0x{}", &hex::encode(&self.0)).serialize(serializer)
+        self.to_string().serialize(serializer)
     }
 }
 

--- a/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
+++ b/testsuite/cluster-test/src/cluster_swarm/configs/fullnode.yaml
@@ -45,6 +45,7 @@ json_rpc:
 # this is only enabled when the binary is compiled with failpoints feature, otherwise no-op
 failpoints:
   api::endpoint_index: 1%return
+  api::endpoint_get_account: 1%return
   api::endpoint_get_account_resources: 1%return
   api::endpoint_get_account_modules: 1%return
   api::endpoint_get_transaction: 1%return


### PR DESCRIPTION
#9193 

`GET /accounts/<address>` returns core account resource for convenience (sequence number and auth key), instead of call get account resources and filter out core account resource.

It is representing new CoreAccount resource working in progress: https://github.com/tzakian/libra/blob/0e1f5c1497123ddbd6a8a96e3958a416ab4cedaa/diem-move/diem-framework/core/sources/CoreAccount.move
