### PR TITLE
[forge] state-sync performance test in Forge

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -13,6 +13,7 @@ use testcases::{
     compatibility_test::SimpleValidatorUpgrade, fixed_tps_test::FixedTpsTest,
     gas_price_test::NonZeroGasPrice, generate_traffic, partial_nodes_down_test::PartialNodesDown,
     performance_test::PerformanceBenchmark, reconfiguration_test::ReconfigurationTest,
+    state_sync_performance::StateSyncPerformance,
 };
 use url::Url;
 
@@ -350,6 +351,7 @@ fn pre_release_suite() -> ForgeConfig<'static> {
             &NonZeroGasPrice,
             &PartialNodesDown,
             &ReconfigurationTest,
+            &StateSyncPerformance,
         ])
 }
 

--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -230,6 +230,15 @@ impl Node for LocalNode {
     fn health_check(&mut self) -> Result<(), HealthCheckError> {
         self.health_check()
     }
+
+    fn counter(&self, _counter: &str, _port: u64) -> Result<f64> {
+        todo!()
+    }
+
+    // local node does not need to expose metric end point
+    fn expose_metric(&self) -> Result<u64> {
+        Ok(0)
+    }
 }
 
 impl Validator for LocalNode {}

--- a/testsuite/forge/src/interface/node.rs
+++ b/testsuite/forge/src/interface/node.rs
@@ -67,6 +67,10 @@ pub trait Node {
 
     /// Performs a Health Check on the Node
     fn health_check(&mut self) -> Result<(), HealthCheckError>;
+
+    fn counter(&self, counter: &str, port: u64) -> Result<f64>;
+
+    fn expose_metric(&self) -> Result<u64>;
 }
 
 /// Trait used to represent a running Validator

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -7,6 +7,7 @@ pub mod gas_price_test;
 pub mod partial_nodes_down_test;
 pub mod performance_test;
 pub mod reconfiguration_test;
+pub mod state_sync_performance;
 
 use diem_sdk::{
     client::Client as JsonRpcClient, transaction_builder::TransactionFactory, types::PeerId,

--- a/testsuite/testcases/src/state_sync_performance.rs
+++ b/testsuite/testcases/src/state_sync_performance.rs
@@ -1,0 +1,110 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::generate_traffic;
+use forge::{NetworkContext, NetworkTest, NodeExt, Result, Test};
+use rand::{
+    rngs::{OsRng, StdRng},
+    seq::IteratorRandom,
+    Rng, SeedableRng,
+};
+use std::{thread, time::Instant};
+use tokio::time::Duration;
+
+const STATE_SYNC_COMMITTED_COUNTER_NAME: &str = "diem_state_sync_version.synced";
+
+pub struct StateSyncPerformance;
+
+impl Test for StateSyncPerformance {
+    fn name(&self) -> &'static str {
+        "StateSyncPerformance"
+    }
+}
+
+impl NetworkTest for StateSyncPerformance {
+    fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()> {
+        let mut rng = StdRng::from_seed(OsRng.gen());
+        let duration = Duration::from_secs(30);
+        let all_validators = ctx
+            .swarm()
+            .validators()
+            .map(|v| v.peer_id())
+            .collect::<Vec<_>>();
+        let all_fullnodes = ctx
+            .swarm()
+            .full_nodes()
+            .map(|v| v.peer_id())
+            .collect::<Vec<_>>();
+
+        // 1. pick one fullnode to stop
+        let fullnode_id = all_fullnodes.iter().choose(&mut rng).unwrap();
+        ctx.swarm().full_node_mut(*fullnode_id).unwrap().stop()?;
+
+        // 2. emit txn to validators
+        generate_traffic(ctx, &all_validators, duration, 0, None)?;
+
+        // 3. read the validator synced version
+        let validator_id = all_validators.iter().choose(&mut rng).unwrap();
+        let validator = ctx.swarm().validator(*validator_id).unwrap();
+        let validator_metric_port = validator.expose_metric()?;
+        let validator_synced_version = validator
+            .counter(STATE_SYNC_COMMITTED_COUNTER_NAME, validator_metric_port)
+            .unwrap_or(0.0);
+        if validator_synced_version == 0.0 {
+            return Err(anyhow::format_err!(
+                "Validator synced zero transactions! Something has gone wrong!"
+            ));
+        }
+        println!(
+            "The validator is now synced at version: {}",
+            validator_synced_version
+        );
+
+        // 4. restart the fullnode so that it starts state syncing to catch up
+        let fullnode = ctx.swarm().full_node_mut(*fullnode_id).unwrap();
+        // do data cleanup
+        fullnode.clear_storage()?;
+        println!("The fullnode is going to restart");
+        fullnode.start()?;
+        fullnode.wait_until_healthy(Instant::now() + Duration::from_secs(60))?;
+        println!(
+            "The fullnode is now up. Waiting for it to state sync to the expected version: {}",
+            validator_synced_version
+        );
+        let start_instant = Instant::now();
+        let fullnode_metric_port = fullnode.expose_metric()?;
+        while fullnode
+            .counter(STATE_SYNC_COMMITTED_COUNTER_NAME, fullnode_metric_port)
+            .unwrap_or(0.0)
+            < validator_synced_version
+        {
+            thread::sleep(Duration::from_secs(1));
+        }
+        println!(
+            "The fullnode has caught up to version: {}",
+            validator_synced_version
+        );
+
+        // Calculate the state sync throughput
+        let time_to_state_sync = start_instant.elapsed().as_secs();
+        if time_to_state_sync == 0 {
+            return Err(anyhow::format_err!(
+                "The time taken to state sync was 0 seconds! Something has gone wrong!"
+            ));
+        }
+        let state_sync_throughput = validator_synced_version as u64 / time_to_state_sync;
+        let state_sync_throughput_message =
+            format!("State sync throughput : {} txn/sec", state_sync_throughput,);
+        println!("Time to state sync: {:?} secs", time_to_state_sync);
+        // Display the state sync throughput and report the results
+        println!("{}", state_sync_throughput_message);
+        ctx.report.report_text(state_sync_throughput_message);
+        ctx.report.report_metric(
+            self.name(),
+            "state_sync_throughput",
+            state_sync_throughput as f64,
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

```
The fullnode has caught up to version: 77386
Time to state sync 30
State sync throughput : 2579 txn/sec
test StateSyncPerformance ... ok
Test Statistics: 
State sync throughput : 2579 txn/sec
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
