### PR TITLE
[move] Update Move tutorial to use `cargo install`

### DIFF
--- a/language/documentation/tutorial/README.md
+++ b/language/documentation/tutorial/README.md
@@ -24,39 +24,54 @@ Now let's get started!
 
 ## Step 0: Installation<span id="Step0"><span>
 
+If you haven't already, open your terminal and clone [the Diem repository](https://github.com/diem/diem):
 
-- Open up your terminal of choice and clone [`diem`](https://github.com/diem/diem) repo if you don't already have it:
 ```bash
-$ git clone https://github.com/diem/diem.git
+git clone https://github.com/diem/diem.git
 ```
 
-- Go to `diem` folder and run the `dev_setup.sh` script:
+Go to the `diem` directory and run the `dev_setup.sh` script:
+
 ```bash
-$ cd diem && sh scripts/dev_setup.sh -ypt
+cd diem
+sh scripts/dev_setup.sh -ypt
 ```
 
-Follow the prompt to install all the necessary dependencies.
+Follow the script's prompts in order to install all of Diem's dependencies.
 
-- Include environment variable definitions in `~/.profile` by running this command:
+The script adds environment variable definitions to your `~/.profile` file.
+Include them by running this command:
+
 ```bash
-$ . ~/.profile
+source ~/.profile
 ````
-- Install Move's CLIs by running this command in diem repo:
+
+Next, install Move's command-line tools by running these commands:
+
 ```bash
-$ cargo build -p df-cli -p move-analyzer
+cargo install --path diem-move/df-cli
+cargo install --path language/move-analyzer
 ```
 
-Once this is done, you can alias the `move` command to point the `df-cli`
-binary:
+After running these commands, you should be able to confirm that they can be
+invoked from the command line:
 
-```bash
-$ alias move="<path_to_diem_repo>/target/debug/df-cli"
+```
+move-analyzer --version  # Outputs: move-analyzer 0.0.0
 ```
 
-You can check that it is working by running
+The `df-cli` executable is a convenient wrapper around Move's command line
+interface. In this tutorial, we will refer to it as `move`. You may add an alias
+so that you can invoke it as such:
 
 ```bash
-$ move package -h
+alias move="df-cli"
+```
+
+You can check that it is working by running the following command:
+
+```bash
+move package -h
 ```
 
 You should see something like this along with a list and description of a
@@ -75,14 +90,13 @@ If you want to find what commands are available and what they do, running
 a command or subcommand with the `-h` flag will print documentation.
 
 There is official Move support for Visual Studio Code. You can install this
-extension by opening VS Code, searching for the "move-analyzer" package and
-installing it. After installing, open your VS Code settings, search for
-`move-analyzer.server.path`, and set it to `<path_to_diem_repo>/target/debug/move-analyzer`.
-More detailed instructions can be found [here](https://github.com/diem/diem/tree/main/language/move-analyzer/editors/code).
+extension by opening VS Code, searching for the "move-analyzer" extension in
+the Extension Pane, and installing it. More detailed instructions can be found
+in the extension's [README](https://github.com/diem/diem/tree/main/language/move-analyzer/editors/code).
 
 Before running the next steps, `cd` to the tutorial directory:
 ```bash
-$ cd <path_to_diem_repo>/language/documentation/tutorial/
+cd <path_to_diem_repo>/language/documentation/tutorial
 ```
 
 ## Step 1: Writing my first Move module<span id="Step1"><span>

--- a/language/move-analyzer/editors/code/README.md
+++ b/language/move-analyzer/editors/code/README.md
@@ -21,12 +21,8 @@ The `move-analyzer` language server is a Rust program that is part of
 
 1. You may clone [the Diem repository](https://github.com/diem/diem) yourself and build
    `move-analyzer` from its source code. This is recommended for Diem hackathon participants, and
-   Diem & Move core developers.
-   1. Follow the instructions in the Move tutorial's
-      [Step 0: Installation](https://github.com/diem/diem/tree/main/language/documentation/tutorial#step-0-installation).
-   2. To confirm that you've built the language server program successfully, execute
-      `<path_to_diem_repo>/target/debug/move-analyzer --version` on the command line. You should see
-      the output `move-analyzer 0.0.0`.
+   Diem & Move core developers. To do so, follow the instructions in the Move tutorial's
+   [Step 0: Installation](https://github.com/diem/diem/tree/main/language/documentation/tutorial#step-0-installation).
 2. You may use Rust's package manager `cargo` to install `move-analyzer` in your user's PATH. This
    is recommended for people who do not work on Diem & Move core.
    1. If you don't already have a Rust toolchain installed, you should install
@@ -35,9 +31,9 @@ The `move-analyzer` language server is a Rust program that is part of
       `move-analyzer` language server in your Cargo binary directory. On macOS and Linux this is
       usually `~/.cargo/bin`. You'll want to make sure this location is in your `PATH` environment
       variable.
-   3. To confirm that you've installed the language server program successfully, execute
-      `move-analyzer --version` on the command line. You should see the output
-      `move-analyzer 0.0.0`.
+
+To confirm that you've installed the language server program successfully, execute
+`move-analyzer --version` on the command line. You should see the output `move-analyzer 0.0.0`.
 
 ### 2. Installing the move-analyzer Visual Studio Code extension
 
@@ -47,21 +43,27 @@ The `move-analyzer` language server is a Rust program that is part of
    sidebar of your Visual Studio Code window.
 3. In the search bar labeled "Search Extensions in Marketplace," type in "move-analyzer". The
    move-analyzer extension should appear in the list below the search bar. Click "Install".
-4. Open the Visual Studio Code settings (`⌘,` on macOS, or use the menu item "Code > Preferences >
-   Settings"). Search for the `move-analyzer.server.path` setting, and set it to the location of the
-   `move-analyzer` language server you installed above.
-   1. If you used method 1, it should exist at `<path_to_diem_repo>/target/debug/move-analyzer`.
-   2. If you used method 2, it should exist in your `PATH` as `move-analyzer`. This is the default
-      value, so you do not need to edit this setting.
-5. Open any file that ends in `.move` (or, create a new file, click on "Select a language," and
+4. Open any file that ends in `.move` (or, create a new file, click on "Select a language," and
    choose the "Move" language). As you type, you should see that keywords and types appear in
    different colors.
 
-**Note:** If you see an error message "language server executable '/path/to/move-analyzer' could not
-be found" in the bottom-right of your Visual Studio Code screen when opening a Move file, it means
-that the `move-analyzer` executable does not exist at the path you specified in your
-`move-analyzer.server.path` setting. Change the setting to point to the location of a
-`move-analyzer` executable you built or installed in [step 1](./Step1).
+### Troubleshooting
+
+If you see an error message "language server executable 'move-analyzer' could not be found" in the
+bottom-right of your Visual Studio Code screen when opening a Move file, it means that the
+`move-analyzer` executable could not be found in your `PATH`. You may try the following:
+
+1. Confirm that invoking `move-analyzer --version` in a command-line terminal prints out
+   `move-analyzer 0.0.0`. If it doesn't, then retry the instructions in [step 1](./Step1). If it
+   does successfully print this text out, try closing and re-opening the Visual Studio Code
+   application, as it may not have picked up the udpates to your `PATH`.
+2. If you installed the `move-analyzer` executable to a different location that is outside of your
+   `PATH`, then you may have the extension look at this location by using the the Visual Studio Code
+   settings (`⌘,` on macOS, or use the menu item "Code > Preferences > Settings"). Search for the
+   `move-analyzer.server.path` setting, and set it to the location of the `move-analyzer` language
+   server you installed.
+3. If the above steps don't work, then report
+   [a GitHub issue to the Diem repository](https://github.com/diem/diem/issues) to get help.
 
 ## Features
 


### PR DESCRIPTION
Invoking `cargo install` places binary's in a user's Cargo binary directory, which will likely be included in their `PATH` (provided that the `dev-setup.sh` script was run successfully). This is simpler and less error-prone than invoking `cargo build` and asking the user to find the executable from within their build directory.
    
Update the tutorial installation steps to use `cargo install`, and modify the Visual Studio Code installation instructions accordingly.