### PR TITLE
Revert the Z3 version

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -25,7 +25,7 @@ KUBECTL_VERSION=1.18.6
 TERRAFORM_VERSION=0.12.26
 HELM_VERSION=3.2.4
 VAULT_VERSION=1.5.0
-Z3_VERSION=4.8.12
+Z3_VERSION=4.8.9
 CVC4_VERSION=aac53f51
 CVC5_VERSION=0.0.3
 DOTNET_VERSION=5.0
@@ -480,9 +480,9 @@ function install_z3 {
      return
   fi
   if [[ "$(uname)" == "Linux" ]]; then
-    Z3_PKG="z3-$Z3_VERSION-x64-glibc-2.31"
+    Z3_PKG="z3-$Z3_VERSION-x64-ubuntu-16.04"
   elif [[ "$(uname)" == "Darwin" ]]; then
-    Z3_PKG="z3-$Z3_VERSION-x64-osx-10.15.7"
+    Z3_PKG="z3-$Z3_VERSION-x64-osx-10.14.6"
   else
     echo "Z3 support not configured for this platform (uname=$(uname))"
     return


### PR DESCRIPTION
This PR reverts the Z3 version. The new version causes a build error.

## Motivation

To resolve the CI build error for the new version of Z3

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes