### PR TITLE
[read-write-set] Trim the inference result for a better performance

### DIFF
--- a/diem-move/vm-genesis/src/lib.rs
+++ b/diem-move/vm-genesis/src/lib.rs
@@ -126,6 +126,7 @@ pub fn encode_genesis_change_set(
             read_write_set::analyze(&stdlib_modules)
                 .expect("Failed to get ReadWriteSet for current Diem Framework")
                 .normalize_all_scripts(diem_vm::read_write_set_analysis::add_on_functions_list())
+                .trim()
                 .into_inner(),
         ))
         .expect("Failed to serialize analyze result");

--- a/diem-move/writeset-transaction-generator/src/admin_script_builder.rs
+++ b/diem-move/writeset-transaction-generator/src/admin_script_builder.rs
@@ -139,6 +139,7 @@ pub fn encode_enable_parallel_execution_with_config() -> WriteSetPayload {
         analyze(diem_framework_releases::current_modules())
             .expect("Failed to get ReadWriteSet for current Diem Framework")
             .normalize_all_scripts(diem_vm::read_write_set_analysis::add_on_functions_list())
+            .trim()
             .into_inner(),
     ))
     .expect("Failed to serialize analyze result");

--- a/language/e2e-testsuite/src/tests/parallel_execution.rs
+++ b/language/e2e-testsuite/src/tests/parallel_execution.rs
@@ -36,7 +36,8 @@ fn peer_to_peer_with_prologue_parallel() {
 
     let analyze_result = analyze(current_modules().iter())
         .unwrap()
-        .normalize_all_scripts(add_on_functions_list());
+        .normalize_all_scripts(add_on_functions_list())
+        .trim();
 
     let mut txns = transfer_txns
         .into_iter()

--- a/language/tools/read-write-set/dynamic/src/normalize.rs
+++ b/language/tools/read-write-set/dynamic/src/normalize.rs
@@ -22,6 +22,28 @@ impl NormalizedReadWriteSetAnalysis {
         Self(inner)
     }
 
+    /// Trim the analysis result by dropping all the results in the trie. This should not affect the
+    /// correctness for those non secondary index access as all relevant info should be stored in
+    /// the root node already. Trimming the result will yield a higher inference speed at runtime.
+    pub fn trim(&self) -> Self {
+        Self(
+            self.0
+                .iter()
+                .map(|(module_id, func_map)| {
+                    (
+                        module_id.clone(),
+                        func_map
+                            .iter()
+                            .map(|(func_name, analysis_result)| {
+                                (func_name.clone(), analysis_result.trim())
+                            })
+                            .collect(),
+                    )
+                })
+                .collect(),
+        )
+    }
+
     fn get_summary(&self, module: &ModuleId, fun: &IdentStr) -> Option<&ReadWriteSet> {
         self.0.get(module)?.get(fun)
     }

--- a/language/tools/read-write-set/types/src/lib.rs
+++ b/language/tools/read-write-set/types/src/lib.rs
@@ -177,6 +177,23 @@ impl ReadWriteSet {
         Self(BTreeMap::new())
     }
 
+    pub fn trim(&self) -> Self {
+        Self(
+            self.0
+                .iter()
+                .map(|(root, node)| {
+                    (
+                        root.clone(),
+                        TrieNode {
+                            data: node.get_access(),
+                            children: BTreeMap::new(),
+                        },
+                    )
+                })
+                .collect(),
+        )
+    }
+
     pub fn add_access_path(&mut self, access_path: AccessPath, access: Access) {
         let mut node = self.0.entry(access_path.root).or_insert_with(TrieNode::new);
         for offset in access_path.offsets {


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Trim the analysis result by removing the child information (i.e: struct field access information). This will offer a better performance since we are not resolving those secondary index information anyway and we don't need those finer grained details at runtime.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan
`cargo test`.

Also this PR will be able to increase the inference speed by 50% on my local benchmarks.