### PR TITLE
[State Sync] Remove some dead code from the streaming service.

### DIFF
--- a/state-sync/state-sync-v2/data-streaming-service/src/lib.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/lib.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![forbid(unsafe_code)]
-#![allow(dead_code)]
 
 mod data_notification;
 mod data_stream;

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/stream_engine.rs
@@ -6,12 +6,10 @@ use crate::{
     error::Error,
     stream_engine::{DataStreamEngine, EpochEndingStreamEngine, StreamEngine},
     streaming_client::{GetAllEpochEndingLedgerInfosRequest, StreamRequest},
-    tests::utils::{initialize_logger, NoopResponseCallback},
+    tests::utils::initialize_logger,
 };
 use claim::{assert_matches, assert_ok};
-use diem_data_client::{
-    GlobalDataSummary, OptimalChunkSizes, Response, ResponseContext, ResponsePayload,
-};
+use diem_data_client::{GlobalDataSummary, OptimalChunkSizes, ResponsePayload};
 use diem_id_generator::U64IdGenerator;
 use std::{cmp, sync::Arc};
 use storage_service_types::CompleteDataRange;
@@ -283,12 +281,4 @@ fn create_notification_id_generator() -> Arc<U64IdGenerator> {
 
 fn create_empty_client_response_payload() -> ResponsePayload {
     ResponsePayload::EpochEndingLedgerInfos(vec![])
-}
-
-fn create_empty_client_response() -> Response<ResponsePayload> {
-    let context = ResponseContext {
-        id: 0,
-        response_callback: Box::new(NoopResponseCallback),
-    };
-    Response::new(context, create_empty_client_response_payload())
 }

--- a/state-sync/state-sync-v2/state-sync-multiplexer/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-multiplexer/Cargo.toml
@@ -32,7 +32,7 @@ diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-genesis-tool = {path = "../../../config/management/genesis", features = ["testing"] }
 diem-infallible = { path = "../../../crates/diem-infallible" }
 diem-temppath = { path = "../../../crates/diem-temppath" }
-diem-time-service = { path = "../../../crates/diem-time-service" }
+diem-time-service = { path = "../../../crates/diem-time-service", features = ["async", "testing"] }
 diem-vm = { path = "../../../diem-move/diem-vm" }
 diemdb = { path = "../../../storage/diemdb" }
 executor = { path = "../../../execution/executor" }


### PR DESCRIPTION
## Motivation

This (tiny) PR removes some dead code from the data streaming service. Now that we have it plugged into diem node, there's no need to use `#![allow(dead_code)]`.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Existing unit tests cover this functionality.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906