### PR TITLE
[api] add block timestamp to UserTransaction response

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -1088,6 +1088,7 @@ components:
         - required:
             - type
             - events
+            - timestamp
           properties:
             type:
               type: string
@@ -1096,6 +1097,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/Event'
+            timestamp:
+              $ref: '#/components/schemas/TimestampUsec'
         - $ref: '#/components/schemas/UserTransactionRequest'
         - $ref: '#/components/schemas/UserTransactionSignature'
         - $ref: '#/components/schemas/OnChainTransactionInfo'

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -117,6 +117,10 @@ impl Context {
         Ok(account_state_blob)
     }
 
+    pub fn get_block_timestamp(&self, version: u64) -> Result<u64> {
+        self.db.get_block_timestamp(version)
+    }
+
     pub fn get_transactions(
         &self,
         start_version: u64,

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -327,6 +327,7 @@ async fn test_get_transactions_output_user_transaction_with_script_function_payl
                 "public_key": format!("0x{}", hex::encode(public_key.unvalidated().to_bytes())),
                 "signature": format!("0x{}", hex::encode(sig.to_bytes())),
             },
+            "timestamp": metadata_txn.timestamp_usec().to_string(),
         }),
     )
 }

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -4,9 +4,8 @@
 use crate::{
     Bytecode, DirectWriteSet, Event, HexEncodedBytes, MoveFunction, MoveModuleBytecode,
     MoveResource, MoveScriptBytecode, MoveType, MoveValue, ScriptFunctionId, ScriptFunctionPayload,
-    ScriptPayload, ScriptWriteSet, Transaction, TransactionData, TransactionInfo,
-    TransactionOnChainData, TransactionPayload, UserTransactionRequest, WriteSet, WriteSetChange,
-    WriteSetPayload,
+    ScriptPayload, ScriptWriteSet, Transaction, TransactionInfo, TransactionOnChainData,
+    TransactionPayload, UserTransactionRequest, WriteSet, WriteSetChange, WriteSetPayload,
 };
 use diem_transaction_builder::error_explain;
 use diem_types::{
@@ -72,18 +71,9 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
         Ok((txn, payload).into())
     }
 
-    pub fn try_into_transaction<T: TransactionInfoTrait>(
-        &self,
-        data: TransactionData<T>,
-    ) -> Result<Transaction> {
-        match data {
-            TransactionData::OnChain(txn) => self.try_into_onchain_transaction(txn),
-            TransactionData::Pending(txn) => self.try_into_pending_transaction(*txn),
-        }
-    }
-
     pub fn try_into_onchain_transaction<T: TransactionInfoTrait>(
         &self,
+        timestamp: u64,
         data: TransactionOnChainData<T>,
     ) -> Result<Transaction> {
         use diem_types::transaction::Transaction::*;
@@ -92,7 +82,7 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
         Ok(match data.transaction {
             UserTransaction(txn) => {
                 let payload = self.try_into_transaction_payload(txn.payload().clone())?;
-                (&txn, info, payload, events).into()
+                (&txn, info, payload, events, timestamp).into()
             }
             GenesisTransaction(write_set) => {
                 let payload = self.try_into_write_set_payload(write_set)?;

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -48,7 +48,7 @@ impl TryFrom<AnnotatedMoveStruct> for MoveResource {
 }
 
 #[derive(Clone, Debug, PartialEq, Copy)]
-pub struct U64(u64);
+pub struct U64(pub u64);
 
 impl U64 {
     pub fn inner(&self) -> &u64 {

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -103,6 +103,17 @@ pub enum Transaction {
     BlockMetadataTransaction(BlockMetadataTransaction),
 }
 
+impl Transaction {
+    pub fn timestamp(&self) -> u64 {
+        match self {
+            Transaction::UserTransaction(txn) => txn.timestamp.0,
+            Transaction::BlockMetadataTransaction(txn) => txn.timestamp.0,
+            Transaction::PendingTransaction(_) => 0,
+            Transaction::GenesisTransaction(_) => 0,
+        }
+    }
+}
+
 impl From<(SignedTransaction, TransactionPayload)> for Transaction {
     fn from((txn, payload): (SignedTransaction, TransactionPayload)) -> Self {
         Transaction::PendingTransaction(PendingTransaction {
@@ -118,20 +129,23 @@ impl
         TransactionInfo,
         TransactionPayload,
         Vec<Event>,
+        u64,
     )> for Transaction
 {
     fn from(
-        (txn, info, payload, events): (
+        (txn, info, payload, events, timestamp): (
             &SignedTransaction,
             TransactionInfo,
             TransactionPayload,
             Vec<Event>,
+            u64,
         ),
     ) -> Self {
         Transaction::UserTransaction(Box::new(UserTransaction {
             info,
             request: (txn, payload).into(),
             events,
+            timestamp: timestamp.into(),
         }))
     }
 }
@@ -204,6 +218,7 @@ pub struct UserTransaction {
     #[serde(flatten)]
     pub request: UserTransactionRequest,
     pub events: Vec<Event>,
+    pub timestamp: U64,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/shuffle/move/examples/main/client.ts
+++ b/shuffle/move/examples/main/client.ts
@@ -172,6 +172,7 @@ export interface UserTransaction extends UserTransactionRequest {
   gas_used: string;
   success: boolean;
   vm_status: string;
+  timestamp: string;
 }
 
 export interface GenesisTransaction {


### PR DESCRIPTION
## Motivation
#9193 
It becomes problematic when a client want to know what is user transaction execution timestamp and user transaction itself doesn't contain the timestamp.
Client need to find the metadata block transaction for the user transaction to know the timestamp.
It is also an early feedback for json-rpc api `get_transaction`, as it does not return timestamp for the transaction and requires client to call `get_metadata` method to get transaction timestamp.

## Test Plan

unit tests.
