### PR TITLE
[language] make diem-workspace-hack a dev-dependency

### DIFF
--- a/language/benchmarks/Cargo.toml
+++ b/language/benchmarks/Cargo.toml
@@ -17,7 +17,6 @@ proptest = "1.0.0"
 criterion-cpu-time = "0.1.0"
 
 bytecode-verifier = { path = "../bytecode-verifier" }
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-core-types = { path = "../move-core/types" }
 move-lang = { path = "../move-lang" }
 move-vm-runtime = { path = "../move-vm/runtime" }
@@ -29,3 +28,6 @@ move-stdlib = { path = "../move-stdlib" }
 [[bench]]
 name = "vm_benches"
 harness = false
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/language/borrow-graph/Cargo.toml
+++ b/language/borrow-graph/Cargo.toml
@@ -7,5 +7,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 mirai-annotations = "1.10.1"
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/language/bytecode-verifier/Cargo.toml
+++ b/language/bytecode-verifier/Cargo.toml
@@ -16,10 +16,10 @@ petgraph = "0.5.1"
 
 borrow-graph = { path = "../borrow-graph" }
 move-binary-format = { path = "../move-binary-format" }
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-core-types = { path = "../move-core/types" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }
 invalid-mutations = { path = "invalid-mutations" }
 
 [features]

--- a/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
+++ b/language/bytecode-verifier/bytecode-verifier-tests/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 petgraph = "0.5.1"
 proptest = "1.0.0"
 
 bytecode-verifier = { path = "../" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 invalid-mutations = { path = "../invalid-mutations" }
 move-core-types = { path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format", features = ["fuzzing"] }

--- a/language/bytecode-verifier/invalid-mutations/Cargo.toml
+++ b/language/bytecode-verifier/invalid-mutations/Cargo.toml
@@ -13,7 +13,9 @@ publish = false
 move-core-types = { path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }
 proptest = "1.0.0"
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/bytecode-verifier/transactional-tests/Cargo.toml
+++ b/language/bytecode-verifier/transactional-tests/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 move-transactional-test-runner = { path = "../../testing-infra/transactional-test-runner" }
 

--- a/language/e2e-testsuite/Cargo.toml
+++ b/language/e2e-testsuite/Cargo.toml
@@ -28,7 +28,6 @@ diem-vm = { path = "../../diem-move/diem-vm" }
 proptest = "1.0.0"
 diem-logger = { path = "../../common/logger" }
 diem-framework-releases = { path = "../../diem-move/diem-framework/DPN/releases" }
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 diem-writeset-generator = { path = "../../diem-move/writeset-transaction-generator"}
 diem-state-view = { path = "../../storage/state-view" }
 read-write-set = { path = "../tools/read-write-set" }
@@ -36,3 +35,6 @@ diem-parallel-executor = { path = "../../diem-move/parallel-executor" }
 
 [features]
 default = ["diem-transaction-builder/fuzzing"]
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/language/ir-testsuite/Cargo.toml
+++ b/language/ir-testsuite/Cargo.toml
@@ -10,13 +10,13 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }
 anyhow = "1.0.38"
 bytecode-verifier = { path = "../bytecode-verifier" }
 datatest-stable = "0.1.1"
 functional-tests = { path = "../testing-infra/functional-tests" }
 ir-to-bytecode = { path = "../move-ir-compiler/ir-to-bytecode" }
 diem-types = { path = "../../types" }
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-ir-types = { path = "../move-ir/types" }
 diem-framework-releases = { path = "../../diem-move/diem-framework/DPN/releases" }
 move-binary-format = { path = "../move-binary-format" }

--- a/language/move-command-line-common/Cargo.toml
+++ b/language/move-command-line-common/Cargo.toml
@@ -17,4 +17,6 @@ sha2 = "0.9.3"
 hex = "0.4.3"
 serde = { version = "1.0.124", features = ["derive"] }
 
+
+[dev-dependencies]
 diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/language/move-core/types/Cargo.toml
+++ b/language/move-core/types/Cargo.toml
@@ -23,11 +23,11 @@ serde = { version = "1.0.124", default-features = false }
 serde_bytes = "0.11.5"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 regex = "1.4.3"
 serde_json = "1.0.64"
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [features]
 default = []

--- a/language/move-ir-compiler/Cargo.toml
+++ b/language/move-ir-compiler/Cargo.toml
@@ -15,7 +15,6 @@ bytecode-verifier = { path = "../bytecode-verifier" }
 move-command-line-common = { path = "../move-command-line-common" }
 ir-to-bytecode = { path = "ir-to-bytecode" }
 bytecode-source-map = { path = "bytecode-source-map" }
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-ir-types = { path = "../move-ir/types" }
 move-core-types = { path = "../move-core/types" }
 move-binary-format = { path = "../move-binary-format" }
@@ -26,3 +25,6 @@ serde_json = "1.0.64"
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }

