### PR TITLE
[data-client] Add Diem Data Client Config to State Sync Config

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
@@ -30,6 +31,7 @@ pub struct StateSyncConfig {
 
     // Everything above belongs to state sync v1 and will be removed in the future.
     pub data_streaming_service: DataStreamingServiceConfig,
+    pub diem_data_client: DiemDataClientConfig,
     pub state_sync_driver: StateSyncDriverConfig,
     pub storage_service: StorageServiceConfig,
 }
@@ -47,6 +49,7 @@ impl Default for StateSyncConfig {
             sync_request_timeout_ms: 60_000,
             tick_interval_ms: 100,
             data_streaming_service: DataStreamingServiceConfig::default(),
+            diem_data_client: DiemDataClientConfig::default(),
             state_sync_driver: StateSyncDriverConfig::default(),
             storage_service: StorageServiceConfig::default(),
         }
@@ -150,6 +153,22 @@ impl Default for DataStreamingServiceConfig {
             max_request_retry: 10,
             max_notification_id_mappings: 2000,
             progress_check_interval_ms: 100,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default)]
+pub struct DiemDataClientConfig {
+    pub response_timeout_ms: Duration, // Timeout (in milliseconds) when waiting for a response
+    pub summary_poll_interval_ms: Duration, // Interval (in milliseconds) between data summary polls
+}
+
+impl Default for DiemDataClientConfig {
+    fn default() -> Self {
+        Self {
+            response_timeout_ms: Duration::from_millis(3_000),
+            summary_poll_interval_ms: Duration::from_millis(1_000),
         }
     }
 }

--- a/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
+++ b/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
@@ -217,6 +217,7 @@ mod tests {
             PeerMetadataStorage::new(&[]),
         );
         let (diem_data_client, _) = DiemNetDataClient::new(
+            node_config.state_sync.diem_data_client,
             node_config.state_sync.storage_service,
             TimeService::mock(),
             network_client,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Existing Diem data client uses hardcoded values for request timeout and data summary polling. This PR removes these hardcoded values and makes these constants configurable as part of `StateSyncConfig`

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manually test by:

- Changing the default values of `DiemDataClientConfig` in `state_sync_config` and verifying that `DiemNetDataClient` uses these default values if no config file is given. 

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
