### PR TITLE
[move] Language server installation instructions

### DIFF
--- a/language/documentation/tutorial/README.md
+++ b/language/documentation/tutorial/README.md
@@ -41,9 +41,9 @@ Follow the prompt to install all the necessary dependencies.
 ```bash
 $ . ~/.profile
 ````
-- Install Move CLI by running this command in diem repo:
+- Install Move's CLIs by running this command in diem repo:
 ```bash
-$ cargo build -p df-cli
+$ cargo build -p df-cli -p move-analyzer
 ```
 
 Once this is done, you can alias the `move` command to point the `df-cli`
@@ -74,10 +74,11 @@ USAGE:
 If you want to find what commands are available and what they do, running
 a command or subcommand with the `-h` flag will print documentation.
 
-There is official Move support for VSCode, you can install this extension
-by opening VSCode and searching for the "move-analyzer" package and
-installing it. More detailed instructions can be found
-[here](https://github.com/diem/diem/tree/main/language/move-analyzer/editors/code).
+There is official Move support for Visual Studio Code. You can install this
+extension by opening VS Code, searching for the "move-analyzer" package and
+installing it. After installing, open your VS Code settings, search for
+`move-analyzer.server.path`, and set it to `<path_to_diem_repo>/target/debug/move-analyzer`.
+More detailed instructions can be found [here](https://github.com/diem/diem/tree/main/language/move-analyzer/editors/code).
 
 Before running the next steps, `cd` to the tutorial directory:
 ```bash

--- a/language/move-analyzer/editors/code/README.md
+++ b/language/move-analyzer/editors/code/README.md
@@ -3,22 +3,74 @@
 Provides language support for the Move programming language.
 
 Currently, this means a basic grammar and language configuration for Move (`.move`) that enables
-syntax highlighting, commenting/uncommenting, and other basic language features in Move files.
+syntax highlighting, commenting/uncommenting, simple context-unaware completion suggestions while
+typing, and other basic language features in Move files.
 
