### PR TITLE
[api] decode Move ASCII::String type as JSON string

### DIFF
--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -1406,7 +1406,7 @@ components:
           * `vector<u64>{255, 255}` => `["255", "255"]`
           * `vector<u8>{255, 255}` => `0xffff`
 
-        Move `struct` type value is serialized into `object` that looks like this:
+        Move `struct` type value is serialized into `object` that looks like this (except some Move stdlib types, see the following section):
 
           ```json
           {
@@ -1418,6 +1418,10 @@ components:
 
         For example:
           `{ "created": "0xa550c18", "role_id": "0" }`
+
+        **Special serialization for Move stdlib types:**
+
+        * [0x1::ASCII::String](https://github.com/diem/diem/blob/main/language/move-stdlib/docs/ASCII.md) is serialized into `string`. For example, struct value `0x1::ASCII::String{bytes: b"hello world"}` is serialized as `"hello world"` in JSON.
 
       example: "3344000000"
     Event:

--- a/api/src/tests/mod.rs
+++ b/api/src/tests/mod.rs
@@ -5,6 +5,7 @@ mod accounts_test;
 mod events_test;
 mod index_test;
 mod invalid_post_request_test;
+mod string_resource_test;
 mod test_context;
 mod transactions_test;
 

--- a/api/src/tests/string_resource_test.rs
+++ b/api/src/tests/string_resource_test.rs
@@ -1,0 +1,64 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::tests::new_test_context;
+
+use diem_api_types::Address;
+use diem_crypto::ed25519::Ed25519PrivateKey;
+use diem_sdk::types::LocalAccount;
+use serde_json::json;
+
+use std::convert::TryInto;
+
+#[tokio::test]
+async fn test_renders_move_acsii_string_into_utf8_string() {
+    let context = new_test_context();
+    let mut account = init_test_account();
+    let txn = context.create_parent_vasp(&account);
+    context.commit_block(&vec![txn]).await;
+
+    // module 0x87342d91af60c3a883a2812c9294c2f8::Message {
+    //     use Std::ASCII;
+    //     struct MessageHolder has key {
+    //         message: ASCII::String,
+    //     }
+    //     public(script) fun set_message(account: signer, msg: vector<u8>) {
+    //         let message = ASCII::string(msg);
+    //         move_to(&account, MessageHolder {
+    //             message,
+    //         });
+    //     }
+    // }
+    let module_code = "0xa11ceb0b0400000008010004020408030c0a05160b07213e085f200a7f060c85011500000101000208000105070000030001000106030200020c0a0200010801010a02074d6573736167650541534349490d4d657373616765486f6c6465720b7365745f6d657373616765076d65737361676506537472696e6706737472696e6787342d91af60c3a883a2812c9294c2f8000000000000000000000000000000010002010408010002000002080b0111010c020e000b0212002d000200";
+    context
+        .api_publish_module(&mut account, module_code.parse().unwrap())
+        .await;
+
+    context
+        .api_execute_script_function(
+            &mut account,
+            "Message::set_message",
+            json!([]),
+            json!([hex::encode(b"hello world")]),
+        )
+        .await;
+
+    let message = context
+        .api_get_account_resource(
+            &account,
+            format!(
+                "{}::Message::MessageHolder",
+                account.address().to_hex_literal()
+            ),
+        )
+        .await;
+    assert_eq!("hello world", message["data"]["message"]);
+}
+
+fn init_test_account() -> LocalAccount {
+    let key_bytes =
+        hex::decode("a38ba78b1a0fbfc55e2c5dfdedf48d1172283d0f7c59fd64c02d811130a2f4b2").unwrap();
+    let private_key: Ed25519PrivateKey = (&key_bytes[..]).try_into().unwrap();
+    let address: Address = "87342d91af60c3a883a2812c9294c2f8".parse().unwrap();
+    LocalAccount::new(address.into(), private_key, 0)
+}

--- a/shuffle/cli/tutorials/HelloBlockchain.md
+++ b/shuffle/cli/tutorials/HelloBlockchain.md
@@ -145,6 +145,7 @@ successfully
 ```
 > await devapi.accountTransactions()
 [
+  ......
   {
     type: "user_transaction",
     version: "255",
@@ -214,14 +215,14 @@ Print all the resources in an account
   {
     type: "0x825b47b8fd2b30cf37c0e58579a78bc8::Message::MessageHolder",
     data: {
-      message: "0x68656c6c6f20626c6f636b636861696e",
+      message: "hello blockchain",
       message_change_events: { counter: "0", guid: [Object] }
     }
   }
 ]
 ```
 
-Use decodedMessages to check that message was set to "hello blockchain"
+Use decodedMessages to check account message:
 
 ```
 > await main.decodedMessages()

--- a/shuffle/move/examples/main/mod.ts
+++ b/shuffle/move/examples/main/mod.ts
@@ -134,7 +134,7 @@ async function invokeScriptFunction(
 export async function decodedMessages(addr?: string) {
   addr = addressOrDefault(addr);
   return (await devapi.resourcesWithName("MessageHolder", addr))
-    .map((entry) => DiemHelpers.hexToAscii(entry.data.message));
+    .map((entry) => entry.data.message);
 }
 
 export async function decodedNFTs(addr?: string) {

--- a/shuffle/move/examples/main/sources/Message.move
+++ b/shuffle/move/examples/main/sources/Message.move
@@ -2,26 +2,28 @@ module Sender::Message {
     use Std::Errors;
     use Std::Event;
     use Std::Signer;
+    use Std::ASCII;
 
     struct MessageHolder has key {
-        message: vector<u8>,
+        message: ASCII::String,
         message_change_events: Event::EventHandle<MessageChangeEvent>,
     }
     struct MessageChangeEvent has drop, store {
-        from_message: vector<u8>,
-        to_message: vector<u8>,
+        from_message: ASCII::String,
+        to_message: ASCII::String,
     }
 
     /// There is no message present
     const ENO_MESSAGE: u64 = 0;
 
-    public fun get_message(addr: address): vector<u8> acquires MessageHolder {
+    public fun get_message(addr: address): ASCII::String acquires MessageHolder {
         assert!(exists<MessageHolder>(addr), Errors::not_published(ENO_MESSAGE));
         *&borrow_global<MessageHolder>(addr).message
     }
 
-    public(script) fun set_message(account: signer, message: vector<u8>)
+    public(script) fun set_message(account: signer, message_bytes: vector<u8>)
     acquires MessageHolder {
+        let message = ASCII::string(message_bytes);
         let account_addr = Signer::address_of(&account);
         if (!exists<MessageHolder>(account_addr)) {
             move_to(&account, MessageHolder {

--- a/shuffle/move/examples/main/sources/MessageTests.move
+++ b/shuffle/move/examples/main/sources/MessageTests.move
@@ -4,6 +4,7 @@ module Sender::MessageTests {
     use Std::Signer;
     use Std::UnitTest;
     use Std::Vector;
+    use Std::ASCII;
 
     fun get_account(): signer {
         Vector::pop_back(&mut UnitTest::create_signers_for_testing(1))
@@ -16,7 +17,7 @@ module Sender::MessageTests {
         Message::set_message(account,  b"Hello Blockchain");
 
         assert!(
-          Message::get_message(addr) == b"Hello Blockchain",
+          Message::get_message(addr) == ASCII::string(b"Hello Blockchain"),
           0
         );
     }


### PR DESCRIPTION
## Motivation
#9193 

1. Convert bytes into string for client, so that clients do not need handle ASCII::String struct.
2. Updated shuffle message example to use ASCII::String type to store message as well.


## Test Plan

unit test

