### PR TITLE
RFC: [shuffle] add job to CI for coverage on .ts,.move changes

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -36,6 +36,7 @@ jobs:
       test-docker-compose: ${{ steps.docker-compose-changes.outputs.changes-found }}
       test-test-coverage: ${{ steps.test-coverage.outputs.changes-found }}
       test-api-spec: ${{ steps.test-api-spec.outputs.changes-found }}
+      test-shuffle: ${{ steps.test-shuffle.outputs.changes-found }}
     steps:
       - uses: actions/checkout@v2.4.0
         with:
@@ -146,6 +147,11 @@ jobs:
         uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
         with:
           pattern: '^api\|^scripts/dev_setup.sh'
+      - id: test-shuffle
+        name: find shuffle changes.
+        uses: diem/actions/matches@faadd16607b77dfa2231a8f366883e01717b3225
+        with:
+          pattern: '^shuffle\|^scripts/dev_setup.sh\|^api'
 
   dev-setup-sh-test:
     runs-on: ubuntu-20.04-xl
@@ -951,6 +957,21 @@ jobs:
       - name:
         working-directory: api
         run: make test
+
+  shuffle_test:
+    name: shuffle test
+    runs-on: ubuntu-20.04
+    needs: prepare
+    if: ${{ needs.prepare.outputs.test-shuffle == 'true' }}
+    container:
+      image: ghcr.io/diem/diem_build_environment:${{ needs.prepare.outputs.changes-target-branch }}
+      volumes:
+        - "${{github.workspace}}:/opt/git/diem"
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: ./.github/actions/build-setup
+      - name:
+        run: $pre_command && cargo nextest -p shuffle --jobs ${max_threads} --tries ${nextest_tries}
 
   # Compile (but don't run) the benchmarks, to insulate against bit rot
   build-benchmarks:


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

PRs that don't contain .rs files don't trigger `cargo test -p shuffle`, which we need because it runs CLI and forge integration tests when .ts and .move files are modified.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

This CI

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