-For information about Move, Diem, these projects' licenses, their contributor guides,
-and more, visit [the Diem repository](https://github.com/diem/diem).
+For information about Move, Diem, these projects' licenses, their contributor guides, links to our
+Discord server, and more, visit [the Diem repository](https://github.com/diem/diem).
 
-## How to Use
+## How to Install
+
+The move-analyzer Visual Studio Code extension works via two components: the extension itself, and
+the `move-analyzer` language server.
+
+### 1. Installing the `move-analyzer` language server<span id="Step1">
+
+The `move-analyzer` language server is a Rust program that is part of
+[the Diem repository](https://github.com/diem/diem). It may be installed in one of two ways:
+
+1. You may clone [the Diem repository](https://github.com/diem/diem) yourself and build
+   `move-analyzer` from its source code. This is recommended for Diem hackathon participants, and
+   Diem & Move core developers.
+   1. Follow the instructions in the Move tutorial's
+      [Step 0: Installation](https://github.com/diem/diem/tree/main/language/documentation/tutorial#step-0-installation).
+   2. To confirm that you've built the language server program successfully, execute
+      `<path_to_diem_repo>/target/debug/move-analyzer --version` on the command line. You should see
+      the output `move-analyzer 0.0.0`.
+2. You may use Rust's package manager `cargo` to install `move-analyzer` in your user's PATH. This
+   is recommended for people who do not work on Diem & Move core.
+   1. If you don't already have a Rust toolchain installed, you should install
+      [Rustup](https://rustup.rs/), which will install the latest stable Rust toolchain.
+   2. Invoke `cargo install --git https://github.com/diem/diem move-analyzer` to install the
+      `move-analyzer` language server in your Cargo binary directory. On macOS and Linux this is
+      usually `~/.cargo/bin`. You'll want to make sure this location is in your `PATH` environment
+      variable.
+   3. To confirm that you've installed the language server program successfully, execute
+      `move-analyzer --version` on the command line. You should see the output
+      `move-analyzer 0.0.0`.
+
+### 2. Installing the move-analyzer Visual Studio Code extension
 
 1. Open a new window in any Visual Studio Code application version 1.55.2 or greater.
-2. Open the command palette (`⇧⌘P` on macOS, or use the menu item "View > Command Palette...") and type in `"Extensions: Install Extensions"`. This will open a panel named "Extensions" in the sidebar of your Visual Studio Code window.
-3. In the search bar labeled "Search Extensions in Marketplace," type in "move-analyzer". The move-analyzer extension should appear in the list below the search bar. Click "Install".
-4. Open any file that ends in `.move` (or, create a new file, click on "Select a language," and choose the "Move" language). As you type, you should see that keywords and types appear in different colors.
+2. Open the command palette (`⇧⌘P` on macOS, or use the menu item "View > Command Palette...") and
+   type in `"Extensions: Install Extensions"`. This will open a panel named "Extensions" in the
+   sidebar of your Visual Studio Code window.
+3. In the search bar labeled "Search Extensions in Marketplace," type in "move-analyzer". The
+   move-analyzer extension should appear in the list below the search bar. Click "Install".
+4. Open the Visual Studio Code settings (`⌘,` on macOS, or use the menu item "Code > Preferences >
+   Settings"). Search for the `move-analyzer.server.path` setting, and set it to the location of the
+   `move-analyzer` language server you installed above.
+   1. If you used method 1, it should exist at `<path_to_diem_repo>/target/debug/move-analyzer`.
+   2. If you used method 2, it should exist in your `PATH` as `move-analyzer`. This is the default
+      value, so you do not need to edit this setting.
+5. Open any file that ends in `.move` (or, create a new file, click on "Select a language," and
+   choose the "Move" language). As you type, you should see that keywords and types appear in
+   different colors.
+
+**Note:** If you see an error message "language server executable '/path/to/move-analyzer' could not
+be found" in the bottom-right of your Visual Studio Code screen when opening a Move file, it means
+that the `move-analyzer` executable does not exist at the path you specified in your
+`move-analyzer.server.path` setting. Change the setting to point to the location of a
+`move-analyzer` executable you built or installed in [step 1](./Step1).
 
 ## Features
 
-Here are some of the features of the move-analyzer Visual Studio Code extension. Open a file with a `.move` file extension, and:
+Here are some of the features of the move-analyzer Visual Studio Code extension. Open a file with a
+`.move` file extension, and:
 
-* See Move keywords and types highlighted in appropriate colors.
-* Comment and un-comment lines of code using the `⌘/` shortcut on macOS (or the menu command "Edit > Toggle Line Comment").
-* Place your cursor on a delimiter, such as `<`, `(`, or `{`, and its corresponding delimiter -- `>`, `)`, or `}` -- will be highlighted.
+- See Move keywords and types highlighted in appropriate colors.
+- Comment and un-comment lines of code using the `⌘/` shortcut on macOS (or the menu command "Edit >
+  Toggle Line Comment").
+- Place your cursor on a delimiter, such as `<`, `(`, or `{`, and its corresponding delimiter --
+  `>`, `)`, or `}` -- will be highlighted.
+- As you type, Move keywords will appear as completion suggestions.

--- a/language/move-analyzer/editors/code/src/configuration.ts
+++ b/language/move-analyzer/editors/code/src/configuration.ts
@@ -24,7 +24,14 @@ export class Configuration {
 
     /** The path to the move-analyzer executable. */
     get serverPath(): string {
-        const path = this.configuration.get<string>('server.path', 'move-analyzer');
+        const defaultName = 'move-analyzer';
+        const path = this.configuration.get<string>('server.path', defaultName);
+        if (path.length === 0) {
+            // The default value of the `server.path` setting is 'move-analyzer'.
+            // A user may have over-written this default with an empty string value, ''.
+            // An empty string cannot be an executable name, so instead use the default.
+            return defaultName;
+        }
         if (path.startsWith('~/')) {
             return os.homedir() + path.slice('~'.length);
         }

--- a/language/move-analyzer/editors/code/src/context.ts
+++ b/language/move-analyzer/editors/code/src/context.ts
@@ -19,7 +19,12 @@ export class Context {
         configuration: Readonly<Configuration>,
     ): Context | Error {
         if (!fs.existsSync(configuration.serverPath)) {
-            return new Error(`command '${configuration.serverPath}' could not be found.`);
+            return new Error(
+                `language server executable '${configuration.serverPath}' could not be found, so ` +
+                'most extension features will be unavailable to you. Follow the instructions in ' +
+                'the move-analyzer Visual Studio Code extension README to install the language ' +
+                'server.',
+            );
         }
         return new Context(extensionContext, configuration);
     }


### PR DESCRIPTION
The move-analyzer Visual Studio Code extension now increasingly depends on features from the `move-analyzer` language server executable. Add instructions to the VS Code extension's README, and to the Move tutorial, on how to install the language server.

Some other notes:

* I (hopefully) improved the error message user's see when the VS Code extension cannot execute the `move-analyzer` language server at the configured path.
* I formatted the VS Code extension README to fit within a column limit.
* To simplify hackathon installation, I modified the installation instructions in the Move tutorial to also install the `move-analyzer` language server.