### PR TITLE
[shuffle] add message events and update HelloBlockchain tutorial

### DIFF
--- a/shuffle/cli/tutorials/HelloBlockchain.md
+++ b/shuffle/cli/tutorials/HelloBlockchain.md
@@ -229,6 +229,43 @@ Use decodedMessages to check account message:
 [ "hello blockchain" ]
 ```
 
+Update message triggers an event, use `main.messageEvents` to find out all update events:
+
+```
+> await main.setMessageScriptFunction("hello again");
+{
+  type: "pending_transaction",
+  hash: "0x262cb8ae79e26f616ba7faf43927b4011b85c366084d5ddbfa15123b5eb2be07",
+  sender: "0x825b47b8fd2b30cf37c0e58579a78bc8",
+  sequence_number: "3",
+  max_gas_amount: "1000000",
+  gas_unit_price: "0",
+  gas_currency_code: "XUS",
+  expiration_timestamp_secs: "99999999999",
+  payload: {
+    type: "script_function_payload",
+    function: "0x825b47b8fd2b30cf37c0e58579a78bc8::Message::set_message",
+    type_arguments: [],
+    arguments: [ "0x68656c6c6f20616761696e" ]
+  },
+  signature: {
+    type: "ed25519_signature",
+    public_key: "0x171b9cd908c329b2b3f091729799b74cba8a25d7075067022bbc15f1faa02303",
+    signature: "0xa10c5a63ff6a474b2bbfeaaca366860ffddc12e4b51d99a14327afa651ab79e9ab21e7f1634a12c9045f47bb060addd2ee..."
+  }
+}
+
+> await main.messageEvents();
+[
+  {
+    key: "0x0400000000000000825b47b8fd2b30cf37c0e58579a78bc8",
+    sequence_number: "0",
+    type: "0x825b47b8fd2b30cf37c0e58579a78bc8::Message::MessageChangeEvent",
+    data: { from_message: "hello blockchain", to_message: "hello again" }
+  }
+]
+```
+
 ## Write E2E Tests
 
 You can also test your module by writing unit tests and integration tests. See

--- a/shuffle/move/examples/e2e/message.test.ts
+++ b/shuffle/move/examples/e2e/message.test.ts
@@ -23,6 +23,20 @@ Deno.test("Ability to set message", async () => {
   const expected = "hello blockchain";
   const messages = await main.decodedMessages();
   assertEquals(messages[0], expected);
+
+  txn = await main.setMessageScriptFunction("hello again");
+  txn = await devapi.waitForTransaction(txn.hash);
+  assert(txn.success);
+
+  const events = await main.messageEvents();
+  // In case there is another test also set message,
+  // we only look for last event
+  assert(events.length >= 1);
+  const event = events[events.length - 1];
+  assertEquals(event.data, {
+    "from_message": "hello blockchain",
+    "to_message": "hello again"
+  });
 });
 
 Deno.test("Ability to set NFTs", async () => {

--- a/shuffle/move/examples/integration/devapi.test.ts
+++ b/shuffle/move/examples/integration/devapi.test.ts
@@ -83,3 +83,21 @@ Deno.test("account", async () => {
   const actual = await devapi.account();
   assert(actual);
 });
+
+Deno.test("events", async () => {
+  const handleStruct = "0x1::DiemAccount::AccountOperationsCapability";
+  const accountAddress = "0xa550c18";
+  const events = await devapi.events(handleStruct, "creation_events", undefined, undefined, accountAddress);
+  // default limit is 25, we need at least 3 events for the following assertions
+  assert(events.length > 3);
+  // default start is 0
+  assertEquals(events[0].sequence_number, "0");
+
+  const events1 = await devapi.events(handleStruct, "creation_events", 0, 2, accountAddress);
+  assertEquals(events1.length, 2);
+
+  const events2 = await devapi.events(handleStruct, "creation_events", 1, 2, accountAddress);
+  assertEquals(events2.length, 2);
+
+  assertEquals(events1[1], events2[0]);
+});

--- a/shuffle/move/examples/main/client.ts
+++ b/shuffle/move/examples/main/client.ts
@@ -67,6 +67,19 @@ export class Client {
     return await this.fetch(this.url(`/accounts/${addr}/modules`));
   }
 
+  async getEventsByEventHandle(
+    addr: string,
+    handleStruct: string,
+    fieldName: string,
+    start?: number,
+    limit?: number
+  ): Promise<Event[]> {
+    start = start || 0;
+    limit = limit || 100;
+    const query = `start=${start}&limit=${limit}`
+    return await this.fetch(this.url(`/accounts/${addr}/events/${handleStruct}/${fieldName}?${query}`));
+  }
+
   async submitTransaction(
     txn: UserTransactionRequest,
   ): Promise<PendingTransaction> {

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -26,9 +26,9 @@ export async function ledgerInfo() {
 }
 
 // Returns a list of transactions, ascending from page 0.
-export async function transactions(): Promise<OnChainTransaction[]> {
+export async function transactions(start?: number, limit?: number): Promise<OnChainTransaction[]> {
   // TODO: Have below return a list of transactions desc by sequence number
-  return await context.client().getTransactions();
+  return await context.client().getTransactions(start, limit);
 }
 
 // Returns a specific transaction based on the version or hash.
@@ -49,9 +49,11 @@ export async function waitForTransaction(
 // Returns transactions specific to a particular address.
 export async function accountTransactions(
   addr?: string,
+  start?: number,
+  limit?: number
 ): Promise<OnChainTransaction[]> {
   addr = context.addressOrDefault(addr);
-  return await context.client().getAccountTransactions(addr);
+  return await context.client().getAccountTransactions(addr, start, limit);
 }
 
 // Returns resources for a specific address.
@@ -77,9 +79,9 @@ export async function account(addr?: string): Promise<Account> {
 export async function events(
   handleStruct: string,
   fieldName: string,
-  addr?: string,
   start?: number,
-  limit?: number
+  limit?: number,
+  addr?: string,
 ): Promise<Event[]> {
   addr = context.addressOrDefault(addr);
   return await context.client().getEventsByEventHandle(addr, handleStruct, fieldName, start, limit);

--- a/shuffle/move/examples/main/devapi.ts
+++ b/shuffle/move/examples/main/devapi.ts
@@ -10,6 +10,7 @@
 import * as context from "./context.ts";
 import {
   Account,
+  Event,
   OnChainTransaction,
   PendingTransaction,
   SigningMessage,
@@ -70,6 +71,18 @@ export async function modules(addr?: string) {
 export async function account(addr?: string): Promise<Account> {
   addr = context.addressOrDefault(addr);
   return await context.client().getAccount(addr);
+}
+
+// Returns events by account event handle.
+export async function events(
+  handleStruct: string,
+  fieldName: string,
+  addr?: string,
+  start?: number,
+  limit?: number
+): Promise<Event[]> {
+  addr = context.addressOrDefault(addr);
+  return await context.client().getEventsByEventHandle(addr, handleStruct, fieldName, start, limit);
 }
 
 // Returns the sequence number for a particular address, or the default account

--- a/shuffle/move/examples/main/mod.ts
+++ b/shuffle/move/examples/main/mod.ts
@@ -6,7 +6,6 @@
 
 import * as DiemHelpers from "./helpers.ts";
 import {
-  addressOrDefault,
   consoleContext,
   defaultUserContext,
   UserContext,
@@ -132,13 +131,27 @@ async function invokeScriptFunction(
 }
 
 export async function decodedMessages(addr?: string) {
-  addr = addressOrDefault(addr);
   return (await devapi.resourcesWithName("MessageHolder", addr))
     .map((entry) => entry.data.message);
 }
 
+export async function messageEvents(
+  addr?: string,
+  start?: number,
+  limit?: number,
+  moduleAddress?: string
+) {
+  moduleAddress = moduleAddress || defaultUserContext.address;
+  return await devapi.events(
+    `${moduleAddress}::Message::MessageHolder`,
+    "message_change_events",
+    addr,
+    start,
+    limit
+  );
+}
+
 export async function decodedNFTs(addr?: string) {
-  addr = addressOrDefault(addr);
   const decodedNfts: any[] = [];
   const nfts = (await devapi.resourcesWithName("NFTStandard", addr))
     .filter((entry) => entry.data && entry.data.nfts)

--- a/shuffle/move/examples/main/mod.ts
+++ b/shuffle/move/examples/main/mod.ts
@@ -136,18 +136,18 @@ export async function decodedMessages(addr?: string) {
 }
 
 export async function messageEvents(
-  addr?: string,
   start?: number,
   limit?: number,
+  addr?: string,
   moduleAddress?: string
 ) {
   moduleAddress = moduleAddress || defaultUserContext.address;
   return await devapi.events(
     `${moduleAddress}::Message::MessageHolder`,
     "message_change_events",
-    addr,
     start,
-    limit
+    limit,
+    addr,
   );
 }
 


### PR DESCRIPTION
## Motivation

1. Demonstrates querying events by account event handle in HelloBlockchain tutorial.
2. Enable getting transactions with optional pagination params.
3. Use `urlcat` to construct url with query params, ensure we encode url components and handles query params properly.

## Test Plan

shuffle example e2e test
