### PR TITLE
[api] GET /transactions should return last page by default

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -215,8 +215,13 @@ impl Transactions {
 
     pub fn list(self, page: Page) -> Result<impl Reply, Error> {
         let ledger_version = self.ledger_info.version();
-        let start_version = page.start(ledger_version, ledger_version)?;
         let limit = page.limit()?;
+        let last_page_start = if ledger_version > (limit as u64) {
+            ledger_version - (limit as u64)
+        } else {
+            0
+        };
+        let start_version = page.start(last_page_start, ledger_version)?;
 
         let data = self
             .context

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -436,6 +436,8 @@ impl fmt::Display for MoveType {
     }
 }
 
+// Implementation is imperfect, only parses type tags,
+// can't parse generic type params and references.
 impl FromStr for MoveType {
     type Err = anyhow::Error;
 
@@ -450,6 +452,8 @@ impl Serialize for MoveType {
     }
 }
 
+// Implementation is imperfect, only parses type tags,
+// can't parse generic type params and references.
 impl<'de> Deserialize<'de> for MoveType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -781,6 +785,9 @@ impl From<&AbilitySet> for MoveFunctionGenericTypeParam {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MoveModuleBytecode {
     pub bytecode: HexEncodedBytes,
+    // We don't need deserialize MoveModule as it should be serialized
+    // from `bytecode`.
+    #[serde(skip_deserializing)]
     pub abi: Option<MoveModule>,
 }
 
@@ -814,6 +821,9 @@ impl From<Module> for MoveModuleBytecode {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MoveScriptBytecode {
     pub bytecode: HexEncodedBytes,
+    // We don't need deserialize MoveModule as it should be serialized
+    // from `bytecode`.
+    #[serde(skip_deserializing)]
     pub abi: Option<MoveFunction>,
 }
 

--- a/shuffle/move/examples/integration/devapi.test.ts
+++ b/shuffle/move/examples/integration/devapi.test.ts
@@ -20,7 +20,7 @@ Deno.test("sequenceNumber", async () => {
 
 Deno.test("transactions", async () => {
   const actual = await devapi.transactions();
-  assertEquals(actual.length, 1);
+  assert(actual.length > 0);
   assert(actual[0].success);
 });
 


### PR DESCRIPTION
## Motivation

#9193 

Current behavior is return last one transaction as we set default `start` param to latest ledger version.

Return one transaction causes an impression there is only one transaction on-chain.

Return last page is a more general convention that is used by most of services when there is pagination for resources.


## Test Plan

Unit test

