### PR TITLE
[move-cli] Fix ordering issues in sandbox publish

### DIFF
--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -198,7 +198,7 @@ impl CoverageSummaryOptions {
         let coverage_map = CoverageMap::from_binary_file(path.join(".coverage_map.mvcov"));
         let package = config.compile_package(path, &mut Vec::new())?;
         let modules: Vec<_> = package
-            .modules()
+            .modules()?
             .filter_map(|unit| match &unit.unit {
                 CompiledUnit::Module(NamedCompiledModule { module, .. }) => Some(module.clone()),
                 _ => None,

--- a/language/tools/move-cli/src/sandbox/commands/publish.rs
+++ b/language/tools/move-cli/src/sandbox/commands/publish.rs
@@ -25,13 +25,13 @@ pub fn publish(
     if verbose {
         println!(
             "Found {} modules",
-            package.modules().collect::<Vec<_>>().len()
+            package.modules()?.collect::<Vec<_>>().len()
         );
     }
 
     if no_republish {
         let republished = package
-            .modules()
+            .modules()?
             .filter_map(|unit| {
                 let id = module(&unit.unit).ok()?.self_id();
                 if state.has_module(&id) {
@@ -58,7 +58,7 @@ pub fn publish(
         let mut has_error = false;
         match override_ordering {
             None => {
-                for unit in package.modules() {
+                for unit in package.modules()? {
                     let module_bytes = unit.unit.serialize();
                     let id = module(&unit.unit)?.self_id();
                     let sender = *id.address();
@@ -73,7 +73,7 @@ pub fn publish(
             }
             Some(ordering) => {
                 let module_map: BTreeMap<_, _> = package
-                    .modules()
+                    .modules()?
                     .into_iter()
                     .map(|unit| (unit.unit.name().to_string(), unit))
                     .collect();
@@ -128,7 +128,7 @@ pub fn publish(
         // backward incompatible changes, as as result, if this flag is set, we skip the VM process
         // and force the CLI to override the on-disk state directly
         let mut serialized_modules = vec![];
-        for unit in package.modules() {
+        for unit in package.modules()? {
             let id = module(&unit.unit)?.self_id();
             let module_bytes = unit.unit.serialize();
             serialized_modules.push((id, module_bytes));

--- a/language/tools/move-cli/src/sandbox/commands/test.rs
+++ b/language/tools/move-cli/src/sandbox/commands/test.rs
@@ -69,7 +69,7 @@ fn collect_coverage(
     )?
     .into_compiled_package()?;
     let src_modules = pkg
-        .modules()
+        .modules()?
         .into_iter()
         .map(|unit| {
             let absolute_path = path_to_string(&unit.source_path.canonicalize()?)?;

--- a/language/tools/move-cli/tests/testsuite/cyclic_multi_module_publish/args.exp
+++ b/language/tools/move-cli/tests/testsuite/cyclic_multi_module_publish/args.exp
@@ -1,4 +1,15 @@
 Command `sandbox publish --override-ordering A --override-ordering B -v`:
+error[E02001]: duplicate declaration, item, or annotation
+  ┌─ ./sources/CyclicFriendsPart2.move:1:13
+  │
+1 │ module 0x3::A {
+  │             ^ Duplicate definition for module '0x3::A'
+  │
+  ┌─ ./sources/CyclicFriendsPart1.move:1:13
+  │
+1 │ module 0x3::A {
+  │             - Module previously defined here
+
 error[E02004]: invalid 'module' declaration
   ┌─ ./sources/CyclicFriendsPart2.move:8:24
   │
@@ -11,15 +22,4 @@ error[E02004]: invalid 'module' declaration
   │
 6 │     public fun foo() { 0x3::A::foo() }
   │                        ----------- '0x3::A' uses '0x3::B'
-
-error[E02001]: duplicate declaration, item, or annotation
-  ┌─ ./sources/CyclicFriendsPart1.move:1:13
-  │
-1 │ module 0x3::A {
-  │             ^ Duplicate definition for module '0x3::A'
-  │
-  ┌─ ./sources/CyclicFriendsPart2.move:1:13
-  │
-1 │ module 0x3::A {
-  │             - Module previously defined here
 

--- a/language/tools/move-cli/tests/testsuite/republish/args.exp
+++ b/language/tools/move-cli/tests/testsuite/republish/args.exp
@@ -38,4 +38,4 @@ module 43.N {
 }
 Command `sandbox publish -v --no-republish`:
 Found 2 modules
-Failed to republish modules since the --no-republish flag is set. Tried to republish the following modules: 00000000000000000000000000000042::M, 00000000000000000000000000000043::N
+Failed to republish modules since the --no-republish flag is set. Tried to republish the following modules: 00000000000000000000000000000043::N, 00000000000000000000000000000042::M

--- a/shuffle/move/examples/main/sources/nft/NFTTests.move
+++ b/shuffle/move/examples/main/sources/nft/NFTTests.move
@@ -17,7 +17,7 @@ module Sender::NFTTests {
         let account1 = Vector::pop_back(&mut UnitTest::create_signers_for_testing(1));
         let addr1 = Signer::address_of(&account1);
         let account2 = Vector::pop_back(&mut UnitTest::create_signers_for_testing(2));
-        let addr2 = Signer::address_of(&account2);
+        let _addr2 = Signer::address_of(&account2);
         let content_uri = b"https://placekitten.com/200/300";
 
         NFTStandard::initialize<TestNFT>(&account1);
@@ -27,7 +27,8 @@ module Sender::NFTTests {
             token,
             content_uri,
         );
-        let nft_id = &GUID::id(NFTStandard::id(&instance));
-        let nft_creation_id = GUID::creation_num(NFTStandard::id(&instance));
+        let _nft_id = &GUID::id(NFTStandard::id(&instance));
+        let _nft_creation_id = GUID::creation_num(NFTStandard::id(&instance));
+        NFTStandard::add(addr1, instance);
     }
 }


### PR DESCRIPTION
This should resolve an issue that @modocache observed where the publish order for modules is not deterministic after #9871 landed.

This is because the `modules()` method on a package was not returning the units in dependency order, and therefore there were chances for non-determinism introduced at that point.

This fixes this issue by making the `modules()` method always return compiled units in dependency order. 