### PR TITLE
[shuffle] add faucet support for e2e test

### DIFF
--- a/shuffle/cli/src/shared.rs
+++ b/shuffle/cli/src/shared.rs
@@ -400,15 +400,11 @@ impl Network {
         self.dev_api_url.clone()
     }
 
-    pub fn get_optional_faucet_url(&self) -> Option<Url> {
+    pub fn get_faucet_url(&self) -> Option<Url> {
         self.faucet_url.clone()
     }
 
-    pub fn get_faucet_url(&self) -> Url {
-        Network::normalize_faucet_url(self).unwrap()
-    }
-
-    fn normalize_faucet_url(&self) -> Result<Url> {
+    pub fn normalized_faucet_url(&self) -> Result<Url> {
         match &self.faucet_url {
             Some(faucet) => Ok(faucet.clone()),
             None => Err(anyhow!("This network doesn't have a faucet url")),


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Before shuffle test e2e --network would run an end to end test with an account created with devapiclient where instead we needed to faucet an account. This PR ensures that whenever a network that supports a faucet url is used, the e2e test will faucet an account. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

1. Add trove_testnet details to Networks.toml.
2. `cargo run -p shuffle -- new <project_path>`
3. `cargo run -p shuffle -- test e2e -p <project_path> --network trove_testnet`

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
