### PR TITLE
[github] Update "Libra" in doc issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/documentation_bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F41B Documentation/developers.libra.org Bug report"
+name: "\U0001F41B Documentation/developers.diem.com Bug report"
 about: Create a bug report to help improve the Diem Developers' Website
 title: "[Bug]"
 labels: bug
@@ -9,11 +9,8 @@ assignees: ''
 
 # 🐛 Bug
 
-If you're looking to report an issue with the Diem Core project go to https://github.com/diem/diem
-
-<!-- A clear and concise description of what the bug is.
-
-If you've uncovered a security issue, please email security@libra.org -->
+<!-- A clear and concise description of your issue with the documentation or website.
+To report a security issue, please email security@diem.com. -->
 
 ## Steps to reproduce
 
@@ -32,7 +29,6 @@ If you've uncovered a security issue, please email security@libra.org -->
 
 **Please complete the following information:**
 - <!-- Browser type and version -->
-
 
 ## Additional context
 


### PR DESCRIPTION
The old links technically do appear to work, but the name incongruity doesn't inspire confidence. Update them to refer to Diem's URLs.

Closes #9804.