### PR TITLE
[move-prover] Loop invariants for functional macros + fixes

### DIFF
--- a/diem-move/diem-framework/tests/move_verification_test.rs
+++ b/diem-move/diem-framework/tests/move_verification_test.rs
@@ -3,17 +3,10 @@
 
 use move_cli::package::prover::ProverTest;
 
+// TODO: split this into individual tests once the package system supports this.
 #[test]
-fn prove_core() {
-    ProverTest::create("core").run()
-}
-
-#[test]
-fn prove_experimental() {
-    ProverTest::create("experimental").run()
-}
-
-#[test]
-fn prove_dpn() {
+fn prove_all() {
+    ProverTest::create("core").run();
+    ProverTest::create("experimental").run();
     ProverTest::create("DPN").run()
 }

--- a/language/move-lang/src/diagnostics/codes.rs
+++ b/language/move-lang/src/diagnostics/codes.rs
@@ -112,6 +112,7 @@ codes!(
         InvalidLValue: { msg: "invalid assignment", severity: NonblockingError },
         SpecContextRestricted:
             { msg: "syntax item restricted to spec contexts", severity: BlockingError },
+        InvalidSpecBlockMember: { msg: "invalid spec block member", severity: NonblockingError },
     ],
     // errors for any rules around declaration items
     Declarations: [

--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -27,7 +27,9 @@ use crate::{
 use internment::LocalIntern;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
-use std::{borrow::Borrow, collections::HashSet, fmt::Debug, hash::Hash, ops::Deref};
+use std::{
+    borrow::Borrow, cell::RefCell, collections::HashSet, fmt::Debug, hash::Hash, ops::Deref,
+};
 
 // =================================================================================================
 /// # Declarations
@@ -54,6 +56,8 @@ pub struct SpecFunDecl {
     pub is_move_fun: bool,
     pub is_native: bool,
     pub body: Option<Exp>,
+    pub callees: BTreeSet<QualifiedId<SpecFunId>>,
+    pub is_recursive: RefCell<Option<bool>>,
 }
 
 // =================================================================================================

--- a/language/move-model/src/simplifier/pass_inline.rs
+++ b/language/move-model/src/simplifier/pass_inline.rs
@@ -134,7 +134,12 @@ impl ExpInliner<'_> {
                 let callee_menv = self.env.get_module(*mid);
                 let callee_decl = callee_menv.get_spec_fun(*fid);
                 debug_assert_eq!(args.len(), callee_decl.params.len());
-                if callee_decl.is_native || callee_decl.uninterpreted || callee_decl.body.is_none()
+                if callee_decl.is_native
+                    || callee_decl.uninterpreted
+                    || callee_decl.body.is_none()
+                    || self
+                        .env
+                        .is_spec_fun_recursive(callee_menv.get_id().qualified(*fid))
                 {
                     Err(e)
                 } else {

--- a/language/move-prover/bytecode/src/loop_analysis.rs
+++ b/language/move-prover/bytecode/src/loop_analysis.rs
@@ -423,7 +423,7 @@ impl LoopAnalysisProcessor {
                 Self::collect_loop_targets(&cfg, &func_target, &sub_loops);
             let back_edges = Self::collect_loop_back_edges(code, &cfg, label, &sub_loops);
 
-            // done with all information collection
+            // done with all information collection.
             fat_loops.insert(
                 label,
                 FatLoop {

--- a/language/move-prover/bytecode/tests/data_invariant_instrumentation/borrow.exp
+++ b/language/move-prover/bytecode/tests/data_invariant_instrumentation/borrow.exp
@@ -195,7 +195,8 @@ public fun Test::test_borrow_mut_local(): Test::R<u64> {
      # VC: data invariant does not hold at tests/data_invariant_instrumentation/borrow.move:17:9+16
  19: assert Gt(select Test::S.y(select Test::R.s($t6)), 0)
  20: write_back[LocalRoot($t0)@]($t6)
- 21: $t12 := move($t0)
- 22: label L1
- 23: return $t12
+ 21: trace_local[d]($t0)
+ 22: $t12 := move($t0)
+ 23: label L1
+ 24: return $t12
 }

--- a/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/basic_test.exp
@@ -275,8 +275,9 @@ fun TestPackref::test1(): TestPackref::R {
   5: write_ref($t5, $t6)
   6: write_back[Reference($t4).x (u64)]($t5)
   7: write_back[LocalRoot($t0)@]($t4)
-  8: $t7 := move($t0)
-  9: return $t7
+  8: trace_local[r]($t0)
+  9: $t7 := move($t0)
+ 10: return $t7
 }
 
 
@@ -296,7 +297,8 @@ public fun TestPackref::test3($t0|r_ref: &mut TestPackref::R, $t1|v: u64) {
   1: TestPackref::test2($t3, $t1)
   2: write_back[Reference($t0).x (u64)]($t3)
   3: trace_local[r_ref]($t0)
-  4: return ()
+  4: trace_local[r_ref]($t0)
+  5: return ()
 }
 
 
@@ -314,8 +316,9 @@ fun TestPackref::test4(): TestPackref::R {
   3: $t4 := 0
   4: TestPackref::test3($t3, $t4)
   5: write_back[LocalRoot($t0)@]($t3)
-  6: $t5 := move($t0)
-  7: return $t5
+  6: trace_local[r]($t0)
+  7: $t5 := move($t0)
+  8: return $t5
 }
 
 
@@ -325,7 +328,8 @@ public fun TestPackref::test5($t0|r_ref: &mut TestPackref::R): &mut u64 {
   0: $t1 := borrow_field<TestPackref::R>.x($t0)
   1: trace_local[r_ref]($t0)
   2: write_back[Reference($t0).x (u64)]($t1)
-  3: return $t1
+  3: trace_local[r_ref]($t0)
+  4: return $t1
 }
 
 
@@ -347,8 +351,9 @@ fun TestPackref::test6(): TestPackref::R {
   5: TestPackref::test2($t5, $t6)
   6: write_back[Reference($t4).x (u64)]($t5)
   7: write_back[LocalRoot($t0)@]($t4)
-  8: $t7 := move($t0)
-  9: return $t7
+  8: trace_local[r]($t0)
+  9: $t7 := move($t0)
+ 10: return $t7
 }
 
 
@@ -368,25 +373,29 @@ fun TestPackref::test7($t0|b: bool) {
   4: $t6 := borrow_local($t1)
   5: $t3 := $t6
   6: write_back[LocalRoot($t1)@]($t6)
-  7: if ($t0) goto 19 else goto 23
-  8: label L1
-  9: goto 13
- 10: label L0
- 11: destroy($t6)
- 12: $t3 := borrow_local($t2)
- 13: label L2
- 14: $t7 := 0
- 15: TestPackref::test3($t3, $t7)
- 16: write_back[LocalRoot($t1)@]($t3)
- 17: write_back[LocalRoot($t2)@]($t3)
- 18: return ()
- 19: label L3
- 20: write_back[LocalRoot($t1)@]($t3)
- 21: destroy($t3)
- 22: goto 10
- 23: label L4
- 24: destroy($t6)
- 25: goto 8
+  7: trace_local[r1]($t1)
+  8: if ($t0) goto 22 else goto 27
+  9: label L1
+ 10: goto 14
+ 11: label L0
+ 12: destroy($t6)
+ 13: $t3 := borrow_local($t2)
+ 14: label L2
+ 15: $t7 := 0
+ 16: TestPackref::test3($t3, $t7)
+ 17: write_back[LocalRoot($t1)@]($t3)
+ 18: trace_local[r1]($t1)
+ 19: write_back[LocalRoot($t2)@]($t3)
+ 20: trace_local[r2]($t2)
+ 21: return ()
+ 22: label L3
+ 23: write_back[LocalRoot($t1)@]($t3)
+ 24: trace_local[r1]($t1)
+ 25: destroy($t3)
+ 26: goto 11
+ 27: label L4
+ 28: destroy($t6)
+ 29: goto 9
 }
 
 
@@ -416,45 +425,51 @@ fun TestPackref::test8($t0|b: bool, $t1|n: u64, $t2|r_ref: &mut TestPackref::R) 
   7: $t9 := <($t8, $t1)
   8: if ($t9) goto 11 else goto 9
   9: label L1
- 10: goto 31
+ 10: goto 33
  11: label L0
  12: write_back[LocalRoot($t3)@]($t5)
- 13: write_back[LocalRoot($t4)@]($t5)
- 14: destroy($t5)
- 15: $t10 := 2
- 16: $t11 := /($t1, $t10)
- 17: $t12 := 0
- 18: $t13 := ==($t11, $t12)
- 19: if ($t13) goto 22 else goto 20
- 20: label L4
- 21: goto 25
- 22: label L3
- 23: $t5 := borrow_local($t3)
- 24: goto 27
- 25: label L5
- 26: $t5 := borrow_local($t4)
- 27: label L6
- 28: $t14 := 1
- 29: $t1 := -($t1, $t14)
- 30: goto 5
- 31: label L2
- 32: if ($t0) goto 35 else goto 33
- 33: label L9
- 34: goto 42
- 35: label L8
- 36: write_back[LocalRoot($t3)@]($t5)
- 37: write_back[LocalRoot($t4)@]($t5)
- 38: destroy($t5)
- 39: $t15 := 0
- 40: TestPackref::test3($t2, $t15)
- 41: goto 48
- 42: label L10
- 43: destroy($t2)
- 44: $t16 := 0
- 45: TestPackref::test3($t5, $t16)
- 46: write_back[LocalRoot($t3)@]($t5)
- 47: write_back[LocalRoot($t4)@]($t5)
- 48: label L11
- 49: trace_local[r_ref]($t2)
- 50: return ()
+ 13: trace_local[r1]($t3)
+ 14: write_back[LocalRoot($t4)@]($t5)
+ 15: trace_local[r2]($t4)
+ 16: destroy($t5)
+ 17: $t10 := 2
+ 18: $t11 := /($t1, $t10)
+ 19: $t12 := 0
+ 20: $t13 := ==($t11, $t12)
+ 21: if ($t13) goto 24 else goto 22
+ 22: label L4
+ 23: goto 27
+ 24: label L3
+ 25: $t5 := borrow_local($t3)
+ 26: goto 29
+ 27: label L5
+ 28: $t5 := borrow_local($t4)
+ 29: label L6
+ 30: $t14 := 1
+ 31: $t1 := -($t1, $t14)
+ 32: goto 5
+ 33: label L2
+ 34: if ($t0) goto 37 else goto 35
+ 35: label L9
+ 36: goto 46
+ 37: label L8
+ 38: write_back[LocalRoot($t3)@]($t5)
+ 39: trace_local[r1]($t3)
+ 40: write_back[LocalRoot($t4)@]($t5)
+ 41: trace_local[r2]($t4)
+ 42: destroy($t5)
+ 43: $t15 := 0
+ 44: TestPackref::test3($t2, $t15)
+ 45: goto 54
+ 46: label L10
+ 47: destroy($t2)
+ 48: $t16 := 0
+ 49: TestPackref::test3($t5, $t16)
+ 50: write_back[LocalRoot($t3)@]($t5)
+ 51: trace_local[r1]($t3)
+ 52: write_back[LocalRoot($t4)@]($t5)
+ 53: trace_local[r2]($t4)
+ 54: label L11
+ 55: trace_local[r_ref]($t2)
+ 56: return ()
 }

--- a/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
+++ b/language/move-prover/bytecode/tests/memory_instr/mut_ref.exp
@@ -299,17 +299,18 @@ public fun TestMutRefs::decrement_invalid($t0|x: &mut TestMutRefs::T) {
   3: $t5 := borrow_field<TestMutRefs::T>.value($t0)
   4: write_ref($t5, $t4)
   5: write_back[Reference($t0).value (u64)]($t5)
-  6: $t6 := 0x0
-  7: $t7 := borrow_global<TestMutRefs::TSum>($t6)
-  8: $t8 := get_field<TestMutRefs::TSum>.sum($t7)
-  9: $t9 := 1
- 10: $t10 := -($t8, $t9)
- 11: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 12: write_ref($t11, $t10)
- 13: write_back[Reference($t7).sum (u64)]($t11)
- 14: write_back[TestMutRefs::TSum@]($t7)
- 15: trace_local[x]($t0)
- 16: return ()
+  6: trace_local[x]($t0)
+  7: $t6 := 0x0
+  8: $t7 := borrow_global<TestMutRefs::TSum>($t6)
+  9: $t8 := get_field<TestMutRefs::TSum>.sum($t7)
+ 10: $t9 := 1
+ 11: $t10 := -($t8, $t9)
+ 12: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
+ 13: write_ref($t11, $t10)
+ 14: write_back[Reference($t7).sum (u64)]($t11)
+ 15: write_back[TestMutRefs::TSum@]($t7)
+ 16: trace_local[x]($t0)
+ 17: return ()
 }
 
 
@@ -355,17 +356,18 @@ public fun TestMutRefs::increment($t0|x: &mut TestMutRefs::T) {
   3: $t5 := borrow_field<TestMutRefs::T>.value($t0)
   4: write_ref($t5, $t4)
   5: write_back[Reference($t0).value (u64)]($t5)
-  6: $t6 := 0x0
-  7: $t7 := borrow_global<TestMutRefs::TSum>($t6)
-  8: $t8 := get_field<TestMutRefs::TSum>.sum($t7)
-  9: $t9 := 1
- 10: $t10 := +($t8, $t9)
- 11: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 12: write_ref($t11, $t10)
- 13: write_back[Reference($t7).sum (u64)]($t11)
- 14: write_back[TestMutRefs::TSum@]($t7)
- 15: trace_local[x]($t0)
- 16: return ()
+  6: trace_local[x]($t0)
+  7: $t6 := 0x0
+  8: $t7 := borrow_global<TestMutRefs::TSum>($t6)
+  9: $t8 := get_field<TestMutRefs::TSum>.sum($t7)
+ 10: $t9 := 1
+ 11: $t10 := +($t8, $t9)
+ 12: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
+ 13: write_ref($t11, $t10)
+ 14: write_back[Reference($t7).sum (u64)]($t11)
+ 15: write_back[TestMutRefs::TSum@]($t7)
+ 16: trace_local[x]($t0)
+ 17: return ()
 }
 
 
@@ -382,7 +384,8 @@ public fun TestMutRefs::increment_invalid($t0|x: &mut TestMutRefs::T) {
   4: write_ref($t4, $t3)
   5: write_back[Reference($t0).value (u64)]($t4)
   6: trace_local[x]($t0)
-  7: return ()
+  7: trace_local[x]($t0)
+  8: return ()
 }
 
 
@@ -434,17 +437,18 @@ fun TestMutRefs::private_decrement($t0|x: &mut TestMutRefs::T) {
   3: $t5 := borrow_field<TestMutRefs::T>.value($t0)
   4: write_ref($t5, $t4)
   5: write_back[Reference($t0).value (u64)]($t5)
-  6: $t6 := 0x0
-  7: $t7 := borrow_global<TestMutRefs::TSum>($t6)
-  8: $t8 := get_field<TestMutRefs::TSum>.sum($t7)
-  9: $t9 := 1
- 10: $t10 := -($t8, $t9)
- 11: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
- 12: write_ref($t11, $t10)
- 13: write_back[Reference($t7).sum (u64)]($t11)
- 14: write_back[TestMutRefs::TSum@]($t7)
- 15: trace_local[x]($t0)
- 16: return ()
+  6: trace_local[x]($t0)
+  7: $t6 := 0x0
+  8: $t7 := borrow_global<TestMutRefs::TSum>($t6)
+  9: $t8 := get_field<TestMutRefs::TSum>.sum($t7)
+ 10: $t9 := 1
+ 11: $t10 := -($t8, $t9)
+ 12: $t11 := borrow_field<TestMutRefs::TSum>.sum($t7)
+ 13: write_ref($t11, $t10)
+ 14: write_back[Reference($t7).sum (u64)]($t11)
+ 15: write_back[TestMutRefs::TSum@]($t7)
+ 16: trace_local[x]($t0)
+ 17: return ()
 }
 
 
@@ -468,7 +472,8 @@ fun TestMutRefs::private_to_public_caller_invalid_data_invariant() {
   3: TestMutRefs::private_decrement($t3)
   4: TestMutRefs::increment($t3)
   5: write_back[LocalRoot($t1)@]($t3)
-  6: return ()
+  6: trace_local[x]($t1)
+  7: return ()
 }
 
 
@@ -483,7 +488,8 @@ public fun TestMutRefsUser::valid() {
   2: $t2 := borrow_local($t0)
   3: TestMutRefs::increment($t2)
   4: write_back[LocalRoot($t0)@]($t2)
-  5: $t3 := move($t0)
-  6: TestMutRefs::delete($t3)
-  7: return ()
+  5: trace_local[x]($t0)
+  6: $t3 := move($t0)
+  7: TestMutRefs::delete($t3)
+  8: return ()
 }

--- a/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
+++ b/language/move-prover/bytecode/tests/spec_instrumentation/fun_spec.exp
@@ -275,25 +275,26 @@ fun Test::mut_ref_param($t0|r: &mut Test::R): u64 {
   1: $t3 := get_field<Test::R>.v($t0)
   2: $t4 := get_field<Test::R>.v($t0)
   3: $t5 := 1
-  4: $t6 := -($t4, $t5) on_abort goto 14 with $t7
+  4: $t6 := -($t4, $t5) on_abort goto 15 with $t7
   5: $t8 := borrow_field<Test::R>.v($t0)
   6: write_ref($t8, $t6)
   7: write_back[Reference($t0).v (u64)]($t8)
   8: trace_local[r]($t0)
-  9: label L1
+  9: trace_local[r]($t0)
+ 10: label L1
      # VC: function does not abort under this condition at tests/spec_instrumentation/fun_spec.move:67:6+42
- 10: assert Not(Eq<u64>(select Test::R.v($t2), 0))
+ 11: assert Not(Eq<u64>(select Test::R.v($t2), 0))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:68:6+27
- 11: assert Eq<u64>($t3, select Test::R.v($t2))
+ 12: assert Eq<u64>($t3, select Test::R.v($t2))
      # VC: post-condition does not hold at tests/spec_instrumentation/fun_spec.move:69:6+28
- 12: assert Eq<u64>(select Test::R.v($t0), Add(select Test::R.v($t2), 1))
- 13: return $t3
- 14: label L2
+ 13: assert Eq<u64>(select Test::R.v($t0), Add(select Test::R.v($t2), 1))
+ 14: return $t3
+ 15: label L2
      # VC: abort not covered by any of the `aborts_if` clauses at tests/spec_instrumentation/fun_spec.move:66:2+138
- 15: assert Eq<u64>(select Test::R.v($t2), 0)
+ 16: assert Eq<u64>(select Test::R.v($t2), 0)
      # VC: abort code not covered by any of the `aborts_if` or `aborts_with` clauses at tests/spec_instrumentation/fun_spec.move:66:2+138
- 16: assert And(Eq<u64>(select Test::R.v($t2), 0), Eq(-1, $t7))
- 17: abort($t7)
+ 17: assert And(Eq<u64>(select Test::R.v($t2), 0), Eq(-1, $t7))
+ 18: abort($t7)
 }
 
 

--- a/language/move-prover/tests/sources/functional/choice.cvc5_exp
+++ b/language/move-prover/tests/sources/functional/choice.cvc5_exp
@@ -81,6 +81,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:65: test_min
    =     at tests/sources/functional/choice.move:66: test_min
    =     at tests/sources/functional/choice.move:67: test_min
+   =         v = <redacted>
    =     at tests/sources/functional/choice.move:68: test_min
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:69: test_min
@@ -101,6 +102,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:79: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:80: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:81: test_not_using_min_incorrect
+   =         v = <redacted>
    =     at tests/sources/functional/choice.move:82: test_not_using_min_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:83: test_not_using_min_incorrect

--- a/language/move-prover/tests/sources/functional/choice.exp
+++ b/language/move-prover/tests/sources/functional/choice.exp
@@ -82,6 +82,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:79: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:80: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:81: test_not_using_min_incorrect
+   =         v = <redacted>
    =     at tests/sources/functional/choice.move:82: test_not_using_min_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:83: test_not_using_min_incorrect

--- a/language/move-prover/tests/sources/functional/choice.simplify_exp
+++ b/language/move-prover/tests/sources/functional/choice.simplify_exp
@@ -77,6 +77,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/choice.move:79: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:80: test_not_using_min_incorrect
    =     at tests/sources/functional/choice.move:81: test_not_using_min_incorrect
+   =         v = <redacted>
    =     at tests/sources/functional/choice.move:82: test_not_using_min_incorrect
    =         result = <redacted>
    =     at tests/sources/functional/choice.move:83: test_not_using_min_incorrect

--- a/language/move-prover/tests/sources/functional/emits.move
+++ b/language/move-prover/tests/sources/functional/emits.move
@@ -1,5 +1,5 @@
-
-
+// CVC5 does take excessively long on this:
+// exclude_for: cvc5
 module 0x42::TestEmits {
     use Std::Event::{Self, EventHandle};
 

--- a/language/move-prover/tests/sources/functional/invariants.exp
+++ b/language/move-prover/tests/sources/functional/invariants.exp
@@ -48,9 +48,11 @@ error: data invariant does not hold
     =     at tests/sources/functional/invariants.move:158: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:143
     =     at tests/sources/functional/invariants.move:158: lifetime_invalid_S_branching
+    =         a = <redacted>
     =         <redacted> = <redacted>
     =         x_ref = <redacted>
     =     at tests/sources/functional/invariants.move:160: lifetime_invalid_S_branching
     =     at tests/sources/functional/invariants.move:143
     =     at tests/sources/functional/invariants.move:163: lifetime_invalid_S_branching
+    =         a = <redacted>
     =     at tests/sources/functional/invariants.move:150

--- a/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
+++ b/language/move-prover/tests/sources/functional/loops_with_memory_ops.exp
@@ -15,8 +15,10 @@ error: unknown assertion failed
    =     at tests/sources/functional/loops_with_memory_ops.move:62: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:63: nested_loop2
+   =         a = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:64: nested_loop2
+   =         b = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:66: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:67: nested_loop2
@@ -29,6 +31,8 @@ error: unknown assertion failed
    =     at tests/sources/functional/loops_with_memory_ops.move:70: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:73: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:74: nested_loop2
+   =         b = <redacted>
+   =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
@@ -50,8 +54,10 @@ error: induction case of the loop invariant does not hold
    =     at tests/sources/functional/loops_with_memory_ops.move:62: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:63: nested_loop2
+   =         a = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:64: nested_loop2
+   =         b = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:66: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:67: nested_loop2
@@ -64,11 +70,15 @@ error: induction case of the loop invariant does not hold
    =     at tests/sources/functional/loops_with_memory_ops.move:70: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:73: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:74: nested_loop2
+   =         b = <redacted>
+   =         a = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:85: nested_loop2
    =         i = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:86: nested_loop2
+   =         a = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:90: nested_loop2
+   =         b = <redacted>
    =         y = <redacted>
    =     at tests/sources/functional/loops_with_memory_ops.move:67: nested_loop2
    =     at tests/sources/functional/loops_with_memory_ops.move:68: nested_loop2

--- a/language/move-prover/tests/sources/functional/macro_verification.exp
+++ b/language/move-prover/tests/sources/functional/macro_verification.exp
@@ -1,0 +1,120 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/macro_verification.move:32:9
+   │
+32 │         ensures forall i in range(v): v[i] == old(v)[i] + 2; // fails
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = Related Bindings:
+   =         old(v) = <redacted>
+   =         v = <redacted>
+   = Execution Trace:
+   =     at tests/sources/functional/macro_verification.move:15: foreach
+   =         v = <redacted>
+   =     at tests/sources/functional/macro_verification.move:16: foreach
+   =         i = <redacted>
+   =     at tests/sources/functional/macro_verification.move:22: foreach
+   =     at tests/sources/functional/macro_verification.move:23: foreach
+   =         `invariant i >= 0 && i <= len(v);` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:24: foreach
+   =         `invariant len(v) == len(old(v));` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:25: foreach
+   =         `invariant forall j in 0..i: v[j] == old(v)[j] + 1;` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:26: foreach
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:23: foreach
+   =         `invariant i >= 0 && i <= len(v);` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:24: foreach
+   =         `invariant len(v) == len(old(v));` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:25: foreach
+   =         `invariant forall j in 0..i: v[j] == old(v)[j] + 1;` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:26: foreach
+   =         `invariant forall j in i..len(v): v[j] == old(v)[j];` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:17: foreach
+   =         v = <redacted>
+   =     at tests/sources/functional/macro_verification.move:30: foreach (spec)
+   =         `ensures len(v) == len(old(v));` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:31: foreach (spec)
+   =         `ensures forall i in range(v): v[i] == old(v)[i] + 1;` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:32: foreach (spec)
+   =         `ensures forall i in range(v): v[i] == old(v)[i] + 2;` = <redacted>
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/macro_verification.move:57:9
+   │
+57 │         ensures len(v) <= 4 ==> result == spec_sum(v, len(v)) + 1; // fails
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = Related Bindings:
+   =         result = <redacted>
+   =         spec_sum(v, len(v)) = <redacted>
+   =         v = <redacted>
+   = Execution Trace:
+   =     at tests/sources/functional/macro_verification.move:40: reduce
+   =         v = <redacted>
+   =     at tests/sources/functional/macro_verification.move:41: reduce
+   =         i = <redacted>
+   =     at tests/sources/functional/macro_verification.move:42: reduce
+   =         sum = <redacted>
+   =     at tests/sources/functional/macro_verification.move:48: reduce
+   =     at tests/sources/functional/macro_verification.move:49: reduce
+   =         `invariant i >= 0 && i <= len(v);` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:50: reduce
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:49: reduce
+   =         `invariant i >= 0 && i <= len(v);` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:50: reduce
+   =         `invariant sum == spec_sum(v, i);` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:43: reduce
+   =         result = <redacted>
+   =     at tests/sources/functional/macro_verification.move:55: reduce (spec)
+   =         `ensures result == spec_sum(v, len(v));` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:57: reduce (spec)
+   =         `ensures len(v) <= 4 ==> result == spec_sum(v, len(v)) + 1;` =
+   =           <redacted>
+
+error: post-condition does not hold
+   ┌─ tests/sources/functional/macro_verification.move:76:9
+   │
+76 │         ensures result == x + y + y; // fails
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = Related Bindings:
+   =         result = <redacted>
+   =         x = <redacted>
+   =         y = <redacted>
+   = Execution Trace:
+   =     at tests/sources/functional/macro_verification.move:67: reduce_test
+   =         x = <redacted>
+   =         y = <redacted>
+   =         z = <redacted>
+   =     at tests/sources/functional/macro_verification.move:68: reduce_test
+   =         v = <redacted>
+   =     at tests/sources/functional/macro_verification.move:69: reduce_test
+   =         v = <redacted>
+   =     at tests/sources/functional/macro_verification.move:70: reduce_test
+   =         v = <redacted>
+   =     at tests/sources/functional/macro_verification.move:71: reduce_test
+   =         v = <redacted>
+   =     at tests/sources/functional/macro_verification.move:72: reduce_test
+   =     at tests/sources/functional/macro_verification.move:40: reduce
+   =         v = <redacted>
+   =     at tests/sources/functional/macro_verification.move:41: reduce
+   =         i = <redacted>
+   =     at tests/sources/functional/macro_verification.move:42: reduce
+   =         sum = <redacted>
+   =     at tests/sources/functional/macro_verification.move:48: reduce
+   =     at tests/sources/functional/macro_verification.move:49: reduce
+   =     at tests/sources/functional/macro_verification.move:50: reduce
+   =     at tests/sources/functional/macro_verification.move:49: reduce
+   =     at tests/sources/functional/macro_verification.move:50: reduce
+   =     at tests/sources/functional/macro_verification.move:43: reduce
+   =         result = <redacted>
+   =         result = <redacted>
+   =     at tests/sources/functional/macro_verification.move:73: reduce_test
+   =     at tests/sources/functional/macro_verification.move:75: reduce_test (spec)
+   =         `ensures result == x + y + z;` = <redacted>
+   =     at tests/sources/functional/macro_verification.move:76: reduce_test (spec)
+   =         `ensures result == x + y + y;` = <redacted>

--- a/language/move-prover/tests/sources/functional/macro_verification.move
+++ b/language/move-prover/tests/sources/functional/macro_verification.move
@@ -1,0 +1,100 @@
+// flag: --trace
+
+// CVC5 does currently not terminate on this:
+// exclude_for: cvc5
+
+/// This file contains some simulated expansions of functional macros and sketches how they can be verified.
+module 0x42::FunMacros {
+    use Std::Vector;
+
+    /// Simulates `foreach!(v, |x| *x = *x + 1 spec  { ensures x == old(x) + 1; })`
+    /// where `macro foreach!<T>(v: &mut vector<T>, action: |&mut T|)`
+    ///
+    /// For the foreach macro the loop invariant can be synthesized from a post condition associated
+    /// with the lambda.
+    fun foreach(v: &mut vector<u64>) {
+        let i = 0;
+        while (i < Vector::length(v)) {
+            let x = Vector::borrow_mut(v, i);
+            *x = *x + 1;
+            i = i + 1;
+        }
+        spec {
+            invariant i >= 0 && i <= len(v);
+            invariant len(v) == len(old(v));
+            invariant forall j in 0..i: v[j] == old(v)[j] + 1; // lambda substituted
+            invariant forall j in i..len(v): v[j] == old(v)[j];
+        };
+    }
+    spec foreach {
+        ensures len(v) == len(old(v));
+        ensures forall i in range(v): v[i] == old(v)[i] + 1; // succeeds
+        ensures forall i in range(v): v[i] == old(v)[i] + 2; // fails
+    }
+
+    /// Simulates `reduce!(v, 0, |sum, x| *sum = *sum + *x ) spec { invariant sum == old(sum) + x; })`
+    /// where `macro reduce!<T, R>(v: &vector<T>, neutral: R, reducer: |&mut R, &T|): R`.
+    ///
+    /// Because the elements of the vector are combined via the reducer, we cannot specify this with
+    /// a quantifier, however, we can use a recursive helper function.
+    fun reduce(v: &vector<u64>) : u64 {
+        let i = 0;
+        let sum = 0;
+        while (i < Vector::length(v)) {
+            let x = Vector::borrow(v, i);
+            sum = sum + *x;
+            i = i + 1;
+        }
+        spec {
+            invariant i >= 0 && i <= len(v);
+            invariant sum == spec_sum(v, i);
+        };
+        sum
+    }
+    spec reduce {
+        ensures result == spec_sum(v, len(v));     // succeeds
+        // Below we use a premise for the failure case to constraint model size.
+        ensures len(v) <= 4 ==> result == spec_sum(v, len(v)) + 1; // fails
+    }
+    spec fun spec_sum(v: vector<u64>, end: num): num {
+        if (end <= 0 || end > len(v))
+            0
+        else
+            // lambda substituted, where old(sum) == spec_sum(v, end - 1)
+            spec_sum(v, end - 1) + v[end - 1]
+    }
+
+    fun reduce_test(x: u64, y: u64, z: u64): u64 {
+        let v = Vector::empty();
+        Vector::push_back(&mut v, x);
+        Vector::push_back(&mut v, y);
+        Vector::push_back(&mut v, z);
+        reduce(&v)
+    }
+    spec reduce_test {
+        ensures result == x + y + z; // succeeds
+        ensures result == x + y + y; // fails
+    }
+
+    /// Simulates `index_of!(v, |x| x > 2)`
+    /// where `macro index_of!<T>(v: &vector<T>, pred: |&T|bool): u64`.
+    ///
+    /// For index_of, we do not need any invariant at the lambda, as it's spec can be fully derived.
+    fun index_of(v: &vector<u64>): u64 {
+        let i = 0;
+        while (i < Vector::length(v)) {
+            let x = Vector::borrow(v, i);
+            if (*x > 2) return i;
+            i = i + 1;
+        }
+        spec {
+            invariant i >= 0 && i <= len(v);
+            invariant forall j in 0..i: !(v[j] > 2);
+        };
+        i
+    }
+    spec index_of {
+        ensures result >= 0 && result <= len(v);
+        ensures forall j in 0..result: !(v[j] > 2);
+    }
+}

--- a/language/move-prover/tests/sources/functional/mono.exp
+++ b/language/move-prover/tests/sources/functional/mono.exp
@@ -7,6 +7,7 @@ error: post-condition does not hold
    │
    =     at tests/sources/functional/mono.move:70: vec_addr
    =         x = <redacted>
+   =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/mono.move:71: vec_addr (spec)
 
@@ -17,6 +18,7 @@ error: post-condition does not hold
    │                     ^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/mono.move:72: vec_bool
+   =         x = <redacted>
    =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/mono.move:73: vec_bool (spec)
@@ -29,6 +31,7 @@ error: post-condition does not hold
    │
    =     at tests/sources/functional/mono.move:68: vec_int
    =         x = <redacted>
+   =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/mono.move:69: vec_int (spec)
 
@@ -40,6 +43,7 @@ error: post-condition does not hold
    │
    =     at tests/sources/functional/mono.move:76: vec_struct_addr
    =         x = <redacted>
+   =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/mono.move:77: vec_struct_addr (spec)
 
@@ -50,6 +54,7 @@ error: post-condition does not hold
    │                           ^^^^^^^^^^^^^^^^^^^^^^^^^
    │
    =     at tests/sources/functional/mono.move:74: vec_struct_int
+   =         x = <redacted>
    =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/mono.move:75: vec_struct_int (spec)
@@ -63,6 +68,7 @@ error: post-condition does not hold
    =     at tests/sources/functional/mono.move:79: vec_vec
    =         x = <redacted>
    =     at tests/sources/functional/mono.move:80: vec_vec
+   =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/mono.move:81: vec_vec
    =     at tests/sources/functional/mono.move:82: vec_vec (spec)

--- a/language/move-prover/tests/sources/functional/mut_ref.exp
+++ b/language/move-prover/tests/sources/functional/mut_ref.exp
@@ -12,17 +12,21 @@ error: data invariant does not hold
   =     at tests/sources/functional/mut_ref.move:115: call_return_ref_different_path_vec2_incorrect
   =         ts = <redacted>
   =     at tests/sources/functional/mut_ref.move:116: call_return_ref_different_path_vec2_incorrect
+  =         is = <redacted>
   =     at tests/sources/functional/mut_ref.move:117: call_return_ref_different_path_vec2_incorrect
+  =         is = <redacted>
   =     at tests/sources/functional/mut_ref.move:118: call_return_ref_different_path_vec2_incorrect
   =     at tests/sources/functional/mut_ref.move:8
   =     at tests/sources/functional/mut_ref.move:118: call_return_ref_different_path_vec2_incorrect
   =     at tests/sources/functional/mut_ref.move:8
   =     at tests/sources/functional/mut_ref.move:118: call_return_ref_different_path_vec2_incorrect
+  =         ts = <redacted>
   =     at tests/sources/functional/mut_ref.move:119: call_return_ref_different_path_vec2_incorrect
   =     at tests/sources/functional/mut_ref.move:8
   =     at tests/sources/functional/mut_ref.move:119: call_return_ref_different_path_vec2_incorrect
   =     at tests/sources/functional/mut_ref.move:8
   =     at tests/sources/functional/mut_ref.move:119: call_return_ref_different_path_vec2_incorrect
+  =         ts = <redacted>
   =     at tests/sources/functional/mut_ref.move:120: call_return_ref_different_path_vec2_incorrect
   =         x = <redacted>
   =     at tests/sources/functional/mut_ref.move:121: call_return_ref_different_path_vec2_incorrect
@@ -32,6 +36,8 @@ error: data invariant does not hold
   =     at tests/sources/functional/mut_ref.move:91: return_ref_different_path_vec2
   =         <redacted> = <redacted>
   =         result = <redacted>
+  =         x = <redacted>
+  =         x = <redacted>
   =         x = <redacted>
   =     at tests/sources/functional/mut_ref.move:92: return_ref_different_path_vec2
   =         r = <redacted>

--- a/language/move-prover/tests/sources/functional/references.exp
+++ b/language/move-prover/tests/sources/functional/references.exp
@@ -17,6 +17,7 @@ error: function does not abort under this condition
    =     at tests/sources/functional/references.move:52: mut_b
    =     at tests/sources/functional/references.move:72: mut_ref_incorrect
    =         b = <redacted>
+   =         b = <redacted>
    =     at tests/sources/functional/references.move:73: mut_ref_incorrect
    =     at tests/sources/functional/references.move:74: mut_ref_incorrect
    =     at tests/sources/functional/references.move:76: mut_ref_incorrect (spec)

--- a/language/move-prover/tests/sources/functional/strong_edges.exp
+++ b/language/move-prover/tests/sources/functional/strong_edges.exp
@@ -27,4 +27,5 @@ error: unknown assertion failed
    =     at tests/sources/functional/strong_edges.move:61: loc__edge_incorrect
    =         r_ref = <redacted>
    =     at tests/sources/functional/strong_edges.move:62: loc__edge_incorrect
+   =         r = <redacted>
    =     at tests/sources/functional/strong_edges.move:64: loc__edge_incorrect

--- a/language/move-prover/tests/sources/functional/trace.simplify_exp
+++ b/language/move-prover/tests/sources/functional/trace.simplify_exp
@@ -36,8 +36,10 @@ error: post-condition does not hold
    =     at tests/sources/functional/trace.move:29: publish_invalid
    =     at tests/sources/functional/trace.move:30: publish_invalid
    =     at tests/sources/functional/trace.move:32: publish_invalid (spec)
+   =     at ../move-stdlib/sources/Signer.move:13: address_of
    =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
    =     at tests/sources/functional/trace.move:32: publish_invalid (spec)
+   =     at ../move-stdlib/sources/Signer.move:13: address_of
    =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
    =         `ensures exists<R>(addr) ==> global<R>(addr).x == x;` = <redacted>
 

--- a/language/move-prover/tools/check_pr.sh
+++ b/language/move-prover/tools/check_pr.sh
@@ -12,6 +12,9 @@ BUILD_MODE=--release
 BASE=$(git rev-parse --show-toplevel)
 echo "*************** [check-pr] Assuming diem root at $BASE"
 
+# Run only tests which would also be run on CI
+export ENV_TEST_ON_CI=1
+
 while getopts "hcxtdgmea" opt; do
   case $opt in
     h)

--- a/language/move-stdlib/nursery/docs/ACL.md
+++ b/language/move-stdlib/nursery/docs/ACL.md
@@ -30,7 +30,7 @@ use a "set" instead when it's available in the language in the future.
 
 
 
-<pre><code><b>struct</b> <a href="ACL.md#0x1_ACL">ACL</a> has <b>copy</b>, drop, store
+<pre><code><b>struct</b> <a href="ACL.md#0x1_ACL">ACL</a> <b>has</b> <b>copy</b>, drop, store
 </code></pre>
 
 
@@ -41,7 +41,7 @@ use a "set" instead when it's available in the language in the future.
 
 <dl>
 <dt>
-<code>list: vector&lt;address&gt;</code>
+<code>list: vector&lt;<b>address</b>&gt;</code>
 </dt>
 <dd>
 
@@ -93,7 +93,7 @@ Return an empty ACL.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_empty">empty</a>(): <a href="ACL.md#0x1_ACL">ACL</a> {
-    <a href="ACL.md#0x1_ACL">ACL</a>{ list: <a href="_empty">Vector::empty</a>&lt;address&gt;() }
+    <a href="ACL.md#0x1_ACL">ACL</a>{ list: <a href="_empty">Vector::empty</a>&lt;<b>address</b>&gt;() }
 }
 </code></pre>
 
@@ -108,7 +108,7 @@ Return an empty ACL.
 Add the address to the ACL.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_add">add</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: address)
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_add">add</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: <b>address</b>)
 </code></pre>
 
 
@@ -117,7 +117,7 @@ Add the address to the ACL.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_add">add</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL">ACL</a>, addr: address) {
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_add">add</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL">ACL</a>, addr: <b>address</b>) {
     <b>assert</b>!(!<a href="_contains">Vector::contains</a>(&<b>mut</b> acl.list, &addr), <a href="_invalid_argument">Errors::invalid_argument</a>(<a href="ACL.md#0x1_ACL_ECONTAIN">ECONTAIN</a>));
     <a href="_push_back">Vector::push_back</a>(&<b>mut</b> acl.list, addr);
 }
@@ -134,7 +134,7 @@ Add the address to the ACL.
 Remove the address from the ACL.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_remove">remove</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: address)
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_remove">remove</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: <b>address</b>)
 </code></pre>
 
 
@@ -143,7 +143,7 @@ Remove the address from the ACL.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_remove">remove</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL">ACL</a>, addr: address) {
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_remove">remove</a>(acl: &<b>mut</b> <a href="ACL.md#0x1_ACL">ACL</a>, addr: <b>address</b>) {
     <b>let</b> (found, index) = <a href="_index_of">Vector::index_of</a>(&<b>mut</b> acl.list, &addr);
     <b>assert</b>!(found, <a href="_invalid_argument">Errors::invalid_argument</a>(<a href="ACL.md#0x1_ACL_ENOT_CONTAIN">ENOT_CONTAIN</a>));
     <a href="_remove">Vector::remove</a>(&<b>mut</b> acl.list, index);
@@ -161,7 +161,7 @@ Remove the address from the ACL.
 Return true iff the ACL contains the address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_contains">contains</a>(acl: &<a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: address): bool
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_contains">contains</a>(acl: &<a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -170,7 +170,7 @@ Return true iff the ACL contains the address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_contains">contains</a>(acl: &<a href="ACL.md#0x1_ACL">ACL</a>, addr: address): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_contains">contains</a>(acl: &<a href="ACL.md#0x1_ACL">ACL</a>, addr: <b>address</b>): bool {
     <a href="_contains">Vector::contains</a>(&acl.list, &addr)
 }
 </code></pre>
@@ -186,7 +186,7 @@ Return true iff the ACL contains the address.
 assert! that the ACL has the address.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_assert_contains">assert_contains</a>(acl: &<a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: address)
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_assert_contains">assert_contains</a>(acl: &<a href="ACL.md#0x1_ACL_ACL">ACL::ACL</a>, addr: <b>address</b>)
 </code></pre>
 
 
@@ -195,7 +195,7 @@ assert! that the ACL has the address.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_assert_contains">assert_contains</a>(acl: &<a href="ACL.md#0x1_ACL">ACL</a>, addr: address) {
+<pre><code><b>public</b> <b>fun</b> <a href="ACL.md#0x1_ACL_assert_contains">assert_contains</a>(acl: &<a href="ACL.md#0x1_ACL">ACL</a>, addr: <b>address</b>) {
     <b>assert</b>!(<a href="ACL.md#0x1_ACL_contains">contains</a>(acl, addr), <a href="_invalid_argument">Errors::invalid_argument</a>(<a href="ACL.md#0x1_ACL_ENOT_CONTAIN">ENOT_CONTAIN</a>));
 }
 </code></pre>

--- a/language/move-stdlib/nursery/docs/Role.md
+++ b/language/move-stdlib/nursery/docs/Role.md
@@ -26,7 +26,7 @@ A generic module for role-based access control (RBAC).
 
 
 
-<pre><code><b>struct</b> <a href="Role.md#0x1_Role">Role</a>&lt;Type&gt; has key
+<pre><code><b>struct</b> <a href="Role.md#0x1_Role">Role</a>&lt;Type&gt; <b>has</b> key
 </code></pre>
 
 
@@ -80,7 +80,7 @@ expected to be a function of the module that defines <code>Type</code>.
 
 <pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_assign_role">assign_role</a>&lt;Type&gt;(<b>to</b>: &signer, _witness: &Type) {
     <b>assert</b>!(!<a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(<a href="_address_of">Signer::address_of</a>(<b>to</b>)), <a href="_already_published">Errors::already_published</a>(<a href="Role.md#0x1_Role_EROLE">EROLE</a>));
-    move_to&lt;<a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;&gt;(<b>to</b>, <a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;{});
+    <b>move_to</b>&lt;<a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;&gt;(<b>to</b>, <a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;{});
 }
 </code></pre>
 
@@ -107,7 +107,7 @@ expected to be a function of the module that defines <code>Type</code>.
 
 <pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_revoke_role">revoke_role</a>&lt;Type&gt;(from: &signer, _witness: &Type) <b>acquires</b> <a href="Role.md#0x1_Role">Role</a> {
     <b>assert</b>!(<a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(<a href="_address_of">Signer::address_of</a>(from)), <a href="_not_published">Errors::not_published</a>(<a href="Role.md#0x1_Role_EROLE">EROLE</a>));
-    <b>let</b> <a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;{} = move_from&lt;<a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;&gt;(<a href="_address_of">Signer::address_of</a>(from));
+    <b>let</b> <a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;{} = <b>move_from</b>&lt;<a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;&gt;(<a href="_address_of">Signer::address_of</a>(from));
 }
 </code></pre>
 
@@ -122,7 +122,7 @@ expected to be a function of the module that defines <code>Type</code>.
 Return true iff the address has the role.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(addr: address): bool
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(addr: <b>address</b>): bool
 </code></pre>
 
 
@@ -131,7 +131,7 @@ Return true iff the address has the role.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(addr: address): bool {
+<pre><code><b>public</b> <b>fun</b> <a href="Role.md#0x1_Role_has_role">has_role</a>&lt;Type&gt;(addr: <b>address</b>): bool {
     <b>exists</b>&lt;<a href="Role.md#0x1_Role">Role</a>&lt;Type&gt;&gt;(addr)
 }
 </code></pre>

--- a/language/move-stdlib/tests/move_verification_test.rs
+++ b/language/move-stdlib/tests/move_verification_test.rs
@@ -3,12 +3,10 @@
 
 use move_cli::package::prover::ProverTest;
 
-#[test]
-fn prove_stdlib() {
-    ProverTest::create(".").run()
-}
+// TODO: split this into individual tests once the package system supports this.
 
 #[test]
-fn prove_nursery() {
+fn prove() {
+    ProverTest::create(".").run();
     ProverTest::create("nursery").run()
 }


### PR DESCRIPTION
This contains a new test case in [`macro_verification.move`](https://github.com/wrwg/diem/blob/inv/language/move-prover/tests/sources/functional/macro_verification.move) which simulates expansion of planned functional macros. The purpose of this to see what we can verify, and what part of the loop invariant can be derived from the specific macro.

Interestingly, after some tweaking, we are able to verify both `foreach!` style and `reduce!` style macros. The later is particularly tricky as it cannot be expressed by a quantifier. Rather, a recursive function is needed to define the loop invariant. This trick has been copied from Dafny, and it seems to work well (however, not with cvc5).

The PR fixes also a few other things around invariants:

- enabling recursive specification functions (this was not possible before)
- supporting a more adequate syntax for loop invariants: `while (cond) body spec` is syntactic sugar for `while ({spec; cond}) body`
- enabling tracing of assertions stemming from loop invariants and other in-code specs.

Also, the prover tests had been broken (perhaps invisible on CI) by a change in the package system, and unfortunately now need to be executed sequentially.

## Motivation

Loops

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test

## Related PRs

NA