### PR TITLE
draft: print `tracing::Span` data through diem::Logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,6 +2950,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-core",
+ "tracing-subscriber",
  "url",
  "warp",
 ]
@@ -4923,9 +4924,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -9107,9 +9108,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
 dependencies = [
  "lazy_static 1.4.0",
 ]
@@ -9136,35 +9137,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde 1.0.130",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.18"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5553bf0883ba7c9cbe493b085c29926bd41b66afc31ff72cf17ff4fb60dcd5"
+checksum = "245da694cc7fc4729f3f418b304cb57789f1bed2a78c575407ab8a23f53cb4d3"
 dependencies = [
  "ansi_term 0.12.1",
- "chrono",
  "lazy_static 1.4.0",
  "matchers",
  "regex",
- "serde 1.0.130",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/crates/diem-logger/Cargo.toml
+++ b/crates/diem-logger/Cargo.toml
@@ -24,4 +24,4 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
 prometheus = { version = "0.12.0", default-features = false }
 tracing = "0.1.26"
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3"

--- a/crates/diem-logger/src/kv.rs
+++ b/crates/diem-logger/src/kv.rs
@@ -12,19 +12,26 @@
 //! ```
 
 use serde::Serialize;
-use std::fmt;
+use std::{
+    borrow::{Borrow, Cow},
+    fmt,
+};
 
 /// The key part of a logging key value pair e.g. `info!(key = value)`
-#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
-pub struct Key(&'static str);
+#[derive(Clone, Debug, Hash, Eq, PartialEq, Ord, PartialOrd, Serialize)]
+pub struct Key(Cow<'static, str>);
 
 impl Key {
     pub fn new(s: &'static str) -> Self {
-        Self(s)
+        Self(Cow::Borrowed(s))
     }
 
-    pub fn as_str(&self) -> &'static str {
-        self.0
+    pub fn new_owned(s: String) -> Self {
+        Self(Cow::Owned(s))
+    }
+
+    pub fn as_str(&self) -> &'_ Self {
+        self.borrow()
     }
 }
 
@@ -83,7 +90,7 @@ impl<'v> KeyValue<'v> {
 
 impl<'v> Schema for KeyValue<'v> {
     fn visit(&self, visitor: &mut dyn Visitor) {
-        visitor.visit_pair(self.key, self.value)
+        visitor.visit_pair(self.key.clone(), self.value)
     }
 }
 

--- a/crates/diem-logger/src/tracing_adapter.rs
+++ b/crates/diem-logger/src/tracing_adapter.rs
@@ -1,34 +1,82 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate as dl;
-use std::fmt;
-use tracing as tr;
-use tracing_subscriber::{layer::Context, Layer};
+use crate::{self as dl};
+use std::{collections::BTreeMap, fmt};
+use tracing::{
+    field::Field,
+    span::{Attributes, Id},
+    Event, Level, Metadata,
+};
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
 
 /// A layer that translates tracing events into diem-logger events.
 pub struct TracingToDiemLoggerLayer;
 
-fn translate_level(level: &tr::Level) -> Option<dl::Level> {
-    if *level == tr::Level::ERROR {
+fn translate_level(level: &Level) -> Option<dl::Level> {
+    if *level == Level::ERROR {
         return Some(dl::Level::Error);
     }
-    if *level == tr::Level::INFO {
+    if *level == Level::INFO {
         return Some(dl::Level::Info);
     }
-    if *level == tr::Level::DEBUG {
+    if *level == Level::DEBUG {
         return Some(dl::Level::Debug);
     }
-    if *level == tr::Level::TRACE {
+    if *level == Level::TRACE {
         return Some(dl::Level::Trace);
     }
-    if *level == tr::Level::WARN {
+    if *level == Level::WARN {
         return Some(dl::Level::Warn);
     }
     None
 }
 
-fn translate_metadata(metadata: &tr::Metadata<'static>) -> Option<dl::Metadata> {
+struct SpanData {
+    data: BTreeMap<String, String>,
+    prefix: String,
+}
+
+impl SpanData {
+    fn new(attrs: &Attributes<'_>, name: String) -> Self {
+        let mut span = Self {
+            data: BTreeMap::new(),
+            prefix: name,
+        };
+        attrs.record(&mut span);
+        span
+    }
+}
+
+impl tracing::field::Visit for SpanData {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        let name = format!("{}.{}", self.prefix, &field.name());
+        self.data.insert(name, value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        let name = format!("{}.{}", self.prefix, &field.name());
+        self.data.insert(name, format!("{:?}", value));
+    }
+}
+
+struct KeyValueVisitorAdapter<'a> {
+    visitor: &'a mut dyn dl::Visitor,
+}
+
+impl<'a> tracing::field::Visit for KeyValueVisitorAdapter<'a> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.visitor
+            .visit_pair(dl::Key::new(field.name()), dl::Value::Display(&value))
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.visitor
+            .visit_pair(dl::Key::new(field.name()), dl::Value::Debug(value))
+    }
+}
+
+fn translate_metadata(metadata: &Metadata<'static>) -> Option<dl::Metadata> {
     let level = translate_level(metadata.level())?;
 
     Some(dl::Metadata::new(
@@ -41,19 +89,23 @@ fn translate_metadata(metadata: &tr::Metadata<'static>) -> Option<dl::Metadata> 
     ))
 }
 
-struct KeyValueVisitorAdapter<'a> {
-    visitor: &'a mut dyn dl::Visitor,
+struct SpanValues {
+    pairs: BTreeMap<String, String>,
 }
 
-impl<'a> tr::field::Visit for KeyValueVisitorAdapter<'a> {
-    fn record_debug(&mut self, field: &tr::field::Field, value: &dyn fmt::Debug) {
-        self.visitor
-            .visit_pair(dl::Key::new(field.name()), dl::Value::Debug(value))
+impl dl::Schema for SpanValues {
+    fn visit(&self, visitor: &mut dyn dl::Visitor) {
+        for (key, value) in &self.pairs {
+            visitor.visit_pair(
+                dl::Key::new_owned(key.to_string()),
+                dl::Value::from_display(&value),
+            )
+        }
     }
 }
 
 struct EventKeyValueAdapter<'a, 'b> {
-    event: &'a tr::Event<'b>,
+    event: &'a Event<'b>,
 }
 
 impl<'a, 'b> dl::Schema for EventKeyValueAdapter<'a, 'b> {
@@ -62,8 +114,39 @@ impl<'a, 'b> dl::Schema for EventKeyValueAdapter<'a, 'b> {
     }
 }
 
-impl<S: tr::Subscriber> Layer<S> for TracingToDiemLoggerLayer {
-    fn on_event(&self, event: &tr::Event, _ctx: Context<S>) {
+impl<S> Layer<S> for TracingToDiemLoggerLayer
+where
+    S: tracing::Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let span = ctx.span(id).expect("Unable to load span; this is a bug");
+
+        let prefix = {
+            if let Some(parent) = span.parent() {
+                // first, load the parent's span's, if present, to avoid
+                // clobbering key/value pairs in the output.
+                let parent_ext = parent.extensions();
+
+                let data = parent_ext
+                    .get::<SpanData>()
+                    .expect("Parent does not have scuba data; this is a bug");
+
+                // an unfortunate clone.
+                Some(data.prefix.clone())
+            } else {
+                None
+            }
+        };
+
+        let prefix = match prefix {
+            Some(prefix) => format!("{}.{}", prefix, attrs.metadata().name()),
+            None => attrs.metadata().name().to_string(),
+        };
+        let data = SpanData::new(attrs, prefix);
+        span.extensions_mut().insert(data);
+    }
+
+    fn on_event(&self, event: &Event, ctx: Context<S>) {
         let metadata = match translate_metadata(event.metadata()) {
             Some(metadata) => metadata,
             None => {
@@ -75,12 +158,26 @@ impl<S: tr::Subscriber> Layer<S> for TracingToDiemLoggerLayer {
             }
         };
 
+        let mut acc = BTreeMap::new();
+        if let Some(scope) = ctx.event_scope(event) {
+            for data in scope {
+                let ext = data.extensions();
+                let data = ext
+                    .get::<SpanData>()
+                    .expect("span does not have data; this is a bug");
+
+                acc.extend(data.data.clone())
+            }
+        }
+        let values = acc;
+        let data = SpanValues { pairs: values };
+
         // `tracing::Event` contains an implicit field named "message".
         // However I couldn't figure out a way to convert it to `fmt::Arguments` due to lifetime issues.
         // Therefore I'm omitting message argument to `Event::dispatch`.
         // This should generally be fine since the message will be translated as a normal record.
         if dl::logger::enabled(&metadata) {
-            dl::Event::dispatch(&metadata, None, &[&EventKeyValueAdapter { event }]);
+            dl::Event::dispatch(&metadata, None, &[&EventKeyValueAdapter { event }, &data]);
         }
     }
 }

--- a/crates/diem-workspace-hack/Cargo.toml
+++ b/crates/diem-workspace-hack/Cargo.toml
@@ -63,7 +63,8 @@ tokio = { version = "1.9.0", features = ["bytes", "fs", "full", "io-std", "io-ut
 tokio-util = { version = "0.6.7", features = ["codec", "compat", "futures-io", "io"] }
 toml = { version = "0.5.8" }
 tracing = { version = "0.1.26", features = ["attributes", "log", "std", "tracing-attributes"] }
-tracing-core = { version = "0.1.18", features = ["lazy_static", "std"] }
+tracing-core = { version = "0.1.21", features = ["lazy_static", "std"] }
+tracing-subscriber = { version = "0.3.3", features = ["alloc", "ansi", "ansi_term", "env-filter", "fmt", "lazy_static", "matchers", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"] }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
 warp = { version = "0.3.0", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 
@@ -125,7 +126,8 @@ tokio = { version = "1.9.0", features = ["bytes", "fs", "full", "io-std", "io-ut
 tokio-util = { version = "0.6.7", features = ["codec", "compat", "futures-io", "io"] }
 toml = { version = "0.5.8" }
 tracing = { version = "0.1.26", features = ["attributes", "log", "std", "tracing-attributes"] }
-tracing-core = { version = "0.1.18", features = ["lazy_static", "std"] }
+tracing-core = { version = "0.1.21", features = ["lazy_static", "std"] }
+tracing-subscriber = { version = "0.3.3", features = ["alloc", "ansi", "ansi_term", "env-filter", "fmt", "lazy_static", "matchers", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"] }
 url = { version = "2.2.2", default-features = false, features = ["serde"] }
 warp = { version = "0.3.0", features = ["multipart", "tls", "tokio-rustls", "tokio-tungstenite", "websocket"] }
 

--- a/language/testing-infra/test-generation/Cargo.toml
+++ b/language/testing-infra/test-generation/Cargo.toml
@@ -19,7 +19,7 @@ hex = "0.4.3"
 getrandom = "0.2.2"
 crossbeam-channel = "0.5.0"
 tracing = "0.1.26"
-tracing-subscriber = "0.2.18"
+tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 once_cell = "1.7.2"
 
 bytecode-verifier = { path = "../../bytecode-verifier" }


### PR DESCRIPTION
## Motivation

Resolves https://github.com/diem/diem/issues/9884. Few notes on this PR: 
- Note that this branch isn't complete because the span values are double-escaped. I'm decently sure this is happening because there are _two_ visitors (tracing's and diem's logger's) recording the data. Here's a sample of the current output:

```rust
2021-12-04T17:19:53.086624Z [verify_tracing_kvs] ERROR  {"another_value":"hello","message":"hello world","outer.inner.one":"\"hello\"","outer.inner.two":"\"two\"","outer.one":"\"hello\"","outer.two":"\"two\""}
```
- To resolve this, I think that the `Value` enum needs to be given an additional variant representing raw strings _or_ the visitors need to be unified. Up to y'all on which approach I take.
- To avoid clobbering span fields (in the instance where an parent and child span both have the same field name), I've updated the layer to prefix each field key with its span's name (as well as any parent span's name). For a field named `one` in whose span is `inner` and whose parent span is `outer`, the field name will be rendered as `outer.inner.one`. To support this, I had to loosen the restrictions on `Key` from being represented _entirely_ as a `&'static str`, but instead as a `Cow<'static str>`. I'm happy to roll this change back if y'all are okay with a single field's key potentially mapping to multiple values.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes, but too late to have semantic commits. This is PR is work-in-progress and not _that_ large, so I'll squash my commits down to a single, semantic commit before merging.

## Test Plan

Testing this through adding unit tests. They'll be expanded before this is marked as "not a draft".

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

[will add]

## If targeting a release branch, please fill the below out as well

N/A
