### PR TITLE
[move] Disassemble script code

### DIFF
--- a/language/move-ir-compiler/src/unit_tests/expression_tests.rs
+++ b/language/move-ir-compiler/src/unit_tests/expression_tests.rs
@@ -11,34 +11,6 @@ use move_binary_format::{
 };
 
 #[test]
-fn compile_script_expr_combined() {
-    let code = String::from(
-        "
-        main() {
-            let x: u64;
-            let y: u64;
-            let z: u64;
-        label b0:
-            x = 3;
-            y = 5;
-            z = move(x) + copy(y) * 5 - copy(y);
-            return;
-        }
-        ",
-    );
-    let compiled_script_res = compile_script_string(&code);
-    let compiled_script = compiled_script_res.unwrap();
-    assert_eq!(count_locals(&compiled_script), 3);
-    assert_eq!(compiled_script.code().code.len(), 13);
-    assert!(compiled_script.struct_handles().is_empty());
-    assert_eq!(compiled_script.function_handles().len(), 0);
-    assert_eq!(compiled_script.signatures().len(), 2);
-    assert_eq!(compiled_script.module_handles().len(), 0);
-    assert_eq!(compiled_script.identifiers().len(), 0);
-    assert_eq!(compiled_script.address_identifiers().len(), 0);
-}
-
-#[test]
 fn compile_script_borrow_local() {
     let code = String::from(
         "

--- a/language/move-ir-compiler/transactional-tests/tests/commands/no_let_outside_if.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/commands/no_let_outside_if.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
     foo() {
     label b0:

--- a/language/move-ir-compiler/transactional-tests/tests/commands/no_rebind.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/commands/no_rebind.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
     foo() {
         let x: u64;

--- a/language/move-ir-compiler/transactional-tests/tests/commands/unpack_top_level.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/commands/unpack_top_level.mvir
@@ -9,7 +9,7 @@ module 0x1.Test {
 }
 
 
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
     import 0x1.Test;
 

--- a/language/move-ir-compiler/transactional-tests/tests/comments/multi_line_comment_commented_by_single_line_comment.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/comments/multi_line_comment_commented_by_single_line_comment.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
     foo() {
     label b0:

--- a/language/move-ir-compiler/transactional-tests/tests/comments/multiple_single_line_comments_mixed.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/comments/multiple_single_line_comments_mixed.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
 foo() {
 label b0:

--- a/language/move-ir-compiler/transactional-tests/tests/comments/multiple_single_line_comments_own_line.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/comments/multiple_single_line_comments_own_line.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
 foo() {
 label b0:

--- a/language/move-ir-compiler/transactional-tests/tests/comments/single_line_comment_line.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/comments/single_line_comment_line.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
 foo() {
 label b0:

--- a/language/move-ir-compiler/transactional-tests/tests/comments/single_line_comment_own_line.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/comments/single_line_comment_own_line.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
 foo() {
 label b0:

--- a/language/move-ir-compiler/transactional-tests/tests/expressions/binary_add.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/expressions/binary_add.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0xE.Expressions {
     binary_add() {
         let x: u64;

--- a/language/move-ir-compiler/transactional-tests/tests/expressions/combined.exp
+++ b/language/move-ir-compiler/transactional-tests/tests/expressions/combined.exp
@@ -1,0 +1,27 @@
+processed 1 task
+
+task 0 'print-bytecode'. lines 1-11:
+// Move bytecode v4
+script {
+
+
+main() {
+L0:	loc0: u64
+L1:	loc1: u64
+L2:	loc2: u64
+B0:
+	0: LdU64(3)
+	1: StLoc[0](loc0: u64)
+	2: LdU64(5)
+	3: StLoc[1](loc1: u64)
+	4: MoveLoc[0](loc0: u64)
+	5: CopyLoc[1](loc1: u64)
+	6: LdU64(5)
+	7: Mul
+	8: Add
+	9: CopyLoc[1](loc1: u64)
+	10: Sub
+	11: StLoc[2](loc2: u64)
+	12: Ret
+}
+}

--- a/language/move-ir-compiler/transactional-tests/tests/expressions/combined.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/expressions/combined.mvir
@@ -1,0 +1,11 @@
+//# print-bytecode
+main() {
+    let x: u64;
+    let y: u64;
+    let z: u64;
+label b0:
+    x = 3;
+    y = 5;
+    z = move(x) + copy(y) * 5 - copy(y);
+    return;
+}

--- a/language/move-ir-compiler/transactional-tests/tests/malformed_constructs/function_in_struct.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/malformed_constructs/function_in_struct.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
     struct T{
         x: u64,

--- a/language/move-ir-compiler/transactional-tests/tests/malformed_constructs/modules_not_a_type.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/malformed_constructs/modules_not_a_type.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
     public no(x: Self.M) {
     label b0:

--- a/language/move-ir-compiler/transactional-tests/tests/signer/signer_keyword.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/signer/signer_keyword.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
     // "signer" is a keyword so it cannot be used as a parameter name
     foo(signer: address) {

--- a/language/move-ir-compiler/transactional-tests/tests/struct_defs/field_undefined.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/struct_defs/field_undefined.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
     struct T {
         x: u64

--- a/language/move-ir-compiler/transactional-tests/tests/struct_defs/fields_out_of_order.mvir
+++ b/language/move-ir-compiler/transactional-tests/tests/struct_defs/fields_out_of_order.mvir
@@ -1,4 +1,4 @@
-//# print-bytecode
+//# print-bytecode --input=module
 module 0x1.M {
     struct T {
         x: u64,

--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -4,8 +4,8 @@
 #![forbid(unsafe_code)]
 
 use crate::tasks::{
-    taskify, InitCommand, PrintBytecodeInputChoice, PublishCommand, RawAddress, RunCommand,
-    SyntaxChoice, TaskCommand, TaskInput, ViewCommand, PrintBytecodeCommand,
+    taskify, InitCommand, PrintBytecodeCommand, PrintBytecodeInputChoice, PublishCommand,
+    RawAddress, RunCommand, SyntaxChoice, TaskCommand, TaskInput, ViewCommand,
 };
 use anyhow::{anyhow, Result};
 use move_binary_format::{
@@ -158,8 +158,12 @@ pub trait MoveTestAdapter<'a> {
                 };
                 let data_path = data.path().to_str().unwrap();
                 let compiled = match input {
-                    PrintBytecodeInputChoice::Script => Either::Left(compile_ir_script(state.dep_modules(), data_path)?),
-                    PrintBytecodeInputChoice::Module => Either::Right(compile_ir_module(state.dep_modules(), data_path)?),
+                    PrintBytecodeInputChoice::Script => {
+                        Either::Left(compile_ir_script(state.dep_modules(), data_path)?)
+                    }
+                    PrintBytecodeInputChoice::Module => {
+                        Either::Right(compile_ir_module(state.dep_modules(), data_path)?)
+                    }
                 };
                 let source_mapping = SourceMapping::new_from_view(
                     match &compiled {

--- a/language/testing-infra/transactional-test-runner/src/tasks.rs
+++ b/language/testing-infra/transactional-test-runner/src/tasks.rs
@@ -218,10 +218,21 @@ pub enum SyntaxChoice {
     IR,
 }
 
-/// Translates the given Move IR module into bytecode, then prints a textual representation of that
-/// bytecode.
+/// When printing bytecode, the input program must either be a script or a module.
+#[derive(Debug)]
+pub enum PrintBytecodeInputChoice {
+    Script,
+    Module,
+}
+
+/// Translates the given Move IR module or script into bytecode, then prints a textual
+/// representation of that bytecode.
 #[derive(Debug, StructOpt)]
-pub struct PrintBytecodeCommand {}
+pub struct PrintBytecodeCommand {
+    /// The kind of input: either a script, or a module.
+    #[structopt(long = "input", default_value = "script")]
+    pub input: PrintBytecodeInputChoice,
+}
 
 #[derive(Debug, StructOpt)]
 pub struct InitCommand {
@@ -380,6 +391,20 @@ impl FromStr for SyntaxChoice {
                 "Invalid syntax choice. Expected '{}' or '{}'",
                 MOVE_EXTENSION,
                 MOVE_IR_EXTENSION
+            )),
+        }
+    }
+}
+
+impl FromStr for PrintBytecodeInputChoice {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "script" => Ok(PrintBytecodeInputChoice::Script),
+            "module" => Ok(PrintBytecodeInputChoice::Module),
+            _ => Err(anyhow!(
+                "Invalid input choice. Expected 'script' or 'module'"
             )),
         }
     }

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/print_bytecode.exp
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/print_bytecode.exp
@@ -1,0 +1,20 @@
+processed 2 tasks
+
+task 0 'print-bytecode'. lines 1-5:
+// Move bytecode v4
+script {
+
+
+
+}
+
+task 1 'print-bytecode'. lines 7-13:
+// Move bytecode v4
+module 42.M {
+
+
+f() {
+B0:
+	0: Ret
+}
+}

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/print_bytecode.exp
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/print_bytecode.exp
@@ -5,7 +5,10 @@ task 0 'print-bytecode'. lines 1-5:
 script {
 
 
-
+main<Ty0, Ty1>() {
+B0:
+	0: Ret
+}
 }
 
 task 1 'print-bytecode'. lines 7-13:
@@ -13,7 +16,7 @@ task 1 'print-bytecode'. lines 7-13:
 module 42.M {
 
 
-f() {
+f<Ty0, Ty1>() {
 B0:
 	0: Ret
 }

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/print_bytecode.move
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/print_bytecode.move
@@ -1,0 +1,13 @@
+//# print-bytecode
+main() {
+label b0:
+    return;
+}
+
+//# print-bytecode --input=module
+module 0x42.M {
+    f() {
+    label b0:
+        return;
+    }
+}

--- a/language/testing-infra/transactional-test-runner/tests/vm_test_harness/print_bytecode.move
+++ b/language/testing-infra/transactional-test-runner/tests/vm_test_harness/print_bytecode.move
@@ -1,12 +1,12 @@
 //# print-bytecode
-main() {
+main<T, U>() {
 label b0:
     return;
 }
 
 //# print-bytecode --input=module
 module 0x42.M {
-    f() {
+    f<X, Y>() {
     label b0:
         return;
     }


### PR DESCRIPTION
# [move] Add test option to print script bytecode

Currently the transactional test runner's "print-bytecode" command assumes that the input is a module. This was originally because the disassembler did not support printing a script's bytecode. However, in preparation for adding that support to the disassembler, add an option to have the print-bytecode command treat the input string as a Move IR module or a script.

# [move] Disassemble script code

9a69b3a changed how the disassembler worked for scripts: previously, a compiled script would be transformed into a compiled module, with a function definition that represented its `main` function. After that change, that transformation no longer occurred, and instead code was rewritten to operate on a "binary view," an enum that represented either a script or a module.

However, the code change didn't account for how the disassembler worked: the disassembler iterates over all function definitions in a module, printing out their bytecode. Since the new code no longer created a function definition for a script's main function, the code in the main function was never printed.

This commit changes that, by modifying the disassembler to print out the bytecode for a compiled script.

With this capability in place, it also migrates an additional test from the move-ir-compiler unit test suite, to the move-ir-compiler-transactional-tests suite.