### PR TITLE
[testing-infra] add test path arg to MoveTestAdapter::init

### DIFF
--- a/language/testing-infra/diem-transactional-test-harness/src/diem_test_harness.rs
+++ b/language/testing-infra/diem-transactional-test-harness/src/diem_test_harness.rs
@@ -521,6 +521,7 @@ impl<'a> MoveTestAdapter<'a> for DiemTestAdapter<'a> {
     }
 
     fn init(
+        _: &Path,
         default_syntax: SyntaxChoice,
         pre_compiled_deps: Option<&'a FullyCompiledProgram>,
         task_opt: Option<TaskInput<(InitCommand, Self::ExtraInitArgs)>>,

--- a/language/testing-infra/transactional-test-runner/src/framework.rs
+++ b/language/testing-infra/transactional-test-runner/src/framework.rs
@@ -79,6 +79,7 @@ pub trait MoveTestAdapter<'a> {
     fn compiled_state(&mut self) -> &mut CompiledState<'a>;
     fn default_syntax(&self) -> SyntaxChoice;
     fn init(
+        test_path: &Path,
         default_syntax: SyntaxChoice,
         option: Option<&'a FullyCompiledProgram>,
         init_data: Option<TaskInput<(InitCommand, Self::ExtraInitArgs)>>,
@@ -496,7 +497,7 @@ where
             None
         }
     };
-    let mut adapter = Adapter::init(default_syntax, fully_compiled_program_opt, init_opt);
+    let mut adapter = Adapter::init(path, default_syntax, fully_compiled_program_opt, init_opt);
     for task in tasks {
         handle_known_task(&mut output, &mut adapter, task);
     }

--- a/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/language/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -80,6 +80,7 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
     }
 
     fn init(
+        _: &Path,
         default_syntax: SyntaxChoice,
         pre_compiled_deps: Option<&'a FullyCompiledProgram>,
         task_opt: Option<TaskInput<(InitCommand, EmptyCommand)>>,


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation
I intended to integrate a custom `MoveTestAdapter` into Move package system to do transactional test.
However, current trait interface cannot make the adapter aware the current package to test. 
Init the adapter with `test_path` will make it happen.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
