### PR TITLE
[shuffle] add serde feature to url import

### DIFF
--- a/shuffle/cli/Cargo.toml
+++ b/shuffle/cli/Cargo.toml
@@ -23,7 +23,7 @@ structopt = "0.3.21"
 tempfile = "3.2.0"
 tokio = { version = "1.8.1", features = ["full"] }
 toml = "0.5.8"
-url = { version = "2.2.2" }
+url = { version = "2.2.2", features = ["serde"] }
 
 abigen = { path = "../../language/move-prover/abigen" }
 diem-api-types = { path = "../../api/types" }


### PR DESCRIPTION

## Motivation

Fresh compilation on M1 Macs failed because of the following error. Adding the serde feature to the url import fixes the issue.

```
error[E0277]: the trait bound `Url: Serialize` is not satisfied
    --> shuffle/cli/src/shared.rs:371:5
     |
371  |     json_rpc_url: Url,
     |     ^^^^^^^^^^^^ the trait `Serialize` is not implemented for `Url`
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

CI
Fresh compilation on M1