### PR TITLE
[shuffle] annotate API call arguments and return types

### DIFF
--- a/shuffle/move/examples/integration/devapi.test.ts
+++ b/shuffle/move/examples/integration/devapi.test.ts
@@ -26,8 +26,13 @@ Deno.test("transactions", async () => {
 
 Deno.test("transaction", async () => {
   const actual = await devapi.transaction(0);
-  assertEquals(actual.type, "genesis_transaction");
-  assert(actual.success);
+  switch (actual.type) {
+    case "genesis_transaction":
+      assert(actual.success);
+      break;
+    default:
+      throw "expect genesis_transaction for version 0"
+  }
 });
 
 Deno.test("transaction not found", async () => {

--- a/shuffle/move/examples/main/client.ts
+++ b/shuffle/move/examples/main/client.ts
@@ -48,6 +48,10 @@ export class Client {
     throw new Error(`wait for transaction(${versionOrHash}) execution timeout`);
   }
 
+  async getAccount(addr: string): Promise<Account> {
+    return await this.fetch(this.url(`/accounts/${addr}`));
+  }
+
   async getAccountTransactions(addr: string): Promise<OnChainTransaction[]> {
     return await this.fetch(this.url(`/accounts/${addr}/transactions`));
   }
@@ -202,4 +206,9 @@ export interface LedgerInfo {
   chain_id: number
   ledger_version: string
   ledger_timestamp: string
+}
+
+export interface Account {
+  sequence_number: string
+  authentication_key: string
 }

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -8,7 +8,15 @@
 // deno-lint-ignore-file no-explicit-any
 // deno-lint-ignore-file ban-types
 import * as context from "./context.ts";
-import { SigningMessageRequest, UserTransactionRequest, Transaction, OnChainTransaction, PendingTransaction, SigningMessage } from "./client.ts";
+import {
+  SigningMessageRequest,
+  UserTransactionRequest,
+  Transaction,
+  OnChainTransaction,
+  PendingTransaction,
+  SigningMessage,
+  Account
+} from "./client.ts";
 
 // Retrieves the ledger information as defined by the root /
 // of the Developer API
@@ -55,23 +63,16 @@ export async function modules(addr?: string) {
 }
 
 // Gets the account resource for a particular adress, or the default account.
-export async function account(addr?: string) {
+export async function account(addr?: string): Promise<Account> {
   addr = context.addressOrDefault(addr);
-  const res = await resources(addr);
-  return res
-    .find(
-      (entry: any) => entry["type"] == "0x1::DiemAccount::DiemAccount",
-    );
+  return await context.client().getAccount(addr);
 }
 
 // Returns the sequence number for a particular address, or the default account
 // for the console if no address is passed.
 export async function sequenceNumber(addr?: string): Promise<number> {
-  const acc: any = await account(addr);
-  if (acc) {
-    return parseInt(acc["data"]["sequence_number"]);
-  }
-  throw "unable to find account";
+  const acc = await account(addr);
+  return parseInt(acc.sequence_number);
 }
 
 export async function accounts() {

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -8,6 +8,7 @@
 // deno-lint-ignore-file no-explicit-any
 // deno-lint-ignore-file ban-types
 import * as context from "./context.ts";
+import { SigningMessageRequest, UserTransactionRequest, Transaction, OnChainTransaction, PendingTransaction, SigningMessage } from "./client.ts";
 
 // Retrieves the ledger information as defined by the root /
 // of the Developer API
@@ -16,13 +17,13 @@ export async function ledgerInfo() {
 }
 
 // Returns a list of transactions, ascending from page 0.
-export async function transactions() {
+export async function transactions(): Promise<OnChainTransaction[]> {
   // TODO: Have below return a list of transactions desc by sequence number
   return await context.client().getTransactions();
 }
 
 // Returns a specific transaction based on the version or hash.
-export async function transaction(versionOrHash: number | string) {
+export async function transaction(versionOrHash: number | string): Promise<Transaction> {
   return await context.client().getTransaction(versionOrHash);
 }
 
@@ -30,12 +31,12 @@ export async function transaction(versionOrHash: number | string) {
 export async function waitForTransactionCompletion(
   versionOrHash: number | string,
   timeout?: number,
-): Promise<any> {
+): Promise<OnChainTransaction> {
   return await context.client().waitForTransaction(versionOrHash, timeout);
 }
 
 // Returns transactions specific to a particular address.
-export async function accountTransactions(addr?: string) {
+export async function accountTransactions(addr?: string): Promise<OnChainTransaction[]> {
   addr = context.addressOrDefault(addr);
   return await context.client().getAccountTransactions(addr);
 }
@@ -87,13 +88,13 @@ export async function postTransactionBcs(
 // POSTs a JSON payload to the /transactions/signing_message endpoint in the
 // developer API to get the signing message for a payload.
 export async function postTransactionSigningMessage(
-  body: string,
-): Promise<any> {
+  body: SigningMessageRequest,
+): Promise<SigningMessage> {
   return await context.client().createSigningMessage(body);
 }
 
 // POSTs a JSON payload to the /transactions endpoint in the developer API.
-export async function postTransactionJson(body: string): Promise<any> {
+export async function postTransactionJson(body: UserTransactionRequest): Promise<PendingTransaction> {
   return await context.client().submitTransaction(body);
 }
 

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -80,7 +80,7 @@ export async function accounts() {
 }
 
 // POSTs a BCS payload to the /transactions endpoint in the developer API.
-export async function postTransactionBcs(
+export async function submitBcsTransaction(
   body: string | Uint8Array,
 ): Promise<any> {
   return await context.client().submitBcsTransaction(body);
@@ -88,14 +88,12 @@ export async function postTransactionBcs(
 
 // POSTs a JSON payload to the /transactions/signing_message endpoint in the
 // developer API to get the signing message for a payload.
-export async function postTransactionSigningMessage(
-  body: SigningMessageRequest,
-): Promise<SigningMessage> {
+export async function createSigningMessage(body: SigningMessageRequest): Promise<SigningMessage> {
   return await context.client().createSigningMessage(body);
 }
 
 // POSTs a JSON payload to the /transactions endpoint in the developer API.
-export async function postTransactionJson(body: UserTransactionRequest): Promise<PendingTransaction> {
+export async function submitTransaction(body: UserTransactionRequest): Promise<PendingTransaction> {
   return await context.client().submitTransaction(body);
 }
 

--- a/shuffle/move/examples/main/helpers.ts
+++ b/shuffle/move/examples/main/helpers.ts
@@ -112,7 +112,7 @@ export async function invokeScriptFunctionForAddress(
   };
 
   const signingMsgPayload = await devapi.postTransactionSigningMessage(
-    JSON.stringify(request),
+    request,
   );
   const signingMsg = signingMsgPayload.message.slice(2); // remove 0x prefix
 
@@ -124,7 +124,7 @@ export async function invokeScriptFunctionForAddress(
     "signature": signature,
   };
 
-  return await devapi.postTransactionJson(JSON.stringify(request));
+  return await devapi.postTransactionJson(request);
 }
 
 export function newRawTransaction(

--- a/shuffle/move/examples/main/helpers.ts
+++ b/shuffle/move/examples/main/helpers.ts
@@ -36,7 +36,7 @@ export async function buildAndSubmitTransaction(
     signingMsg,
   );
 
-  return await devapi.postTransactionBcs(signedTxnBytes);
+  return await devapi.submitBcsTransaction(signedTxnBytes);
 }
 
 export function buildScriptFunctionTransaction(
@@ -111,7 +111,7 @@ export async function invokeScriptFunctionForAddress(
     },
   };
 
-  const signingMsgPayload = await devapi.postTransactionSigningMessage(
+  const signingMsgPayload = await devapi.createSigningMessage(
     request,
   );
   const signingMsg = signingMsgPayload.message.slice(2); // remove 0x prefix
@@ -124,7 +124,7 @@ export async function invokeScriptFunctionForAddress(
     "signature": signature,
   };
 
-  return await devapi.postTransactionJson(request);
+  return await devapi.submitTransaction(request);
 }
 
 export function newRawTransaction(


### PR DESCRIPTION
1. Created interface definition for Transaction, Event, SigningMessage and LedgerInfo
2. Changed client methods to accept type arguments and returns type
3. Switched to call get account for account core resource instead of looking up DiemAccount resource
4. Renamed devapi functions postTransactionBcs, postTransactionSigningMessage and postTransactionJson to use same names defined by API/client