--- a/language/move-ir-compiler/bytecode-source-map/Cargo.toml
+++ b/language/move-ir-compiler/bytecode-source-map/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
@@ -21,3 +20,6 @@ serde = { version = "1.0.124", default-features = false }
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/move-ir-compiler/ir-to-bytecode/Cargo.toml
+++ b/language/move-ir-compiler/ir-to-bytecode/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 ir-to-bytecode-syntax = { path = "syntax" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
@@ -26,3 +25,6 @@ ouroboros = "0.9.2"
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/move-ir-compiler/ir-to-bytecode/syntax/Cargo.toml
+++ b/language/move-ir-compiler/ir-to-bytecode/syntax/Cargo.toml
@@ -15,8 +15,10 @@ hex = "0.4.3"
 move-ir-types = { path = "../../../move-ir/types" }
 move-core-types = { path = "../../../move-core/types" }
 move-symbol-pool = { path = "../../../move-symbol-pool" }
-diem-workspace-hack = { path = "../../../../common/workspace-hack" }
 move-command-line-common = { path = "../../../move-command-line-common" }
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../../common/workspace-hack" }

--- a/language/move-ir-compiler/transactional-tests/Cargo.toml
+++ b/language/move-ir-compiler/transactional-tests/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 move-transactional-test-runner = { path = "../../testing-infra/transactional-test-runner" }
 

--- a/language/move-ir/types/Cargo.toml
+++ b/language/move-ir/types/Cargo.toml
@@ -17,7 +17,9 @@ serde = { version = "1.0.124", features = ["derive"] }
 hex = "0.4.3"
 once_cell = "1.7.2"
 
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 move-command-line-common = { path = "../../move-command-line-common" }
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/move-lang/Cargo.toml
+++ b/language/move-lang/Cargo.toml
@@ -22,7 +22,6 @@ move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
 move-bytecode-verifier = { path = "../bytecode-verifier", package = "bytecode-verifier" }
 move-symbol-pool = { path = "../move-symbol-pool" }
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-ir-types = { path = "../move-ir/types" }
 ir-to-bytecode = { path = "../move-ir-compiler/ir-to-bytecode" }
 borrow-graph = { path = "../borrow-graph" }
@@ -31,6 +30,7 @@ bcs = "0.1.2"
 move-command-line-common = { path = "../move-command-line-common" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-stdlib = { path = "../move-stdlib" }
 datatest-stable = "0.1.1"
 

--- a/language/move-lang/functional-tests/Cargo.toml
+++ b/language/move-lang/functional-tests/Cargo.toml
@@ -9,9 +9,9 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 anyhow = "1.0.38"
 tempfile = "3.2.0"
 once_cell = "1.7.2"

--- a/language/move-lang/transactional-tests/Cargo.toml
+++ b/language/move-lang/transactional-tests/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 move-transactional-test-runner = { path = "../../testing-infra/transactional-test-runner" }
 

--- a/language/move-model/Cargo.toml
+++ b/language/move-model/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0"
 move-lang = { path = "../move-lang" }
 bytecode-verifier = { path = "../bytecode-verifier" }
 move-binary-format = { path = "../move-binary-format" }
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 bytecode-source-map = { path = "../move-ir-compiler/bytecode-source-map" }
 move-ir-types = { path = "../move-ir/types" }
 move-core-types = { path = "../move-core/types" }
@@ -32,6 +31,7 @@ anyhow = "1.0.38"
 serde = { version = "1.0.124", features = ["derive"] }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 move-prover-test-utils = { path = "../move-prover/test-utils" }
 

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -18,7 +18,6 @@ abigen = { path = "abigen" }
 errmapgen = { path = "errmapgen" }
 bytecode = { path = "bytecode" }
 bytecode-interpreter = { path = "interpreter" }
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-ir-types = { path = "../move-ir/types" }
 move-core-types = { path = "../move-core/types" }
 
@@ -44,6 +43,7 @@ tokio = { version = "1.8.1", features = ["full"] }
 toml = "0.5.8"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 move-prover-test-utils = { path = "test-utils" }
 shell-words = "1.0.0"

--- a/language/move-prover/abigen/Cargo.toml
+++ b/language/move-prover/abigen/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 [dependencies]
 # diem dependencies
 move-model = { path = "../../move-model" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 bytecode-verifier = { path = "../../bytecode-verifier" }
 move-command-line-common = { path = "../../move-command-line-common" }
@@ -22,6 +21,7 @@ heck = "0.3.2"
 serde = { version = "1.0.124", features = ["derive"] }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 codespan-reporting = "0.11.1"
 move-prover = { path = ".." }
 datatest-stable = "0.1.1"

--- a/language/move-prover/boogie-backend/Cargo.toml
+++ b/language/move-prover/boogie-backend/Cargo.toml
@@ -13,7 +13,6 @@ bytecode = { path = "../bytecode" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-model = { path = "../../move-model" }
 move-binary-format = { path = "../../move-binary-format" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 num = "0.4.0"
 itertools = "0.10.0"
 move-core-types = { path = "../../move-core/types" }
@@ -30,3 +29,6 @@ tera = "1.7.1"
 tokio = { version = "1.8.1", features = ["full"] }
 codespan = "0.11.1"
 codespan-reporting = "0.11.1"
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -15,7 +15,6 @@ move-binary-format = { path = "../../move-binary-format" }
 bytecode-verifier = { path = "../../bytecode-verifier" }
 borrow-graph = { path = "../../borrow-graph" }
 ir-to-bytecode = { path = "../../move-ir-compiler/ir-to-bytecode" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-read-write-set-types = { path = "../../tools/read-write-set/types" }
@@ -33,6 +32,7 @@ paste = "1.0.5"
 petgraph = "0.5.1"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-stdlib = { path = "../../move-stdlib" }
 datatest-stable = "0.1.1"
 move-prover-test-utils = { path = "../test-utils" }

--- a/language/move-prover/docgen/Cargo.toml
+++ b/language/move-prover/docgen/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0"
 move-lang = { path = "../../move-lang" }
 move-model = { path = "../../move-model" }
 bytecode = { path = "../bytecode" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 # external dependencies
 codespan = "0.11.1"
@@ -25,6 +24,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 once_cell = "1.7.2"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-prover = { path = ".." }
 datatest-stable = "0.1.1"
 tempfile = "3.2.0"

--- a/language/move-prover/errmapgen/Cargo.toml
+++ b/language/move-prover/errmapgen/Cargo.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 # diem dependencies
 move-command-line-common = { path = "../../move-command-line-common" }
 move-model = { path = "../../move-model" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 bcs = "0.1.2"
 
@@ -20,6 +19,7 @@ anyhow = "1.0.38"
 serde = { version = "1.0.124", features = ["derive"] }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 codespan-reporting = "0.11.1"
 move-prover = { path = ".." }
 datatest-stable = "0.1.1"

--- a/language/move-prover/interpreter/Cargo.toml
+++ b/language/move-prover/interpreter/Cargo.toml
@@ -10,7 +10,6 @@ license = "Apache-2.0"
 # diem dependencies
 bytecode = { path = "../bytecode" }
 bytecode-interpreter-crypto = { path = "crypto" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
 move-core-types = { path = "../../move-core/types" }
 move-model = { path = "../../move-model" }
@@ -25,5 +24,6 @@ serde = { version = "1.0.124", features = ["derive"] }
 structopt = "0.3.21"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 move-prover-test-utils = { path = "../test-utils" }

--- a/language/move-prover/interpreter/crypto/Cargo.toml
+++ b/language/move-prover/interpreter/crypto/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-diem-workspace-hack = { path = "../../../../common/workspace-hack" }
 
 # external dependencies
 anyhow = "1.0.38"
@@ -21,3 +20,6 @@ default = ["fiat"]
 fiat = ["curve25519-dalek/fiat_u64_backend", "ed25519-dalek/fiat_u64_backend"]
 u64 = ["curve25519-dalek/u64_backend", "ed25519-dalek/u64_backend"]
 u32 = ["curve25519-dalek/u32_backend", "ed25519-dalek/u32_backend"]
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../../common/workspace-hack" }

--- a/language/move-prover/lab/Cargo.toml
+++ b/language/move-prover/lab/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0"
 move-model = { path = "../../move-model" }
 move-prover = { path = ".." }
 bytecode = { path = "../bytecode"}
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 # FB external dependencies
 z3tracer = "0.8.0"
@@ -31,5 +30,6 @@ serde_json = "1.0.64"
 simplelog = "0.9.0"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 move-prover-test-utils = { path = "../test-utils" }

--- a/language/move-prover/mutation/Cargo.toml
+++ b/language/move-prover/mutation/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0"
 move-model = { path = "../../move-model" }
 move-prover = { path = ".." }
 bytecode = { path = "../bytecode"}
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 # FB external dependencies
 z3tracer = "0.8.0"
@@ -32,5 +31,6 @@ serde_json = "1.0.64"
 simplelog = "0.9.0"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 move-prover-test-utils = { path = "../test-utils" }

--- a/language/move-prover/test-utils/Cargo.toml
+++ b/language/move-prover/test-utils/Cargo.toml
@@ -10,5 +10,7 @@ license = "Apache-2.0"
 prettydiff = "0.4.0"
 anyhow = "1.0.38"
 regex = "1.4.3"
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-command-line-common = { path = "../../move-command-line-common" }
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/move-prover/tools/spec-flatten/Cargo.toml
+++ b/language/move-prover/tools/spec-flatten/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-diem-workspace-hack = { path = "../../../../common/workspace-hack" }
 
 # move dependencies
 bytecode = { path = "../../bytecode" }
@@ -20,3 +19,6 @@ anyhow = "1.0.38"
 itertools = "0.10.1"
 pretty = "0.10.0"
 structopt = "0.3.21"
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../../common/workspace-hack" }

--- a/language/move-stdlib/Cargo.toml
+++ b/language/move-stdlib/Cargo.toml
@@ -16,7 +16,6 @@ errmapgen = { path = "../move-prover/errmapgen" }
 docgen = { path = "../move-prover/docgen" }
 move-command-line-common = { path = "../move-command-line-common" }
 move-prover = { path = "../move-prover" }
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-vm-types = { path = "../move-vm/types" }
 move-binary-format = { path = "../move-binary-format" }
 move-core-types = { path = "../move-core/types" }
@@ -30,6 +29,7 @@ sha2 = "0.9.3"
 sha3 = "0.9.1"
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }
 move-unit-test = { path = "../tools/move-unit-test" }
 tempfile = "3.2.0"
 dir-diff = "0.3.2"

--- a/language/move-symbol-pool/Cargo.toml
+++ b/language/move-symbol-pool/Cargo.toml
@@ -13,9 +13,9 @@ edition = "2018"
 once_cell = "1.7.2"
 serde = { version = "1.0.124", features = ["derive"] }
 
-diem-workspace-hack = { path = "../../common/workspace-hack" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../common/workspace-hack" }
 serde_json = { version = "1.0.64" }
 
 [features]

--- a/language/move-vm/integration-tests/Cargo.toml
+++ b/language/move-vm/integration-tests/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 anyhow = "1.0.38"
 tempfile = "3.2.0"
 
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = {path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }
 move-lang = { path = "../../move-lang" }
@@ -23,3 +22,6 @@ move-vm-runtime = { path = "../runtime" }
 move-vm-types = { path = "../types" }
 move-vm-test-utils = { path = "../test-utils" }
 move-stdlib = { path = "../../move-stdlib" }
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/move-vm/runtime/Cargo.toml
+++ b/language/move-vm/runtime/Cargo.toml
@@ -20,12 +20,12 @@ sha3 = "0.9.1"
 tracing = "0.1.26"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-vm-types = { path = "../types" }
 move-binary-format = { path = "../../move-binary-format" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 anyhow = "1.0.38"
 hex = "0.4.3"
 proptest = "1.0.0"

--- a/language/move-vm/test-utils/Cargo.toml
+++ b/language/move-vm/test-utils/Cargo.toml
@@ -14,7 +14,9 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.38"
 
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-vm-runtime = { path = "../runtime" }
 move-core-types = {path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/move-vm/transactional-tests/Cargo.toml
+++ b/language/move-vm/transactional-tests/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 move-transactional-test-runner = { path = "../../testing-infra/transactional-test-runner" }
 

--- a/language/move-vm/types/Cargo.toml
+++ b/language/move-vm/types/Cargo.toml
@@ -18,11 +18,11 @@ serde = { version = "1.0.124", features = ["derive", "rc"] }
 smallvec = "1.6.1"
 
 bcs = "0.1.2"
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-binary-format = { path = "../../move-binary-format" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 proptest = "1.0.0"
 
 [features]

--- a/language/testing-infra/diem-transactional-test-harness/Cargo.toml
+++ b/language/testing-infra/diem-transactional-test-harness/Cargo.toml
@@ -30,11 +30,11 @@ diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-framework = { path = "../../../diem-move/diem-framework" }
 diem-keygen = { path = "../../../diem-move/diem-keygen" }
 diem-state-view = { path = "../../../storage/state-view" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-command-line-common = { path = "../../move-command-line-common" }
 vm-genesis= { path = "../../../diem-move/vm-genesis" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 
 [[test]]

--- a/language/testing-infra/e2e-tests/Cargo.toml
+++ b/language/testing-infra/e2e-tests/Cargo.toml
@@ -33,8 +33,10 @@ diem-keygen = { path = "../../../diem-move/diem-keygen" }
 diem-proptest-helpers = { path = "../../../common/proptest-helpers" }
 diem-config = { path = "../../../config" }
 diem-framework-releases = { path = "../../../diem-move/diem-framework/DPN/releases" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 diem-transaction-builder = { path = "../../../sdk/transaction-builder" }
 move-command-line-common = { path = "../../move-command-line-common" }
 read-write-set = { path = "../../tools/read-write-set" }
 hex = "0.4.3"
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/testing-infra/functional-tests/Cargo.toml
+++ b/language/testing-infra/functional-tests/Cargo.toml
@@ -22,7 +22,6 @@ language-e2e-tests = { path = "../e2e-tests" }
 diem-keygen = { path = "../../../diem-move/diem-keygen" }
 diem-config = { path = "../../../config", features = ["fuzzing"] }
 diem-crypto = { path = "../../../crates/diem-crypto" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 once_cell = "1.7.2"
 regex = { version = "1.4.3", default-features = false, features = ["std", "perf"] }
 thiserror = "1.0.24"
@@ -37,3 +36,6 @@ itertools = "0.10.0"
 difference = "2.0.0"
 term_size = "0.3.2"
 vm-genesis = { path = "../../../diem-move/vm-genesis" }
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/testing-infra/module-generation/Cargo.toml
+++ b/language/testing-infra/module-generation/Cargo.toml
@@ -16,9 +16,11 @@ bytecode-verifier = { path = "../../bytecode-verifier" }
 ir-to-bytecode = { path = "../../move-ir-compiler/ir-to-bytecode" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
 move-symbol-pool = { path = "../../move-symbol-pool" }
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/testing-infra/test-generation/Cargo.toml
+++ b/language/testing-infra/test-generation/Cargo.toml
@@ -23,7 +23,6 @@ tracing-subscriber = "0.2.18"
 once_cell = "1.7.2"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-vm-runtime = { path = "../../move-vm/runtime" }
 move-vm-test-utils = { path = "../../move-vm/test-utils" }
@@ -35,3 +34,6 @@ move-lang = { path = "../../move-lang" }
 
 [features]
 mirai-contracts = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/testing-infra/transactional-test-runner/Cargo.toml
+++ b/language/testing-infra/transactional-test-runner/Cargo.toml
@@ -18,7 +18,6 @@ rayon = "1.5.0"
 structopt = "0.3.21"
 tempfile = "3.2.0"
 
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 
 bytecode-interpreter = { path = "../../move-prover/interpreter" }
 bytecode-source-map = { path = "../../move-ir-compiler/bytecode-source-map" }
@@ -39,6 +38,7 @@ move-vm-runtime = { path = "../../move-vm/runtime" }
 resource-viewer = { path = "../../tools/resource-viewer" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 difference = "2.0.0"
 

--- a/language/tools/disassembler/Cargo.toml
+++ b/language/tools/disassembler/Cargo.toml
@@ -13,7 +13,6 @@ colored = "2.0.0"
 bytecode-verifier = { path = "../../bytecode-verifier" }
 bytecode-source-map = { path = "../../move-ir-compiler/bytecode-source-map" }
 move-command-line-common = { path = "../../move-command-line-common" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
 move-binary-format = { path = "../../move-binary-format" }
@@ -24,3 +23,6 @@ structopt = "0.3.21"
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/tools/mirai-dataflow-analysis/Cargo.toml
+++ b/language/tools/mirai-dataflow-analysis/Cargo.toml
@@ -17,4 +17,6 @@ serde = {version="1.0", features=["derive"]}
 serde_json = "1.0"
 structopt = "0.3"
 
+
+[dev-dependencies]
 diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/tools/move-bytecode-utils/Cargo.toml
+++ b/language/tools/move-bytecode-utils/Cargo.toml
@@ -11,7 +11,9 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
 move-core-types = { path = "../../move-core/types" }
 petgraph = "0.5.1"
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/tools/move-bytecode-viewer/Cargo.toml
+++ b/language/tools/move-bytecode-viewer/Cargo.toml
@@ -15,7 +15,6 @@ tui = "0.14.0"
 
 move-command-line-common = { path = "../../move-command-line-common" }
 bytecode-source-map = { path = "../../move-ir-compiler/bytecode-source-map" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-ir-types = { path = "../../move-ir/types" }
 move-binary-format = { path = "../../move-binary-format" }
 disassembler = { path = "../disassembler" }
@@ -23,3 +22,6 @@ disassembler = { path = "../disassembler" }
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/tools/move-cli/Cargo.toml
+++ b/language/tools/move-cli/Cargo.toml
@@ -28,7 +28,6 @@ bytecode-verifier = { path = "../../bytecode-verifier" }
 
 disassembler = { path = "../disassembler" }
 move-command-line-common = { path = "../../move-command-line-common" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 move-coverage = { path = "../move-coverage" }
 move-core-types = { path = "../../move-core/types" }
@@ -50,6 +49,7 @@ bytecode-source-map = { path = "../../move-ir-compiler/bytecode-source-map" }
 move-bytecode-viewer = { path = "../move-bytecode-viewer" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 
 [[bin]]

--- a/language/tools/move-coverage/Cargo.toml
+++ b/language/tools/move-coverage/Cargo.toml
@@ -22,10 +22,12 @@ bcs = "0.1.2"
 move-command-line-common = { path = "../../move-command-line-common" }
 move-core-types = { path = "../../move-core/types" }
 move-ir-types = { path = "../../move-ir/types" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
 bytecode-source-map = { path = "../../move-ir-compiler/bytecode-source-map" }
 bytecode-verifier = { path = "../../bytecode-verifier" }
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/tools/move-explain/Cargo.toml
+++ b/language/tools/move-explain/Cargo.toml
@@ -12,9 +12,11 @@ edition = "2018"
 [dependencies]
 structopt = "0.3.21"
 move-command-line-common = { path = "../../move-command-line-common" }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 bcs = "0.1.2"
 
 [features]
 default = []
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/tools/move-package/Cargo.toml
+++ b/language/tools/move-package/Cargo.toml
@@ -21,7 +21,6 @@ sha2 = "0.9.3"
 regex = "1.1.9"
 ptree = "0.4.0"
 
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
 move-lang = { path = "../../move-lang" }
 bytecode-source-map = { path = "../../move-ir-compiler/bytecode-source-map" }
@@ -35,6 +34,7 @@ move-model = { path = "../../move-model" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 
 [[test]]

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -19,7 +19,6 @@ regex = "1.1.9"
 
 move-command-line-common = { path = "../../move-command-line-common" }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-lang = { path = "../../move-lang" }
 move-vm-types = { path = "../../move-vm/types" }
@@ -32,6 +31,7 @@ bytecode-interpreter = { path = "../../move-prover/interpreter" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 
 [dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }
 datatest-stable = "0.1.1"
 difference = "2.0.0"
 

--- a/language/tools/read-write-set/Cargo.toml
+++ b/language/tools/read-write-set/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-binary-format = { path = "../../move-binary-format" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 move-core-types = { path = "../../move-core/types" }
@@ -20,3 +19,6 @@ prover_bytecode = { path = "../../move-prover/bytecode", package="bytecode" }
 resource-viewer = { path = "../resource-viewer" }
 move-read-write-set-types = { path = "types" }
 read-write-set-dynamic = { path = "dynamic" }
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }

--- a/language/tools/read-write-set/dynamic/Cargo.toml
+++ b/language/tools/read-write-set/dynamic/Cargo.toml
@@ -11,8 +11,10 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
-diem-workspace-hack = { path = "../../../../common/workspace-hack" }
 move-binary-format = { path = "../../../move-binary-format" }
 move-bytecode-utils = { path = "../../move-bytecode-utils" }
 move-core-types = { path = "../../../move-core/types" }
 move-read-write-set-types = { path = "../types" }
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../../common/workspace-hack" }

--- a/language/tools/resource-viewer/Cargo.toml
+++ b/language/tools/resource-viewer/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 
 [dependencies]
 bcs = "0.1.2"
-diem-workspace-hack = { path = "../../../common/workspace-hack" }
 move-core-types = { path = "../../move-core/types" }
 move-vm-types = { path = "../../move-vm/types" }
 move-binary-format = { path = "../../move-binary-format" }
@@ -20,3 +19,6 @@ serde = { version = "1.0.124", features = ["derive", "rc"] }
 anyhow = "1.0.38"
 once_cell = "1.7.2"
 hex = "0.4.3"
+
+[dev-dependencies]
+diem-workspace-hack = { path = "../../../common/workspace-hack" }


### PR DESCRIPTION
This makes `diem-workspace-hack` a dev dependency for all crates inside `language`. It is a preparation for publishing Move crates to crates.io as dev-dependencies are ignored during that process.

This whole diff is generated using the following python code:
```
import os

def make_workspace_hack_dev_dependency(path):
    with open(path, 'r+') as f:
        workspace_deps = []
        buffer = []
        for line in f.readlines():
            if 'diem-workspace-hack' in line:
                workspace_deps.append(line)
            else:
                buffer.append(line)

        f.seek(0)
        f.truncate(0)

        for line in buffer:
            f.write(line)
            if workspace_deps != None and '[dev-dependencies]' in line:
                for line in workspace_deps:
                    f.write(line)
                workspace_deps = None

        if workspace_deps != None:
            f.write('\n')
            f.write('[dev-dependencies]\n')
            for line in workspace_deps:
                f.write(line)


for root, dirs, files in os.walk("."):
    for name in files:
        if name == "Cargo.toml":
            path = os.path.join(root, name)
            make_workspace_hack_dev_dependency(path)

```