### PR TITLE
[forge] Fix forge test exit code

### DIFF
--- a/scripts/fgi/run
+++ b/scripts/fgi/run
@@ -235,22 +235,22 @@ print(
 print("**********\n")
 
 test_res = 'failed'
+# perf report
+test_report = []
+read_lines = False
+with open(f"{OUTPUT_TEE}", 'r') as file:
+    for line in file.readlines():
+        if 'json-report-end' in line: read_lines = False
+        if read_lines:
+            test_report.append(line)
+        if 'json-report-begin' in line: read_lines = True
+        if 'test result: ok' in line: test_res = 'passed'
+if len(test_report) == 0:
+    test_report.append("{\"text\": \"Forge test runner is terminated\"}")
+temp = json.loads(''.join(test_report))
+temp["logs"] = "Logs: " + LOGGING_LINK
+temp["dashboard"] = "Dashboard: " + DASHBOARD_LINK
 if args.report:
-    # perf report
-    test_report = []
-    read_lines = False
-    with open(f"{OUTPUT_TEE}", 'r') as file:
-        for line in file.readlines():
-            if 'json-report-end' in line: read_lines = False
-            if read_lines:
-                test_report.append(line)
-            if 'json-report-begin' in line: read_lines = True
-            if 'test result: ok' in line: test_res = 'passed'
-    if len(test_report) == 0:
-        test_report.append("{\"text\": \"Forge test runner is terminated\"}")
-    temp = json.loads(''.join(test_report))
-    temp["logs"] = "Logs: " + LOGGING_LINK
-    temp["dashboard"] = "Dashboard: " + DASHBOARD_LINK
     with open(f"{REPORT}", 'w') as file_object:
         file_object.write(json.dumps(temp))
 


### PR DESCRIPTION
If we do not pass in args for `args.report`, forge test exit code will be 1 which ci/cd pipeline will treat it as failed.

We should remove the condition outside for wrong logic here

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
