### PR TITLE
[move-cli] Update CLI documentation, restructure CLI arguments to make more sense and be more consistent

### DIFF
--- a/language/tools/move-cli/src/experimental/cli.rs
+++ b/language/tools/move-cli/src/experimental/cli.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use move_core_types::{
     language_storage::TypeTag, parser, transaction_argument::TransactionArgument,
 };
+use std::path::Path;
 
 use structopt::{clap::arg_enum, StructOpt};
 
@@ -51,7 +52,7 @@ arg_enum! {
 }
 
 impl ExperimentalCommand {
-    pub fn handle_command(&self, move_args: &Move) -> Result<()> {
+    pub fn handle_command(&self, move_args: &Move, storage_dir: &Path) -> Result<()> {
         match self {
             ExperimentalCommand::ReadWriteSet {
                 module_file,
@@ -62,7 +63,7 @@ impl ExperimentalCommand {
                 concretize,
             } => {
                 let state = PackageContext::new(&move_args.package_path, &move_args.build_config)?
-                    .prepare_state(&move_args.storage_dir)?;
+                    .prepare_state(storage_dir)?;
                 experimental::commands::analyze_read_write_set(
                     &state,
                     module_file,

--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -39,6 +39,7 @@ use crate::{package::prover::run_move_prover, NativeFunctionRecord};
 
 #[derive(StructOpt)]
 pub enum CoverageSummaryOptions {
+    /// Display a coverage summary for all modules in this package
     #[structopt(name = "summary")]
     Summary {
         /// Whether function coverage summaries should be displayed
@@ -47,15 +48,14 @@ pub enum CoverageSummaryOptions {
         /// Output CSV data of coverage
         #[structopt(long = "csv")]
         output_csv: bool,
-        /// Whether path coverage should be derived (default is instruction coverage)
-        #[structopt(long = "derive-path-coverage")]
-        derive_path_coverage: bool,
     },
+    /// Display coverage information about the module against source code
     #[structopt(name = "source")]
     Source {
         #[structopt(long = "module")]
         module_name: String,
     },
+    /// Display coverage information about the module against disassembled bytecode
     #[structopt(name = "bytecode")]
     Bytecode {
         #[structopt(long = "module")]
@@ -84,9 +84,10 @@ pub enum PackageCommand {
     ErrMapGen {
         /// The prefix that all error reasons within modules will be prefixed with, e.g., "E" if
         /// all error reasons are "E_CANNOT_PERFORM_OPERATION", "E_CANNOT_ACCESS", etc.
+        #[structopt(long)]
         error_prefix: Option<String>,
         /// The file to serialize the generated error map to.
-        #[structopt(default_value = "error_map", parse(from_os_str))]
+        #[structopt(long, default_value = "error_map", parse(from_os_str))]
         output_file: PathBuf,
     },
     /// Run the Move Prover on the package at `path`. If no path is provided defaults to current
@@ -104,11 +105,14 @@ pub enum PackageCommand {
         #[structopt(subcommand)]
         options: Option<ProverOptions>,
     },
+    /// Inspect test coverage for this package. A previous test run with the `--coverage` flag must
+    /// have previously been run.
     #[structopt(name = "coverage")]
     CoverageReport {
         #[structopt(subcommand)]
         options: CoverageSummaryOptions,
     },
+    /// Run Move unit tests in this package.
     #[structopt(name = "test")]
     UnitTest {
         /// Bound the number of instructions that can be executed by any one test.
@@ -119,14 +123,13 @@ pub enum PackageCommand {
             long = "instructions"
         )]
         instruction_execution_bound: u64,
-        /// A filter string to determine which unit tests to run
+        /// A filter string to determine which unit tests to run. A unit test will be run only if it
+        /// contains this string in its fully qualified (<addr>::<module_name>::<fn_name>) name.
         #[structopt(name = "filter", short = "f", long = "filter")]
         filter: Option<String>,
-
         /// List all tests
         #[structopt(name = "list", short = "l", long = "list")]
         list: bool,
-
         /// Number of threads to use for running tests.
         #[structopt(
             name = "num_threads",
@@ -138,27 +141,24 @@ pub enum PackageCommand {
         /// Report test statistics at the end of testing
         #[structopt(name = "report_statistics", short = "s", long = "statistics")]
         report_statistics: bool,
-
         /// Show the storage state at the end of execution of a failing test
         #[structopt(name = "global_state_on_error", short = "g", long = "state_on_error")]
         report_storage_on_error: bool,
-
         /// Use the stackless bytecode interpreter to run the tests and cross check its results with
         /// the execution result from Move VM.
         #[structopt(long = "stackless")]
         check_stackless_vm: bool,
-
         /// Verbose mode
         #[structopt(long = "verbose")]
         verbose_mode: bool,
-
+        /// Collect coverage information for later use with the various `package coverage` subcommands
         #[structopt(long = "coverage")]
         compute_coverage: bool,
     },
-
+    /// Disassemble the Move bytecode pointed to
     #[structopt(name = "disassemble")]
     BytecodeView {
-        /// If set will start a disassembled bytecode-to-source explorer
+        /// Start a disassembled bytecode-to-source explorer
         #[structopt(long = "interactive")]
         interactive: bool,
         /// The package name. If not provided defaults to current package modules only

--- a/language/tools/move-package/src/lib.rs
+++ b/language/tools/move-package/src/lib.rs
@@ -35,28 +35,28 @@ pub struct BuildConfig {
     /// Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if
     /// this flag is set. This flag is useful for development of packages that expose named
     /// addresses that are not set to a specific value.
-    #[structopt(name = "dev-mode", short = "d", long = "dev")]
+    #[structopt(name = "dev-mode", short = "d", long = "dev", global = true)]
     pub dev_mode: bool,
 
     /// Compile in 'test' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used
     /// along with any code in the 'test' directory.
-    #[structopt(name = "test-mode", short = "t", long = "test")]
+    #[structopt(name = "test-mode", long = "test", global = true)]
     pub test_mode: bool,
 
     /// Generate documentation for packages
-    #[structopt(name = "generate-docs", long = "doc")]
+    #[structopt(name = "generate-docs", long = "doc", global = true)]
     pub generate_docs: bool,
 
     /// Generate ABIs for packages
-    #[structopt(name = "generate-abis", long = "abi")]
+    #[structopt(name = "generate-abis", long = "abi", global = true)]
     pub generate_abis: bool,
 
     /// Installation directory for compiled artifacts. Defaults to current directory.
-    #[structopt(long = "install-dir", parse(from_os_str))]
+    #[structopt(long = "install-dir", parse(from_os_str), global = true)]
     pub install_dir: Option<PathBuf>,
 
     /// Force recompilation of all packages
-    #[structopt(name = "force-recompilation", long = "force", short = "f")]
+    #[structopt(name = "force-recompilation", long = "force", global = true)]
     pub force_recompilation: bool,
 
     /// Additional named address mapping. Useful for tools in rust


### PR DESCRIPTION
This restructures the Move CLI and some of the global arguments to make more sense with a package-based system. This additionally adds and updates documentation throughout the Move CLI and its subcommands. See below for all the different help commands and what they print. 

Examples for top-level, package, and sandbox help messages:

## Top level
```
$ move -h 
move-cli 0.1.0
Package and build system for Move code.

USAGE:
    move [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
    -d, --dev        Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if this flag
                     is set. This flag is useful for development of packages that expose named addresses that are not
                     set to a specific value
        --force      Force recompilation of all packages
        --abi        Generate ABIs for packages
        --doc        Generate documentation for packages
    -h, --help       Prints help information
        --test       Compile in 'test' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used along with
                     any code in the 'test' directory
    -V, --version    Prints version information
    -v               Print additional diagnostics if available

OPTIONS:
        --install-dir <install-dir>    Installation directory for compiled artifacts. Defaults to current directory
    -p, --path <package-path>          Path to a package which the command should be run with respect to [default: .]

SUBCOMMANDS:
    experimental    (Experimental) Run static analyses on Move source or bytecode
    help            Prints this message or the help of the given subcommand(s)
    package         Execute a package command. Executed in the current directory or the closest containing Move
                    package
    sandbox         Execute a sandbox command
```

## Package
```
$ move package -h
move-package 0.1.0
Execute a package command. Executed in the current directory or the closest containing Move package

USAGE:
    move package [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
    -d, --dev        Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if this flag
                     is set. This flag is useful for development of packages that expose named addresses that are not
                     set to a specific value
        --force      Force recompilation of all packages
        --abi        Generate ABIs for packages
        --doc        Generate documentation for packages
    -h, --help       Prints help information
        --test       Compile in 'test' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used along with
                     any code in the 'test' directory
    -V, --version    Prints version information
    -v               Print additional diagnostics if available

OPTIONS:
        --install-dir <install-dir>    Installation directory for compiled artifacts. Defaults to current directory
    -p, --path <package-path>          Path to a package which the command should be run with respect to [default: .]

SUBCOMMANDS:
    build          Build the package at `path`. If no path is provided defaults to current directory
    coverage       Inspect test coverage for this package. A previous test run with the `--coverage` flag must have
                   previously been run
    disassemble    Disassemble the Move bytecode pointed to
    errmap         Generate error map for the package and its dependencies at `path` for use by the Move explanation
                   tool
    help           Prints this message or the help of the given subcommand(s)
    info           Print address information
    new            Create a new Move package with name `name` at `path`. If `path` is not provided the package will
                   be created in the directory `name`
    prove          Run the Move Prover on the package at `path`. If no path is provided defaults to current
                   directory. Use `.. prove .. -- <options>` to pass on options to the prover
    test           Run Move unit tests in this package

```

## Sandbox
``` 
$ move sandbox -h
move-sandbox 0.1.0
Execute a sandbox command

USAGE:
    move sandbox [FLAGS] [OPTIONS] <SUBCOMMAND>

FLAGS:
    -d, --dev        Compile in 'dev' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used if this flag
                     is set. This flag is useful for development of packages that expose named addresses that are not
                     set to a specific value
        --force      Force recompilation of all packages
        --abi        Generate ABIs for packages
        --doc        Generate documentation for packages
    -h, --help       Prints help information
        --test       Compile in 'test' mode. The 'dev-addresses' and 'dev-dependencies' fields will be used along with
                     any code in the 'test' directory
    -V, --version    Prints version information
    -v               Print additional diagnostics if available

OPTIONS:
        --install-dir <install-dir>    Installation directory for compiled artifacts. Defaults to current directory
    -p, --path <package-path>          Path to a package which the command should be run with respect to [default: .]
        --storage-dir <storage-dir>    Directory storing Move resources, events, and module bytecodes produced by module
                                       publishing and script execution [default: storage]

SUBCOMMANDS:
    clean       Delete all resources, events, and modules stored on disk under `storage-dir`. Does *not* delete
                anything in `src`
    doctor      Run well-formedness checks on the `storage-dir` and `install-dir` directories
    exp-test    Run expected value tests using the given batch file
    generate    Generate struct layout bindings for the modules stored on disk under `storage-dir`
    help        Prints this message or the help of the given subcommand(s)
    publish     Compile the modules in this package and its dependencies and publish the resulting bytecodes in
                global storage
    run         Run a Move script that reads/writes resources stored on disk in `storage-dir`. The script must be
                defined in the package
    view        View Move resources, events files, and modules stored on disk

```