### PR TITLE
[forge] fix pre release test suite in changelog

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -499,8 +499,6 @@ impl NetworkTest for RestartValidator {
         node.stop()?;
         println!("Restarting node {}", node.peer_id());
         node.start()?;
-        // wait node to recovery
-        std::thread::sleep(Duration::from_millis(1000));
         node.health_check().expect("node health check failed");
 
         Ok(())

--- a/testsuite/forge/src/backend/k8s/node.rs
+++ b/testsuite/forge/src/backend/k8s/node.rs
@@ -1,7 +1,9 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{scale_sts_replica, FullNode, HealthCheckError, Node, Result, Validator, Version};
+use crate::{
+    scale_sts_replica, FullNode, HealthCheckError, Node, NodeExt, Result, Validator, Version,
+};
 use anyhow::{format_err, Context};
 use diem_config::config::NodeConfig;
 use diem_sdk::{
@@ -15,7 +17,7 @@ use std::{
     process::{Command, Stdio},
     str::FromStr,
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 const NODE_METRIC_PORT: u64 = 9101;
@@ -95,7 +97,10 @@ impl Node for K8sNode {
     }
 
     fn start(&mut self) -> Result<()> {
-        scale_sts_replica(self.sts_name(), 1)
+        scale_sts_replica(self.sts_name(), 1)?;
+        self.wait_until_healthy(Instant::now() + Duration::from_secs(60))?;
+
+        Ok(())
     }
 
     fn stop(&mut self) -> Result<()> {

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -9,9 +9,7 @@ pub mod performance_test;
 pub mod reconfiguration_test;
 pub mod state_sync_performance;
 
-use diem_sdk::{
-    client::Client as JsonRpcClient, transaction_builder::TransactionFactory, types::PeerId,
-};
+use diem_sdk::{transaction_builder::TransactionFactory, types::PeerId};
 use forge::{EmitJobRequest, NetworkContext, NodeExt, Result, TxnEmitter, TxnStats, Version};
 use rand::SeedableRng;
 use std::{
@@ -61,7 +59,7 @@ pub fn generate_traffic<'t>(
     let mut emitter = TxnEmitter::new(
         chain_info.treasury_compliance_account,
         chain_info.designated_dealer_account,
-        JsonRpcClient::new(&chain_info.json_rpc_url),
+        validator_clients[0].clone(),
         transaction_factory,
         rng,
     );

--- a/testsuite/testcases/src/partial_nodes_down_test.rs
+++ b/testsuite/testcases/src/partial_nodes_down_test.rs
@@ -40,7 +40,6 @@ impl NetworkTest for PartialNodesDown {
             println!("Node {} is going to restart", node.name());
             node.start()?;
         }
-        thread::sleep(Duration::from_secs(5));
 
         Ok(())
     }

--- a/testsuite/testcases/src/state_sync_performance.rs
+++ b/testsuite/testcases/src/state_sync_performance.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::generate_traffic;
-use forge::{NetworkContext, NetworkTest, NodeExt, Result, Test};
+use forge::{NetworkContext, NetworkTest, Result, Test};
 use rand::{
     rngs::{OsRng, StdRng},
     seq::IteratorRandom,
@@ -66,7 +66,6 @@ impl NetworkTest for StateSyncPerformance {
         fullnode.clear_storage()?;
         println!("The fullnode is going to restart");
         fullnode.start()?;
-        fullnode.wait_until_healthy(Instant::now() + Duration::from_secs(60))?;
         println!(
             "The fullnode is now up. Waiting for it to state sync to the expected version: {}",
             validator_synced_version


### PR DESCRIPTION
We used to use json_rpc_client to fetch faucet account which is initialized at the first when tx_emitter is created, but in 10% down test, the client's corresponded node has chance to be stopped which end point is not availiable anymore. 

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan
```
./scripts/fgi/run --pr 9963 --suite pre_release -W forge-2
```


```
Test Statistics: 
fixed-tps-test : 10 TPS, 1369 ms latency, 3000 ms p99 latency,no expired txns
all up : 2420 TPS, 1841 ms latency, 2150 ms p99 latency,no expired txns
gas-price-unit-1 : 2325 TPS, 1915 ms latency, 2550 ms p99 latency,no expired txns
10%-down : 2147 TPS, 1871 ms latency, 4150 ms p99 latency,no expired txns
Reconfiguration: total epoch: 101 finished in 197 seconds
State sync throughput : 2286 txn/sec

====json-report-begin===
{
  "metrics": [
    {
      "test_name": "fixed-tps-test",
      "metric": "submitted_txn",
      "value": 2400.0
    },
    {
      "test_name": "fixed-tps-test",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "test_name": "fixed-tps-test",
      "metric": "avg_tps",
      "value": 10.0
    },
    {
      "test_name": "fixed-tps-test",
      "metric": "avg_latency",
      "value": 1369.0
    },
    {
      "test_name": "fixed-tps-test",
      "metric": "p99_latency",
      "value": 3000.0
    },
    {
      "test_name": "all up",
      "metric": "submitted_txn",
      "value": 580905.0
    },
    {
      "test_name": "all up",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "test_name": "all up",
      "metric": "avg_tps",
      "value": 2420.0
    },
    {
      "test_name": "all up",
      "metric": "avg_latency",
      "value": 1841.0
    },
    {
      "test_name": "all up",
      "metric": "p99_latency",
      "value": 2150.0
    },
    {
      "test_name": "gas-price-unit-1",
      "metric": "submitted_txn",
      "value": 558060.0
    },
    {
      "test_name": "gas-price-unit-1",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "test_name": "gas-price-unit-1",
      "metric": "avg_tps",
      "value": 2325.0
    },
    {
      "test_name": "gas-price-unit-1",
      "metric": "avg_latency",
      "value": 1915.0
    },
    {
      "test_name": "gas-price-unit-1",
      "metric": "p99_latency",
      "value": 2550.0
    },
    {
      "test_name": "10%-down",
      "metric": "submitted_txn",
      "value": 257715.0
    },
    {
      "test_name": "10%-down",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "test_name": "10%-down",
      "metric": "avg_tps",
      "value": 2147.0
    },
    {
      "test_name": "10%-down",
      "metric": "avg_latency",
      "value": 1871.0
    },
    {
      "test_name": "10%-down",
      "metric": "p99_latency",
      "value": 4150.0
    },
    {
      "test_name": "StateSyncPerformance",
      "metric": "state_sync_throughput",
      "value": 2286.0
    }
  ],
  "text": "fixed-tps-test : 10 TPS, 1369 ms latency, 3000 ms p99 latency,no expired txns\nall up : 2420 TPS, 1841 ms latency, 2150 ms p99 latency,no expired txns\ngas-price-unit-1 : 2325 TPS, 1915 ms latency, 2550 ms p99 latency,no expired txns\n10%-down : 2147 TPS, 1871 ms latency, 4150 ms p99 latency,no expired txns\nReconfiguration: total epoch: 101 finished in 197 seconds\nState sync throughput : 2286 txn/sec"
}
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
