### PR TITLE
[shuffle] add strong typing to typescript SDK and invokeScriptFunction

### DIFF
--- a/shuffle/move/examples/e2e/message.test.ts
+++ b/shuffle/move/examples/e2e/message.test.ts
@@ -10,7 +10,6 @@ import {
 import * as devapi from "../main/devapi.ts";
 import * as main from "../main/mod.ts";
 import * as context from "../main/context.ts";
-import * as helpers from "../main/helpers.ts";
 
 Deno.test("Test Assert", () => {
   assert("Hello");
@@ -54,7 +53,7 @@ Deno.test("Ability to set NFTs", async () => {
 
   // Transfer TestNFT from sender to receiver
   const creator = nfts[0].id.id.addr;
-  const creationNum = new helpers.StringLiteral(nfts[0].id.id.creation_num);
+  const creationNum = nfts[0].id.id.creation_num;
 
   let transferTxn = await main.transferNFTScriptFunction(
     secondUserContext.address,

--- a/shuffle/move/examples/integration/helpers.test.ts
+++ b/shuffle/move/examples/integration/helpers.test.ts
@@ -8,6 +8,7 @@ import {
 import * as util from "https://deno.land/std@0.85.0/node/util.ts";
 import { defaultUserContext } from "../main/context.ts";
 import * as devapi from "../main/devapi.ts";
+import * as mv from "../main/move.ts";
 import * as helpers from "../main/helpers.ts";
 import * as codegen from "../main/generated/diemStdlib/mod.ts";
 
@@ -16,7 +17,7 @@ Deno.test("invokeScriptFunction", async () => {
   let txn = await helpers.invokeScriptFunction(
     scriptFunction,
     [],
-    ["invoked script function"],
+    [mv.Ascii("invoked script function")],
   );
   txn = await devapi.waitForTransactionCompletion(txn.hash);
   assert(txn.success);
@@ -28,7 +29,6 @@ Deno.test("invokeScriptFunction", async () => {
     "invoked script function",
   );
 });
-
 
 Deno.test("buildAndSubmitTransaction with generated code", async () => {
   const textEncoder = new util.TextEncoder();

--- a/shuffle/move/examples/main/mod.ts
+++ b/shuffle/move/examples/main/mod.ts
@@ -12,8 +12,8 @@ import {
   UserContext,
 } from "./context.ts";
 import * as devapi from "./devapi.ts";
+import * as mv from "./move.ts";
 import { green } from "https://deno.land/x/nanocolors@0.1.12/mod.ts";
-import { StringLiteral } from "./helpers.ts";
 
 await printWelcome();
 
@@ -50,9 +50,9 @@ export async function setMessageScriptFunction(
   return await invokeScriptFunction(
     "Message::set_message",
     [],
-    [message],
+    [mv.Ascii(message)],
     sender,
-    moduleAddress
+    moduleAddress,
   );
 }
 
@@ -66,9 +66,9 @@ export async function createTestNFTScriptFunction(
   return await invokeScriptFunction(
     "TestNFT::create_nft",
     [],
-    [contentUri],
+    [mv.Ascii(contentUri)],
     sender,
-    moduleAddress
+    moduleAddress,
   );
 }
 
@@ -77,7 +77,7 @@ export async function createTestNFTScriptFunction(
 export async function transferNFTScriptFunction(
   to: string,
   creator: string,
-  creationNum: StringLiteral,
+  creationNum: string,
   sender?: UserContext,
   moduleAddress?: string,
 ) {
@@ -86,9 +86,9 @@ export async function transferNFTScriptFunction(
   return await invokeScriptFunction(
     "NFTStandard::transfer",
     [`${moduleAddress}::TestNFT::TestNFT`],
-    [to, creator, creationNum],
+    [mv.Address(to), mv.Address(creator), mv.U64(creationNum)],
     sender,
-    moduleAddress
+    moduleAddress,
   );
 }
 
@@ -106,14 +106,14 @@ export async function initializeNFTScriptFunction(
     [`${moduleAddress}::TestNFT::TestNFT`],
     [],
     sender,
-    moduleAddress
+    moduleAddress,
   );
 }
 
 async function invokeScriptFunction(
   funcName: string,
   typeArgs: string[],
-  args: any[],
+  args: mv.MoveType[],
   sender?: UserContext,
   moduleAddress?: string,
 ) {
@@ -125,7 +125,7 @@ async function invokeScriptFunction(
     `${moduleAddress}::${funcName}`,
     typeArgs,
     args,
-  )
+  );
 }
 
 export async function decodedMessages(addr?: string) {

--- a/shuffle/move/examples/main/move.ts
+++ b/shuffle/move/examples/main/move.ts
@@ -1,0 +1,96 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Javascript/Typescript has a very loose type system, resulting in ambiguity
+ * when trying to encode string values for onchain Move programs, a space that
+ * has a very strong type system.
+ *
+ * Let's look at two examples:
+ * 1)
+ * invokeScriptFunction("0xDEADBEEF::Module::set_u64", [], ["9"]);
+ * invokeScriptFunction("0xDEADBEEF::Module::set_ascii", [], ["9"]);
+ *
+ * In set_u64 , we want "9" to remain a string, because javascript does
+ * not have support for integers, especially of the size u64. The proper encoding
+ * happens in rust in the Dev API.
+ *
+ * In set_ascii, we want to send hex encoded bytes representing ascii on chain,
+ * which would require us to hex encode the bytes representing "9".
+ *
+ * We cannot automatically infer the desired encoding without a signal from
+ * the developer, hence the reason for a type system. *
+ *
+ * invokeScriptFunction("0xDEADBEEF::Module::set_u64", [], [U64("9")]);
+ * invokeScriptFunction("0xDEADBEEF::Module::set_ascii", [], [Ascii("9")]);
+ *
+ * * NOTE: We could get the argument type of u64 for the script function
+ * before encoding for this scenario, but please see the next scenario.
+ *
+ * 2)
+ * invokeScriptFunction("0xDEADBEEF::Module::set_ascii", [], ["0xb1e55ed"])
+ * invokeScriptFunction("0xDEADBEEF::Module::set_bytes", [], ["0xb1e55ed"])
+ *
+ * The first invocation, we would like to leave the string as is, the second,
+ * we would like to hex encode.
+ * To solve this, we introduce type signaling:
+ * invokeScriptFunction("0xDEADBEEF::Module::set_ascii", [], [Ascii("0xb1e55ed")])
+ * invokeScriptFunction("0xDEADBEEF::Module::set_bytes", [], [Hex("0xb1e55ed")])
+ *
+ * * NOTE: Both these script functions have argument type of vector<u8>, requiring
+ * client side typing to indicate intent.
+ * @module
+ */
+
+// deno-lint-ignore-file no-explicit-any
+
+import * as util from "https://deno.land/std@0.85.0/node/util.ts";
+
+export class MoveType {
+  constructor(readonly value: string) {}
+  encode(): string {
+    return this.value;
+  }
+}
+
+export class AsciiType extends MoveType {
+  encode(): string {
+    return asciiToHex(this.value);
+  }
+}
+
+export class AddressType extends MoveType {}
+export class HexType extends MoveType {}
+export class U64Type extends MoveType {}
+export class U8Type extends MoveType {}
+
+export function Address(value: string): MoveType {
+  return new AddressType(value);
+}
+
+export function Ascii(value: string): MoveType {
+  return new AsciiType(value);
+}
+
+export function Hex(value: string): MoveType {
+  return new HexType(value);
+}
+
+export function U64(value: string): MoveType {
+  return new U64Type(value);
+}
+
+export function U8(value: string | number): MoveType {
+  return new U8Type(value.toString());
+}
+
+const textEncoder = new util.TextEncoder();
+export function asciiToHex(input: string): string {
+  return bufferToHex(textEncoder.encode(input));
+}
+
+function bufferToHex(buffer: any) {
+  return [...new Uint8Array(buffer)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}


### PR DESCRIPTION
## Motivation

We continue to run into edge cases that prevent us to automatically encode a script function's argument. This PR introduces a type system into the typescript ecosystem to unambiguously encode arguments correctly for their move counterpart.

Examples described below:

```
Javascript/Typescript has a very loose type system, resulting in ambiguity
when trying to encode string values for onchain Move programs, a space that
has a very strong type system.

Let's look at two examples:
1)
invokeScriptFunction("0xDEADBEEF::Module::set_u64", [], ["9"]);
invokeScriptFunction("0xDEADBEEF::Module::set_ascii", [], ["9"]);

In set_u64 , we want "9" to remain a string, because javascript does
not have support for integers, especially of the size u64. The proper encoding
happens in rust in the Dev API.

In set_ascii, we want to send hex encoded bytes representing ascii on chain,
which would require us to hex encode the bytes representing "9".

We cannot automatically infer the desired encoding without a signal from
the developer, hence the reason for a type system. *

invokeScriptFunction("0xDEADBEEF::Module::set_u64", [], [U64("9")]);
invokeScriptFunction("0xDEADBEEF::Module::set_ascii_string", [], [Ascii("9")]);

* NOTE: We could get the argument type of u64 for the script function
before encoding for this scenario, but please see the next scenario.

2)
invokeScriptFunction("0xDEADBEEF::Module::set_ascii_string", [], ["0xb1e55ed"])
invokeScriptFunction("0xDEADBEEF::Module::set_bytes", [], ["0xb1e55ed"])

The first invocation, we would like to leave the string as is, the second,
we would like to hex encode.

To solve this, we introduce type signaling:
invokeScriptFunction("0xDEADBEEF::Module::set_ascii_string", [], [Ascii("0xb1e55ed")])
invokeScriptFunction("0xDEADBEEF::Module::set_bytes", [], [Hex("0xb1e55ed")])

* NOTE: Both these script functions have argument type of vector<u8>, requiring
client side typing to indicate intent.
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

1. Existing CI
2. `cargo test -p shuffle`
