### PR TITLE
[State Sync] Small renames to the data streaming service and diem data client.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -65,11 +65,11 @@ pub enum BootstrappingMode {
     ExecuteTransactionsFromGenesis,     // Executes transactions (starting at genesis)
 }
 
-/// The syncing mode determines how the node will stay up-to-date once it has
-/// bootstrapped and the blockchain continues to grow, e.g., continuously
-/// executing all transactions.
+/// The continuous syncing mode determines how the node will stay up-to-date
+/// once it has bootstrapped and the blockchain continues to grow, e.g.,
+/// continuously executing all transactions.
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub enum SyncingMode {
+pub enum ContinuousSyncingMode {
     ExecuteTransactions,     // Executes transactions to stay up-to-date
     ApplyTransactionOutputs, // Applies transaction outputs to stay up-to-date
 }
@@ -79,7 +79,7 @@ pub enum SyncingMode {
 pub struct StateSyncDriverConfig {
     pub bootstrapping_mode: BootstrappingMode, // The mode by which to bootstrap
     pub enable_state_sync_v2: bool,            // If the node should sync with state sync v2
-    pub syncing_mode: SyncingMode,             // The mode by which to sync after bootstrapping
+    pub continuous_syncing_mode: ContinuousSyncingMode, // The mode by which to sync after bootstrapping
     pub progress_check_interval_ms: u64, // The interval (ms) at which to check state sync progress
 }
 
@@ -90,7 +90,7 @@ impl Default for StateSyncDriverConfig {
         Self {
             bootstrapping_mode: BootstrappingMode::DownloadLatestAccountStates,
             enable_state_sync_v2: false,
-            syncing_mode: SyncingMode::ApplyTransactionOutputs,
+            continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
             progress_check_interval_ms: 500,
         }
     }

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_notification.rs
@@ -85,7 +85,7 @@ pub struct NumberOfAccountsRequest {
 pub struct TransactionsWithProofRequest {
     pub start_version: Version,
     pub end_version: Version,
-    pub max_proof_version: Version,
+    pub proof_version: Version,
     pub include_events: bool,
 }
 
@@ -94,7 +94,7 @@ pub struct TransactionsWithProofRequest {
 pub struct TransactionOutputsWithProofRequest {
     pub start_version: Version,
     pub end_version: Version,
-    pub max_proof_version: Version,
+    pub proof_version: Version,
 }
 
 /// A pending client response where data has been requested from the

--- a/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/data_stream.rs
@@ -744,7 +744,7 @@ async fn get_transaction_outputs_with_proof<T: DiemDataClient + Send + Clone + '
     request: TransactionOutputsWithProofRequest,
 ) -> Result<Response<ResponsePayload>, diem_data_client::Error> {
     let client_response = diem_data_client.get_transaction_outputs_with_proof(
-        request.max_proof_version,
+        request.proof_version,
         request.start_version,
         request.end_version,
     );
@@ -758,7 +758,7 @@ async fn get_transactions_with_proof<T: DiemDataClient + Send + Clone + 'static>
     request: TransactionsWithProofRequest,
 ) -> Result<Response<ResponsePayload>, diem_data_client::Error> {
     let client_response = diem_data_client.get_transactions_with_proof(
-        request.max_proof_version,
+        request.proof_version,
         request.start_version,
         request.end_version,
         request.include_events,

--- a/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
@@ -1175,7 +1175,7 @@ fn create_data_client_request(
                     DataClientRequest::TransactionsWithProof(TransactionsWithProofRequest {
                         start_version: start_index,
                         end_version: end_index,
-                        max_proof_version: target_ledger_info_version,
+                        proof_version: target_ledger_info_version,
                         include_events: request.include_events,
                     })
                 }
@@ -1184,7 +1184,7 @@ fn create_data_client_request(
                         TransactionOutputsWithProofRequest {
                             start_version: start_index,
                             end_version: end_index,
-                            max_proof_version: target_ledger_info_version,
+                            proof_version: target_ledger_info_version,
                         },
                     )
                 }
@@ -1202,7 +1202,7 @@ fn create_data_client_request(
                 DataClientRequest::TransactionsWithProof(TransactionsWithProofRequest {
                     start_version: start_index,
                     end_version: end_index,
-                    max_proof_version: request.max_proof_version,
+                    proof_version: request.proof_version,
                     include_events: request.include_events,
                 })
             }
@@ -1210,7 +1210,7 @@ fn create_data_client_request(
                 DataClientRequest::TransactionOutputsWithProof(TransactionOutputsWithProofRequest {
                     start_version: start_index,
                     end_version: end_index,
-                    max_proof_version: request.max_proof_version,
+                    proof_version: request.proof_version,
                 })
             }
             request => invalid_stream_request!(request),

--- a/state-sync/state-sync-v2/data-streaming-service/src/streaming_client.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/streaming_client.rs
@@ -48,24 +48,22 @@ pub trait DataStreamingClient {
     ) -> Result<DataStreamListener, Error>;
 
     /// Fetches all transaction outputs with proofs from `start_version` to
-    /// `end_version` (inclusive), where the proof versions can be up to the
-    /// specified `max_proof_version` (inclusive).
+    /// `end_version` (inclusive) at the specified `proof_version`.
     async fn get_all_transaction_outputs(
         &self,
         start_version: Version,
         end_version: Version,
-        max_proof_version: Version,
+        proof_version: Version,
     ) -> Result<DataStreamListener, Error>;
 
     /// Fetches all transactions with proofs from `start_version` to
-    /// `end_version` (inclusive), where the proof versions can be up to the
-    /// specified `max_proof_version` (inclusive). If `include_events` is true,
-    /// events are also included in the proofs.
+    /// `end_version` (inclusive) at the specified `proof_version`. If
+    /// `include_events` is true, events are also included in the proofs.
     async fn get_all_transactions(
         &self,
         start_version: Version,
         end_version: Version,
-        max_proof_version: Version,
+        proof_version: Version,
         include_events: bool,
     ) -> Result<DataStreamListener, Error>;
 
@@ -172,7 +170,7 @@ pub struct GetAllEpochEndingLedgerInfosRequest {
 pub struct GetAllTransactionsRequest {
     pub start_version: Version,
     pub end_version: Version,
-    pub max_proof_version: Version,
+    pub proof_version: Version,
     pub include_events: bool,
 }
 
@@ -181,7 +179,7 @@ pub struct GetAllTransactionsRequest {
 pub struct GetAllTransactionOutputsRequest {
     pub start_version: Version,
     pub end_version: Version,
-    pub max_proof_version: Version,
+    pub proof_version: Version,
 }
 
 /// A client request for continuously streaming transactions with proofs
@@ -296,13 +294,13 @@ impl DataStreamingClient for StreamingServiceClient {
         &self,
         start_version: u64,
         end_version: u64,
-        max_proof_version: u64,
+        proof_version: u64,
     ) -> Result<DataStreamListener, Error> {
         let client_request =
             StreamRequest::GetAllTransactionOutputs(GetAllTransactionOutputsRequest {
                 start_version,
                 end_version,
-                max_proof_version,
+                proof_version,
             });
         self.send_request_and_await_response(client_request).await
     }
@@ -311,13 +309,13 @@ impl DataStreamingClient for StreamingServiceClient {
         &self,
         start_version: u64,
         end_version: u64,
-        max_proof_version: u64,
+        proof_version: u64,
         include_events: bool,
     ) -> Result<DataStreamListener, Error> {
         let client_request = StreamRequest::GetAllTransactions(GetAllTransactionsRequest {
             start_version,
             end_version,
-            max_proof_version,
+            proof_version,
             include_events,
         });
         self.send_request_and_await_response(client_request).await

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/data_stream.rs
@@ -342,7 +342,7 @@ fn create_transaction_stream(
     let stream_request = StreamRequest::GetAllTransactions(GetAllTransactionsRequest {
         start_version,
         end_version,
-        max_proof_version: end_version,
+        proof_version: end_version,
         include_events: false,
     });
     create_data_stream(streaming_service_config, stream_request)

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_client.rs
@@ -87,12 +87,12 @@ fn test_get_all_transactions() {
     // Note the request we expect to receive on the streaming service side
     let request_start_version = 101;
     let request_end_version = 200;
-    let request_max_proof_version = 300;
+    let request_proof_version = 300;
     let request_include_events = true;
     let expected_request = StreamRequest::GetAllTransactions(GetAllTransactionsRequest {
         start_version: request_start_version,
         end_version: request_end_version,
-        max_proof_version: request_max_proof_version,
+        proof_version: request_proof_version,
         include_events: request_include_events,
     });
 
@@ -103,7 +103,7 @@ fn test_get_all_transactions() {
     let response = block_on(streaming_service_client.get_all_transactions(
         request_start_version,
         request_end_version,
-        request_max_proof_version,
+        request_proof_version,
         request_include_events,
     ));
     assert_ok!(response);
@@ -118,12 +118,12 @@ fn test_get_all_transaction_outputs() {
     // Note the request we expect to receive on the streaming service side
     let request_start_version = 101;
     let request_end_version = 200;
-    let request_max_proof_version = 300;
+    let request_proof_version = 300;
     let expected_request =
         StreamRequest::GetAllTransactionOutputs(GetAllTransactionOutputsRequest {
             start_version: request_start_version,
             end_version: request_end_version,
-            max_proof_version: request_max_proof_version,
+            proof_version: request_proof_version,
         });
 
     // Spawn a new server thread to handle any transaction output stream requests
@@ -133,7 +133,7 @@ fn test_get_all_transaction_outputs() {
     let response = block_on(streaming_service_client.get_all_transaction_outputs(
         request_start_version,
         request_end_version,
-        request_max_proof_version,
+        request_proof_version,
     ));
     assert_ok!(response);
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -10,7 +10,7 @@ use data_streaming_service::{
     data_stream::DataStreamListener,
     streaming_client::{DataStreamingClient, NotificationFeedback, StreamingServiceClient},
 };
-use diem_config::config::SyncingMode;
+use diem_config::config::ContinuousSyncingMode;
 use diem_infallible::Mutex;
 use diem_types::{
     contract_event::ContractEvent,
@@ -91,8 +91,8 @@ impl<S: StorageSynchronizerInterface> ContinuousSyncer<S> {
             .lock()
             .as_ref()
             .map(|sync_request| sync_request.get_sync_target());
-        let active_data_stream = match self.driver_configuration.config.syncing_mode {
-            SyncingMode::ApplyTransactionOutputs => {
+        let active_data_stream = match self.driver_configuration.config.continuous_syncing_mode {
+            ContinuousSyncingMode::ApplyTransactionOutputs => {
                 self.streaming_service_client
                     .continuously_stream_transaction_outputs(
                         next_version,
@@ -101,7 +101,7 @@ impl<S: StorageSynchronizerInterface> ContinuousSyncer<S> {
                     )
                     .await?
             }
-            SyncingMode::ExecuteTransactions => {
+            ContinuousSyncingMode::ExecuteTransactions => {
                 self.streaming_service_client
                     .continuously_stream_transactions(
                         next_version,
@@ -202,8 +202,8 @@ impl<S: StorageSynchronizerInterface> ContinuousSyncer<S> {
         .await?;
 
         // Execute/apply and commit the transactions/outputs
-        let committed_events = match self.driver_configuration.config.syncing_mode {
-            SyncingMode::ApplyTransactionOutputs => {
+        let committed_events = match self.driver_configuration.config.continuous_syncing_mode {
+            ContinuousSyncingMode::ApplyTransactionOutputs => {
                 if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
                     self.storage_synchronizer
                         .lock()
@@ -221,7 +221,7 @@ impl<S: StorageSynchronizerInterface> ContinuousSyncer<S> {
                         .await;
                 }
             }
-            SyncingMode::ExecuteTransactions => {
+            ContinuousSyncingMode::ExecuteTransactions => {
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     self.storage_synchronizer
                         .lock()


### PR DESCRIPTION
## Motivation

This (small) PR makes two simple changes (each in their own commit):
1. Renames `max_proof_version` to `proof_version` in the data streaming service and diem data client. This is required because we cannot yet support any proof versions up to the max, so this name is misleading. Instead, the proof version must be fixed.
2. Renames `SyncingMode` to `ContinuousSyncingMode` in the state sync config. This makes it consistent with the state sync driver implementation that differentiates between bootstrap syncing and continuous syncing.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

This is covered by the existing unit tests.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906