### PR TITLE
[move] Don't auto-close `<` `>` pairs in VS Code

### DIFF
--- a/language/move-analyzer/editors/code/language-configuration.json
+++ b/language/move-analyzer/editors/code/language-configuration.json
@@ -9,7 +9,6 @@
         { "open": "{", "close": "}" },
         { "open": "[", "close": "]" },
         { "open": "(", "close": ")" },
-        { "open": "<", "close": ">" },
         { "open": "\"", "close": "\"", "notIn": ["string", "comment"] },
         { "open": "/*", "close": "*/", "notIn": ["string"] }
     ],

--- a/language/move-analyzer/editors/code/package-lock.json
+++ b/language/move-analyzer/editors/code/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "move-analyzer",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/language/move-analyzer/editors/code/package.json
+++ b/language/move-analyzer/editors/code/package.json
@@ -4,7 +4,7 @@
     "description": "A language server and basic grammar for the Move programming language.",
     "publisher": "move",
     "license": "Apache-2.0",
-    "version": "0.0.4",
+    "version": "0.0.5",
     "preview": true,
     "homepage": "https://developers.diem.com/docs/move/move-overview",
     "repository": {


### PR DESCRIPTION
When using the VS Code extension, `<` and `>` are defined as auto-closing pairs,
meaning that typing `<` in VS Code will result in a `>` being inserted
automatically, even in contexts where this doesn't make sense.

The rust-analzyer VS Code extension does not define `<` and `>` as auto-closing
pairs, just as "brackets" (meaning the editor highlights the opening delimiter
when the closing delimiter is selected). I think this is the right call.

Closes #9984.