### PR TITLE
[shuffle] run deno lint on any change to ^shuffle

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -114,7 +114,7 @@ jobs:
         name: find shell/dockerfile changes
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
-          pattern: 'Dockerfile$\|.*.sh$\|^developers.diem.com'
+          pattern: 'Dockerfile$\|.*.sh$\|^developers.diem.com\|^shuffle'
       - id: helm-changes
         name: find helm changes
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Trigger `non-rust-lint` jobs on any changes inside ^shuffle so we pick up malformed TS.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI

CI fails on unlinted file prior to https://github.com/diem/diem/pull/9909

<img width="1212" alt="CleanShot 2021-12-01 at 13 11 25@2x" src="https://user-images.githubusercontent.com/635121/144314663-2dd0787c-c7fe-4ee7-9533-43e9bdce2bba.png">


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
