### PR TITLE
[State Sync] Add bootstrapper component to state sync driver.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -1,0 +1,848 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    driver::DriverConfiguration,
+    error::Error,
+    storage_synchronizer::{StorageStateSummary, StorageSynchronizerInterface},
+    utils,
+};
+use data_streaming_service::{
+    data_notification::{DataNotification, DataPayload, NotificationId},
+    data_stream::DataStreamListener,
+    streaming_client::{DataStreamingClient, NotificationFeedback, StreamingServiceClient},
+};
+use diem_config::config::BootstrappingMode;
+use diem_data_client::GlobalDataSummary;
+use diem_infallible::Mutex;
+use diem_logger::*;
+use diem_types::{
+    contract_event::ContractEvent,
+    epoch_change::Verifier,
+    epoch_state::EpochState,
+    ledger_info::LedgerInfoWithSignatures,
+    transaction::{
+        default_protocol::{TransactionListWithProof, TransactionOutputListWithProof},
+        Version,
+    },
+    waypoint::Waypoint,
+};
+use event_notifications::EventSubscriptionService;
+use futures::channel::oneshot;
+use std::{collections::BTreeMap, sync::Arc};
+
+/// A simple container for verified epoch states and epoch ending ledger infos
+/// that have been fetched from the network.
+struct VerifiedEpochStates {
+    // If new epoch ending ledger infos have been fetched from the network
+    fetched_epoch_ending_ledger_infos: bool,
+
+    // The highest epoch ending version fetched thus far
+    highest_fetched_epoch_ending_version: Version,
+
+    // The latest epoch state that has been verified by the node
+    latest_epoch_state: EpochState,
+
+    // A map from versions to epoch ending ledger infos fetched from the network
+    new_epoch_ending_ledger_infos: BTreeMap<Version, LedgerInfoWithSignatures>,
+
+    // If the node has successfully verified the waypoint
+    verified_waypoint: bool,
+}
+
+impl VerifiedEpochStates {
+    pub fn new(latest_epoch_state: EpochState) -> Self {
+        Self {
+            fetched_epoch_ending_ledger_infos: false,
+            highest_fetched_epoch_ending_version: 0,
+            latest_epoch_state,
+            new_epoch_ending_ledger_infos: BTreeMap::new(),
+            verified_waypoint: false,
+        }
+    }
+
+    /// Returns true iff the node has already fetched any new epoch
+    /// ending ledger infos from the network.
+    pub fn fetched_epoch_ending_ledger_infos(&self) -> bool {
+        self.fetched_epoch_ending_ledger_infos
+    }
+
+    /// Sets `fetched_epoch_ending_ledger_infos` to true
+    pub fn set_fetched_epoch_ending_ledger_infos(&mut self) {
+        self.fetched_epoch_ending_ledger_infos = true;
+    }
+
+    /// Returns true iff the node has verified the waypoint
+    pub fn verified_waypoint(&self) -> bool {
+        self.verified_waypoint
+    }
+
+    /// Sets `verified_waypoint` to true
+    pub fn set_verified_waypoint(&mut self) {
+        self.verified_waypoint = true;
+    }
+
+    /// Verifies the given epoch ending ledger info, updates our latest
+    /// trusted epoch state and attempts to verify any given waypoint.
+    pub fn verify_epoch_ending_ledger_info(
+        &mut self,
+        epoch_ending_ledger_info: &LedgerInfoWithSignatures,
+        waypoint: &Waypoint,
+    ) -> Result<(), Error> {
+        // Verify the ledger info against the latest epoch state
+        self.latest_epoch_state
+            .verify(epoch_ending_ledger_info)
+            .map_err(|error| {
+                Error::VerificationError(format!("Ledger info failed verification: {:?}", error))
+            })?;
+
+        // Update the latest epoch state with the next epoch
+        if let Some(next_epoch_state) = epoch_ending_ledger_info.ledger_info().next_epoch_state() {
+            self.highest_fetched_epoch_ending_version =
+                epoch_ending_ledger_info.ledger_info().version();
+            self.latest_epoch_state = next_epoch_state.clone();
+            self.insert_new_epoch_ending_ledger_info(epoch_ending_ledger_info.clone());
+
+            trace!(
+                "Updated the latest epoch state to epoch: {:?}",
+                self.latest_epoch_state.epoch
+            );
+        } else {
+            return Err(Error::VerificationError(
+                "The ledger info was not epoch ending!".into(),
+            ));
+        }
+
+        // Check if the ledger info corresponds to the trusted waypoint
+        self.verify_waypoint(epoch_ending_ledger_info, waypoint)
+    }
+
+    /// Attempts to verify the waypoint using the new epoch ending ledger info
+    fn verify_waypoint(
+        &mut self,
+        epoch_ending_ledger_info: &LedgerInfoWithSignatures,
+        waypoint: &Waypoint,
+    ) -> Result<(), Error> {
+        if !self.verified_waypoint {
+            // Fetch the waypoint and ledger info versions
+            let waypoint_version = waypoint.version();
+            let ledger_info = epoch_ending_ledger_info.ledger_info();
+            let ledger_info_version = ledger_info.version();
+
+            // Verify we haven't missed the waypoint
+            if ledger_info_version > waypoint_version {
+                return Err(Error::VerificationError(
+                    format!("Failed to verify the waypoint: ledger info version is too high! Waypoint version: {:?}, ledger info version: {:?}",
+                            waypoint_version, ledger_info_version)
+                ));
+            }
+
+            // Check if we've found the ledger info corresponding to the waypoint version
+            if ledger_info_version == waypoint_version {
+                match waypoint.verify(ledger_info) {
+                    Ok(()) => self.verified_waypoint = true,
+                    Err(error) => {
+                        return Err(Error::VerificationError(
+                            format!("Failed to verify the waypoint: {:?}! Waypoint: {:?}, given ledger info: {:?}",
+                                    error, waypoint, ledger_info)
+                        ));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Adds an epoch ending ledger info to the new epoch ending ledger infos map
+    fn insert_new_epoch_ending_ledger_info(
+        &mut self,
+        epoch_ending_ledger_info: LedgerInfoWithSignatures,
+    ) {
+        debug!(
+            "Adding a new epoch to the epoch ending ledger infos: {:?}",
+            &epoch_ending_ledger_info
+        );
+
+        // Insert the version to ledger info mapping
+        let version = epoch_ending_ledger_info.ledger_info().version();
+        if let Some(epoch_ending_ledger_info) = self
+            .new_epoch_ending_ledger_infos
+            .insert(version, epoch_ending_ledger_info)
+        {
+            panic!(
+                "Duplicate epoch ending ledger info found!\
+                 Version: {:?}, \
+                 ledger info: {:?}",
+                version, epoch_ending_ledger_info,
+            );
+        }
+    }
+
+    /// Returns any epoch ending ledger info associated with the given version
+    pub fn get_epoch_ending_ledger_info(
+        &self,
+        version: Version,
+    ) -> Option<LedgerInfoWithSignatures> {
+        self.new_epoch_ending_ledger_infos.get(&version).cloned()
+    }
+
+    /// Returns the highest known ledger info (including the newly fetch ones)
+    pub fn get_highest_known_ledger_info(
+        &self,
+        latest_storage_summary: StorageStateSummary,
+    ) -> LedgerInfoWithSignatures {
+        // Get the current highest versioned ledger info from storage
+        let mut highest_known_ledger_info = latest_storage_summary.latest_ledger_info;
+
+        // Check if we've fetched a higher versioned ledger info from the network
+        if !self.new_epoch_ending_ledger_infos.is_empty() {
+            let highest_fetched_ledger_info = self
+                .get_epoch_ending_ledger_info(self.highest_fetched_epoch_ending_version)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "The highest known ledger info for version: {:?} was not found!",
+                        self.highest_fetched_epoch_ending_version
+                    )
+                });
+
+            if highest_fetched_ledger_info.ledger_info().version()
+                > highest_known_ledger_info.ledger_info().version()
+            {
+                highest_known_ledger_info = highest_fetched_ledger_info;
+            }
+        }
+
+        highest_known_ledger_info
+    }
+
+    /// Returns the next epoch ending version after the given version (if one
+    /// exists).
+    pub fn next_epoch_ending_version(&self, version: Version) -> Option<Version> {
+        // BTreeMap keys are iterated through in increasing key orders (i.e., versions)
+        for (epoch_ending_version, _) in self.new_epoch_ending_ledger_infos.iter() {
+            if *epoch_ending_version > version {
+                return Some(*epoch_ending_version);
+            }
+        }
+        None
+    }
+}
+
+/// A simple component that manages the bootstrapping of the node
+pub struct Bootstrapper<S> {
+    // The currently active data stream (provided by the data streaming service)
+    active_data_stream: Option<DataStreamListener>,
+
+    // The channel used to notify a listener of successful bootstrapping
+    bootstrap_notifier_channel: Option<oneshot::Sender<Result<(), Error>>>,
+
+    // If the node has completed bootstrapping
+    bootstrapped: bool,
+
+    // The config of the state sync driver
+    driver_configuration: DriverConfiguration,
+
+    // The event subscription service to notify listeners of on-chain events
+    event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
+
+    // The client through which to stream data from the Diem network
+    streaming_service_client: StreamingServiceClient,
+
+    // The storage synchronizer used to update local storage
+    storage_synchronizer: Arc<Mutex<S>>,
+
+    // The epoch states verified by this node (held in memory)
+    verified_epoch_states: VerifiedEpochStates,
+}
+
+impl<S: StorageSynchronizerInterface> Bootstrapper<S> {
+    pub fn new(
+        driver_configuration: DriverConfiguration,
+        event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
+        streaming_service_client: StreamingServiceClient,
+        storage_synchronizer: Arc<Mutex<S>>,
+    ) -> Self {
+        // Load the latest epoch state from storage
+        let latest_storage_summary = storage_synchronizer
+            .lock()
+            .get_storage_summary()
+            .expect("Unable to load storage summary!");
+        let latest_epoch_state = latest_storage_summary.latest_epoch_state;
+        let verified_epoch_states = VerifiedEpochStates::new(latest_epoch_state);
+
+        Self {
+            active_data_stream: None,
+            bootstrap_notifier_channel: None,
+            bootstrapped: false,
+            driver_configuration,
+            event_subscription_service,
+            streaming_service_client,
+            storage_synchronizer,
+            verified_epoch_states,
+        }
+    }
+
+    /// Returns true iff the node has already completed bootstrapping
+    pub fn is_bootstrapped(&self) -> bool {
+        self.bootstrapped
+    }
+
+    /// Subscribes the specified channel to bootstrap completion notifications
+    pub fn subscribe_to_bootstrap_notifications(
+        &mut self,
+        bootstrap_notifier_channel: oneshot::Sender<Result<(), Error>>,
+    ) {
+        if self.bootstrap_notifier_channel.is_some() {
+            panic!("Only one boostrap subscriber is supported at a time!");
+        }
+
+        self.bootstrap_notifier_channel = Some(bootstrap_notifier_channel)
+    }
+
+    /// Notifies any listeners if we've now bootstrapped
+    fn notify_if_bootstrapped(&mut self) -> Result<(), Error> {
+        if self.bootstrapped {
+            if let Some(notifier_channel) = self.bootstrap_notifier_channel.take() {
+                if let Err(error) = notifier_channel.send(Ok(())) {
+                    return Err(Error::CallbackSendFailed(format!(
+                        "Bootstrap notification error: {:?}",
+                        error
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Checks if the bootstrapper is able to make progress
+    pub async fn drive_progress(
+        &mut self,
+        global_data_summary: &GlobalDataSummary,
+    ) -> Result<(), Error> {
+        if self.is_bootstrapped() {
+            return Err(Error::AlreadyBootstrapped(
+                "The bootstrapper should not attempt to make progress!".into(),
+            ));
+        }
+
+        if self.active_data_stream.is_some() {
+            // We have an active data stream. Process any notifications!
+            self.process_active_stream_notifications().await?;
+        } else {
+            // Fetch a new data stream to start streaming data
+            self.initialize_active_data_stream(global_data_summary)
+                .await?;
+        }
+
+        // Check if we've now bootstrapped
+        self.notify_if_bootstrapped()
+    }
+
+    /// Initializes an active data stream so that we can begin to process notifications
+    async fn initialize_active_data_stream(
+        &mut self,
+        global_data_summary: &GlobalDataSummary,
+    ) -> Result<(), Error> {
+        // Always fetch the new epoch ending ledger infos first
+        if !self
+            .verified_epoch_states
+            .fetched_epoch_ending_ledger_infos()
+            || !self.verified_epoch_states.verified_waypoint()
+        {
+            return self
+                .fetch_epoch_ending_ledger_infos(global_data_summary)
+                .await;
+        }
+
+        // Get the highest synced and known ledger info versions
+        let highest_synced_version = self.get_highest_synced_version()?;
+        let highest_known_ledger_info = self.get_highest_known_ledger_info()?;
+        let highest_known_ledger_version = highest_known_ledger_info.ledger_info().version();
+
+        // Check if we've already fetched the required data for bootstrapping
+        if highest_synced_version == highest_known_ledger_version {
+            info!("The node has successfully bootstrapped!");
+            self.bootstrapped = true;
+            return Ok(());
+        }
+
+        // Verify we haven't synced beyond the highest ledger info
+        if highest_synced_version > highest_known_ledger_version {
+            unreachable!(
+                "Synced beyond the highest ledger info! Synced version: {:?}, highest ledger version: {:?}", highest_synced_version, highest_known_ledger_version
+            );
+        }
+
+        // Fetch all data until the epoch ending ledger info for the current epoch
+        let next_version = highest_synced_version.checked_add(1).ok_or_else(|| {
+            Error::IntegerOverflow("The next output version has overflown!".into())
+        })?;
+        let end_version = self
+            .verified_epoch_states
+            .next_epoch_ending_version(highest_synced_version)
+            .expect("No higher epoch ending version known!");
+        let data_stream = match self.driver_configuration.config.bootstrapping_mode {
+            BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
+                self.streaming_service_client
+                    .get_all_transaction_outputs(
+                        next_version,
+                        end_version,
+                        highest_known_ledger_version,
+                    )
+                    .await?
+            }
+            BootstrappingMode::ExecuteTransactionsFromGenesis => {
+                self.streaming_service_client
+                    .get_all_transactions(
+                        next_version,
+                        end_version,
+                        highest_known_ledger_version,
+                        false,
+                    )
+                    .await?
+            }
+            bootstrapping_mode => {
+                unimplemented!("Bootstrapping mode not supported: {:?}", bootstrapping_mode)
+            }
+        };
+        self.active_data_stream = Some(data_stream);
+
+        Ok(())
+    }
+
+    /// Processes any notifications already pending on the active stream
+    async fn process_active_stream_notifications(&mut self) -> Result<(), Error> {
+        loop {
+            // Fetch and process any data notifications
+            let data_notification =
+                utils::get_data_notification(self.active_data_stream.as_mut()).await?;
+            match data_notification.data_payload {
+                DataPayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos) => {
+                    self.process_epoch_ending_payload(
+                        data_notification.notification_id,
+                        epoch_ending_ledger_infos,
+                    )
+                    .await?;
+                }
+                DataPayload::TransactionsWithProof(transactions_with_proof) => {
+                    let payload_start_version = transactions_with_proof.first_transaction_version;
+                    self.process_transaction_or_output_payload(
+                        data_notification.notification_id,
+                        Some(transactions_with_proof),
+                        None,
+                        payload_start_version,
+                    )
+                    .await?;
+                }
+                DataPayload::TransactionOutputsWithProof(transaction_outputs_with_proof) => {
+                    let payload_start_version =
+                        transaction_outputs_with_proof.first_transaction_output_version;
+                    self.process_transaction_or_output_payload(
+                        data_notification.notification_id,
+                        None,
+                        Some(transaction_outputs_with_proof),
+                        payload_start_version,
+                    )
+                    .await?;
+                }
+                _ => {
+                    return self
+                        .handle_end_of_stream_or_invalid_payload(data_notification)
+                        .await
+                }
+            }
+        }
+    }
+
+    /// Fetches all epoch ending ledger infos (from the current epoch to the
+    /// maximum that can be found by the data streaming service).
+    async fn fetch_epoch_ending_ledger_infos(
+        &mut self,
+        global_data_summary: &GlobalDataSummary,
+    ) -> Result<(), Error> {
+        // Verify the waypoint can be satisfied
+        self.verify_waypoint_is_satisfiable(global_data_summary)?;
+
+        // Get the highest advertised epoch that has ended
+        let highest_advertised_epoch_end = global_data_summary
+            .advertised_data
+            .highest_epoch_ending_ledger_info()
+            .ok_or_else(|| {
+                Error::AdvertisedDataError(
+                    "No highest advertised epoch end found in the network!".into(),
+                )
+            })?;
+
+        // Fetch the highest epoch end known locally
+        let highest_known_ledger_info = self.get_highest_known_ledger_info()?;
+        let highest_known_ledger_info = highest_known_ledger_info.ledger_info();
+        let highest_local_epoch_end = if highest_known_ledger_info.ends_epoch() {
+            highest_known_ledger_info.epoch()
+        } else if highest_known_ledger_info.epoch() > 0 {
+            highest_known_ledger_info
+                .epoch()
+                .checked_sub(1)
+                .ok_or_else(|| {
+                    Error::IntegerOverflow("The highest local epoch end has overflown!".into())
+                })?
+        } else {
+            unreachable!("Genesis should always end epoch 0!");
+        };
+
+        // Compare the highest local epoch end to the highest advertised epoch end
+        if highest_local_epoch_end > highest_advertised_epoch_end {
+            let error_message =
+                format!(
+                    "The highest local epoch end is higher than the advertised epoch end! Local: {:?}, advertised: {:?}",
+                    highest_local_epoch_end, highest_advertised_epoch_end
+                );
+            return Err(Error::AdvertisedDataError(error_message));
+        } else if highest_local_epoch_end < highest_advertised_epoch_end {
+            debug!("Found higher epoch ending ledger infos in the network! Local: {:?}, advertised: {:?}",
+                   highest_local_epoch_end, highest_advertised_epoch_end);
+            let next_epoch_end = highest_local_epoch_end.checked_add(1).ok_or_else(|| {
+                Error::IntegerOverflow("The next epoch end has overflown!".into())
+            })?;
+            let epoch_ending_stream = self
+                .streaming_service_client
+                .get_all_epoch_ending_ledger_infos(next_epoch_end)
+                .await?;
+            self.active_data_stream = Some(epoch_ending_stream);
+        } else if self.verified_epoch_states.verified_waypoint() {
+            debug!("No new epoch ending ledger infos to fetch! All peers are in the same epoch!");
+            self.verified_epoch_states
+                .set_fetched_epoch_ending_ledger_infos();
+        } else {
+            return Err(Error::AdvertisedDataError("Our waypoint is unverified, but there's no higher epoch ending ledger infos advertised!".into()));
+        };
+
+        Ok(())
+    }
+
+    /// Verifies that connected peers have advertised data beyond our waypoint
+    /// or that our waypoint is trivially satisfiable.
+    fn verify_waypoint_is_satisfiable(
+        &mut self,
+        global_data_summary: &GlobalDataSummary,
+    ) -> Result<(), Error> {
+        // If our storage has already synced beyond our waypoint, nothing needs to be checked
+        let latest_storage_summary = self.storage_synchronizer.lock().get_storage_summary()?;
+        let latest_ledger_info = latest_storage_summary.latest_ledger_info.ledger_info();
+        let waypoint_version = self.driver_configuration.waypoint.version();
+        if latest_ledger_info.version() >= waypoint_version {
+            self.verified_epoch_states.set_verified_waypoint();
+            return Ok(());
+        }
+
+        // Get the highest advertised synced ledger info version
+        let highest_advertised_ledger_info = global_data_summary
+            .advertised_data
+            .highest_synced_ledger_info()
+            .ok_or_else(|| {
+                Error::AdvertisedDataError(
+                    "No highest advertised ledger info found in the network!".into(),
+                )
+            })?;
+        let highest_advertised_version = highest_advertised_ledger_info.ledger_info().version();
+
+        // Compare the highest advertised version with our waypoint
+        if highest_advertised_version < waypoint_version {
+            Err(Error::AdvertisedDataError(
+                format!(
+                    "No advertised version higher than our waypoint! Highest version: {:?}, waypoint version: {:?}",
+                    highest_advertised_version, waypoint_version
+                )
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Process a single epoch ending payload
+    async fn process_epoch_ending_payload(
+        &mut self,
+        notification_id: NotificationId,
+        epoch_ending_ledger_infos: Vec<LedgerInfoWithSignatures>,
+    ) -> Result<(), Error> {
+        // Verify the payload isn't empty
+        if epoch_ending_ledger_infos.is_empty() {
+            self.terminate_active_stream(notification_id, NotificationFeedback::EmptyPayloadData)
+                .await?;
+            return Err(Error::VerificationError(
+                "The epoch ending payload was empty!".into(),
+            ));
+        }
+
+        // Verify the epoch change proofs, update our latest epoch state and
+        // verify our waypoint.
+        for epoch_ending_ledger_info in epoch_ending_ledger_infos {
+            if let Err(error) = self.verified_epoch_states.verify_epoch_ending_ledger_info(
+                &epoch_ending_ledger_info,
+                &self.driver_configuration.waypoint,
+            ) {
+                self.terminate_active_stream(
+                    notification_id,
+                    NotificationFeedback::PayloadProofFailed,
+                )
+                .await?;
+                return Err(error);
+            }
+        }
+
+        // TODO(joshlind): do we want to preemptively notify certain components
+        // of the new reconfigurations?
+
+        Ok(())
+    }
+
+    /// Process a single transaction or transaction output data payload
+    async fn process_transaction_or_output_payload(
+        &mut self,
+        notification_id: NotificationId,
+        transaction_list_with_proof: Option<TransactionListWithProof>,
+        transaction_outputs_with_proof: Option<TransactionOutputListWithProof>,
+        payload_start_version: Option<Version>,
+    ) -> Result<(), Error> {
+        // Verify the payload starting version
+        self.verify_payload_start_version(notification_id, payload_start_version)
+            .await?;
+
+        // Get the end of epoch ledger info if the payload ends the epoch
+        let end_of_epoch_ledger_info = self
+            .get_end_of_epoch_ledger_info(
+                notification_id,
+                payload_start_version,
+                transaction_list_with_proof.as_ref(),
+                transaction_outputs_with_proof.as_ref(),
+            )
+            .await?;
+
+        // Get the highest known ledger info (this should be the proof ledger info)
+        let highest_known_ledger_info = self.get_highest_known_ledger_info()?;
+
+        // Execute/apply and commit the transactions/outputs
+        let committed_events = match self.driver_configuration.config.bootstrapping_mode {
+            BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
+                if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
+                    self.storage_synchronizer
+                        .lock()
+                        .apply_and_commit_transaction_outputs(
+                            transaction_outputs_with_proof,
+                            highest_known_ledger_info,
+                            end_of_epoch_ledger_info,
+                        )
+                } else {
+                    self.terminate_active_stream(
+                        notification_id,
+                        NotificationFeedback::PayloadTypeIsIncorrect,
+                    )
+                    .await?;
+                    return Err(Error::InvalidPayload(
+                        "Did not receive transaction outputs with proof!".into(),
+                    ));
+                }
+            }
+            BootstrappingMode::ExecuteTransactionsFromGenesis => {
+                if let Some(transaction_list_with_proof) = transaction_list_with_proof {
+                    self.storage_synchronizer
+                        .lock()
+                        .execute_and_commit_transactions(
+                            transaction_list_with_proof,
+                            highest_known_ledger_info,
+                            end_of_epoch_ledger_info,
+                        )
+                } else {
+                    self.terminate_active_stream(
+                        notification_id,
+                        NotificationFeedback::PayloadTypeIsIncorrect,
+                    )
+                    .await?;
+                    return Err(Error::InvalidPayload(
+                        "Did not receive transactions with proof!".into(),
+                    ));
+                }
+            }
+            bootstrapping_mode => {
+                unimplemented!("Bootstrapping mode not supported: {:?}", bootstrapping_mode)
+            }
+        };
+
+        // Notify the event subscription service of new events
+        self.notify_committed_events(notification_id, committed_events)
+            .await
+    }
+
+    /// Verifies the first payload version matches the version we wish to sync
+    async fn verify_payload_start_version(
+        &mut self,
+        notification_id: NotificationId,
+        payload_start_version: Option<Version>,
+    ) -> Result<(), Error> {
+        // Fetch the highest synced version
+        let highest_synced_version = self.get_highest_synced_version()?;
+
+        // Compare the payload start version with the expected version
+        if let Some(payload_start_version) = payload_start_version {
+            let expected_version = highest_synced_version
+                .checked_add(1)
+                .ok_or_else(|| Error::IntegerOverflow("Expected version has overflown!".into()))?;
+
+            if payload_start_version != expected_version {
+                self.terminate_active_stream(
+                    notification_id,
+                    NotificationFeedback::InvalidPayloadData,
+                )
+                .await?;
+                Err(Error::VerificationError(format!(
+                    "The payload start version does not match the expected version! Start: {:?}, expected: {:?}",
+                    payload_start_version, expected_version
+                )))
+            } else {
+                Ok(())
+            }
+        } else {
+            self.terminate_active_stream(notification_id, NotificationFeedback::EmptyPayloadData)
+                .await?;
+            Err(Error::VerificationError(
+                "The playload starting version is missing!".into(),
+            ))
+        }
+    }
+
+    /// Returns the end of epoch ledger info for the given payload. If
+    /// calculation fails, the active stream is terminated. Assumes the
+    /// `payload_start_version` exists.
+    async fn get_end_of_epoch_ledger_info(
+        &mut self,
+        notification_id: NotificationId,
+        payload_start_version: Option<Version>,
+        transaction_list_with_proof: Option<&TransactionListWithProof>,
+        transaction_outputs_with_proof: Option<&TransactionOutputListWithProof>,
+    ) -> Result<Option<LedgerInfoWithSignatures>, Error> {
+        let payload_start_version =
+            payload_start_version.expect("Payload start version should exist!");
+
+        // Calculate the payload end version
+        let num_versions = match self.driver_configuration.config.bootstrapping_mode {
+            BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
+                if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
+                    transaction_outputs_with_proof
+                        .transactions_and_outputs
+                        .len()
+                } else {
+                    self.terminate_active_stream(
+                        notification_id,
+                        NotificationFeedback::PayloadTypeIsIncorrect,
+                    )
+                    .await?;
+                    return Err(Error::InvalidPayload(
+                        "Did not receive transaction outputs with proof!".into(),
+                    ));
+                }
+            }
+            BootstrappingMode::ExecuteTransactionsFromGenesis => {
+                if let Some(transaction_list_with_proof) = transaction_list_with_proof {
+                    transaction_list_with_proof.transactions.len()
+                } else {
+                    self.terminate_active_stream(
+                        notification_id,
+                        NotificationFeedback::PayloadTypeIsIncorrect,
+                    )
+                    .await?;
+                    return Err(Error::InvalidPayload(
+                        "Did not receive transactions with proof!".into(),
+                    ));
+                }
+            }
+            bootstrapping_mode => {
+                unimplemented!("Bootstrapping mode not supported: {:?}", bootstrapping_mode)
+            }
+        };
+        let payload_end_version = payload_start_version
+            .checked_add(num_versions as u64)
+            .and_then(|v| v.checked_sub(1))
+            .ok_or_else(|| {
+                Error::IntegerOverflow("The payload end version has overflown!".into())
+            })?; // payload_end_version = payload_start_version + num_versions - 1
+
+        // Find any epoch ending ledger info at the payload end version
+        Ok(self
+            .verified_epoch_states
+            .get_epoch_ending_ledger_info(payload_end_version))
+    }
+
+    /// Notifies the event subscription service of committed events
+    async fn notify_committed_events(
+        &mut self,
+        notification_id: NotificationId,
+        committed_events: Result<Vec<ContractEvent>, Error>,
+    ) -> Result<(), Error> {
+        match committed_events {
+            Ok(committed_events) => {
+                let latest_storage_summary =
+                    self.storage_synchronizer.lock().get_storage_summary()?;
+                utils::notify_committed_events(
+                    latest_storage_summary,
+                    self.event_subscription_service.clone(),
+                    committed_events,
+                )
+                .await
+            }
+            Err(error) => {
+                self.terminate_active_stream(
+                    notification_id,
+                    NotificationFeedback::InvalidPayloadData,
+                )
+                .await?;
+                Err(error)
+            }
+        }
+    }
+
+    /// Returns the highest synced version in storage
+    fn get_highest_synced_version(&self) -> Result<Version, Error> {
+        let latest_storage_summary = self.storage_synchronizer.lock().get_storage_summary()?;
+        Ok(latest_storage_summary.latest_synced_version)
+    }
+
+    /// Returns the highest known ledger info (including the newly fetch ones)
+    fn get_highest_known_ledger_info(&self) -> Result<LedgerInfoWithSignatures, Error> {
+        let latest_storage_summary = self.storage_synchronizer.lock().get_storage_summary()?;
+        Ok(self
+            .verified_epoch_states
+            .get_highest_known_ledger_info(latest_storage_summary))
+    }
+
+    /// Handles the end of stream notification or an invalid payload by
+    /// terminating the stream appropriately.
+    pub async fn handle_end_of_stream_or_invalid_payload(
+        &mut self,
+        data_notification: DataNotification,
+    ) -> Result<(), Error> {
+        self.active_data_stream = None;
+
+        utils::handle_end_of_stream_or_invalid_payload(
+            &mut self.streaming_service_client,
+            data_notification,
+        )
+        .await
+    }
+
+    /// Terminates the currently active stream with the provided feedback
+    async fn terminate_active_stream(
+        &mut self,
+        notification_id: NotificationId,
+        notification_feedback: NotificationFeedback,
+    ) -> Result<(), Error> {
+        self.active_data_stream = None;
+
+        utils::terminate_stream_with_feedback(
+            &mut self.streaming_service_client,
+            notification_id,
+            notification_feedback,
+        )
+        .await
+    }
+}

--- a/state-sync/state-sync-v2/state-sync-driver/src/error.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     FullNodeConsensusNotification(String),
     #[error("An integer overflow has occurred: {0}")]
     IntegerOverflow(String),
+    #[error("An invalid payload was received: {0}")]
+    InvalidPayload(String),
     #[error("Failed to notify mempool of the new commit: {0}")]
     NotifyMempoolError(String),
     #[error("Received an old sync request for version {0}, but our committed version is: {1}")]

--- a/state-sync/state-sync-v2/state-sync-driver/src/lib.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![forbid(unsafe_code)]
 
+mod bootstrapper;
 mod continuous_syncer;
 mod driver;
 mod driver_client;

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/driver.rs
@@ -5,25 +5,10 @@ use crate::tests::{
     utils,
     utils::{create_ledger_info_at_version, create_test_transaction},
 };
-use claim::{assert_err, assert_ok, assert_some};
+use claim::assert_err;
 use consensus_notifications::ConsensusNotificationSender;
-use futures::{FutureExt, StreamExt};
 
-#[tokio::test]
-async fn test_bootstrap_notification() {
-    // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, _, _) = utils::create_validator_driver();
-
-    // Send a new commit notification to the driver to complete bootstrapping
-    let result = consensus_notifier
-        .notify_new_commit(vec![create_test_transaction()], vec![])
-        .await;
-    assert_ok!(result);
-
-    // TODO(joshlind): verify the client is notified (the node has already bootstrapped)
-
-    // TODO(joshlind): verify listeners are also eventually notified when the node bootstraps
-}
+// TODO(joshlind): extend these tests to cover more functionality!
 
 #[tokio::test]
 async fn test_consensus_commit_notification() {
@@ -37,25 +22,13 @@ async fn test_consensus_commit_notification() {
     assert_err!(result);
 
     // Create a driver for a validator with a waypoint at version 0
-    let (_validator_driver, consensus_notifier, mut mempool_listener, mut reconfig_listener) =
-        utils::create_validator_driver();
+    let (_validator_driver, consensus_notifier, _, _) = utils::create_validator_driver();
 
-    // Send a new commit notification to the driver
+    // Send a new commit notification and verify the node isn't bootstrapped
     let result = consensus_notifier
         .notify_new_commit(vec![create_test_transaction()], vec![])
         .await;
-    assert_ok!(result);
-
-    // Verify that mempool is notified
-    let mempool_commit_notification = mempool_listener.select_next_some().now_or_never().unwrap();
-    let result = mempool_listener.ack_commit_notification(mempool_commit_notification);
-    assert_ok!(result);
-
-    // Verify reconfiguration notifications are published
-    assert_some!(reconfig_listener
-        .notification_receiver
-        .select_next_some()
-        .now_or_never());
+    assert_err!(result);
 }
 
 #[tokio::test]
@@ -72,19 +45,9 @@ async fn test_consensus_sync_request() {
     // Create a driver for a validator with a waypoint at version 0
     let (_validator_driver, consensus_notifier, _, _) = utils::create_validator_driver();
 
-    // Send a new commit notification to the driver to complete bootstrapping
-    let result = consensus_notifier
-        .notify_new_commit(vec![create_test_transaction()], vec![])
-        .await;
-    assert_ok!(result);
-
-    // Verify the driver notifies consensus that it has already reached the target
+    // Send a new sync request and verify the node isn't bootstrapped
     let result = consensus_notifier
         .sync_to_target(create_ledger_info_at_version(0))
         .await;
-    assert_ok!(result);
-
-    // TODO(joshlind): verify the validator sync request should error because the node has not bootstrapped
-
-    // TODO(joshlind): update the database and ensure that consensus is eventually notified
+    assert_err!(result);
 }

--- a/testsuite/smoke-test/src/lib.rs
+++ b/testsuite/smoke-test/src/lib.rs
@@ -30,6 +30,8 @@ mod release_flow;
 #[cfg(test)]
 mod state_sync;
 #[cfg(test)]
+mod state_sync_v2;
+#[cfg(test)]
 mod storage;
 
 #[cfg(test)]

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -8,7 +8,6 @@ use crate::{
         assert_balance, create_and_fund_account, diem_swarm_utils::insert_waypoint, transfer_coins,
     },
 };
-use diem_config::config::NodeConfig;
 use diem_types::{
     account_address::AccountAddress,
     epoch_change::EpochChangeProof,
@@ -341,64 +340,5 @@ fn test_state_sync_multichunk_epoch() {
         .unwrap();
     swarm
         .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(60))
-        .unwrap();
-}
-
-#[test]
-fn test_state_sync_v2_fullnode() {
-    // Create a validator swarm of 1 validator node
-    let mut swarm = new_local_swarm(1);
-
-    // Create a fullnode config with state sync v2 enabled
-    let mut vfn_config = NodeConfig::default_for_validator_full_node();
-    vfn_config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
-
-    // Create the fullnode running state sync v2
-    let validator_peer_id = swarm.validators().next().unwrap().peer_id();
-    let vfn_peer_id = swarm
-        .add_validator_fullnode(
-            &swarm.versions().max().unwrap(),
-            vfn_config,
-            validator_peer_id,
-        )
-        .unwrap();
-
-    // Start the validator and fullnode (make sure they boot up)
-    swarm
-        .validator_mut(validator_peer_id)
-        .unwrap()
-        .wait_until_healthy(Instant::now() + Duration::from_secs(30))
-        .unwrap();
-    for fullnode in swarm.full_nodes_mut() {
-        fullnode
-            .wait_until_healthy(Instant::now() + Duration::from_secs(30))
-            .unwrap();
-    }
-
-    // Stop the fullnode
-    swarm.fullnode_mut(vfn_peer_id).unwrap().stop();
-
-    // Execute a number of transactions on the validator
-    let validator_client = swarm
-        .validator(validator_peer_id)
-        .unwrap()
-        .json_rpc_client();
-    let transaction_factory = swarm.chain_info().transaction_factory();
-    let mut account_0 = create_and_fund_account(&mut swarm, 1000);
-    let account_1 = create_and_fund_account(&mut swarm, 1000);
-    for _ in 0..10 {
-        transfer_coins(
-            &validator_client,
-            &transaction_factory,
-            &mut account_0,
-            &account_1,
-            1,
-        );
-    }
-
-    // Restart the fullnode and verify it can sync
-    swarm.fullnode_mut(vfn_peer_id).unwrap().restart().unwrap();
-    swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(30))
         .unwrap();
 }

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -1,0 +1,182 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    scripts_and_modules::enable_open_publishing,
+    smoke_test_environment::new_local_swarm,
+    test_utils::{create_and_fund_account, transfer_coins},
+};
+use diem_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
+use diem_sdk::{
+    client::BlockingClient, transaction_builder::TransactionFactory, types::LocalAccount,
+};
+use forge::{LocalSwarm, NodeExt, Swarm, SwarmExt};
+use std::time::{Duration, Instant};
+
+const MAX_CATCH_UP_SECS: u64 = 60; // The max time we'll wait for nodes to catch up
+
+#[test]
+fn test_full_node_bootstrap_outputs() {
+    // Create a validator swarm of 1 validator node
+    let swarm = new_local_swarm(1);
+
+    // Create a fullnode config that uses transaction outputs to sync
+    let mut vfn_config = NodeConfig::default_for_validator_full_node();
+    vfn_config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+    vfn_config.state_sync.state_sync_driver.bootstrapping_mode =
+        BootstrappingMode::ApplyTransactionOutputsFromGenesis;
+    vfn_config
+        .state_sync
+        .state_sync_driver
+        .continuous_syncing_mode = ContinuousSyncingMode::ApplyTransactionOutputs;
+
+    // Test the ability of the fullnode to sync
+    test_full_node_sync(vfn_config, swarm, true)
+}
+
+#[test]
+fn test_full_node_bootstrap_transactions() {
+    // Create a validator swarm of 1 validator node
+    let swarm = new_local_swarm(1);
+
+    // Create a fullnode config that uses transactions to sync
+    let mut vfn_config = NodeConfig::default_for_validator_full_node();
+    vfn_config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+    vfn_config.state_sync.state_sync_driver.bootstrapping_mode =
+        BootstrappingMode::ExecuteTransactionsFromGenesis;
+    vfn_config
+        .state_sync
+        .state_sync_driver
+        .continuous_syncing_mode = ContinuousSyncingMode::ExecuteTransactions;
+
+    // Test the ability of the fullnode to sync
+    test_full_node_sync(vfn_config, swarm, true)
+}
+
+#[test]
+fn test_full_node_continuous_sync_outputs() {
+    // Create a validator swarm of 1 validator node
+    let swarm = new_local_swarm(1);
+
+    // Create a fullnode config that uses transaction outputs to sync
+    let mut vfn_config = NodeConfig::default_for_validator_full_node();
+    vfn_config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+    vfn_config
+        .state_sync
+        .state_sync_driver
+        .continuous_syncing_mode = ContinuousSyncingMode::ApplyTransactionOutputs;
+
+    // Test the ability of the fullnode to sync
+    test_full_node_sync(vfn_config, swarm, false)
+}
+
+#[test]
+fn test_full_node_continuous_sync_transactions() {
+    // Create a validator swarm of 1 validator node
+    let swarm = new_local_swarm(1);
+
+    // Create a fullnode config that uses transactions to sync
+    let mut vfn_config = NodeConfig::default_for_validator_full_node();
+    vfn_config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+    vfn_config
+        .state_sync
+        .state_sync_driver
+        .continuous_syncing_mode = ContinuousSyncingMode::ExecuteTransactions;
+
+    // Test the ability of the fullnode to sync
+    test_full_node_sync(vfn_config, swarm, false)
+}
+
+/// A helper method that tests that a full node can sync from a validator after
+/// a failure and continue to stay up-to-date.
+fn test_full_node_sync(full_node_config: NodeConfig, mut swarm: LocalSwarm, epoch_changes: bool) {
+    // Create the fullnode
+    let validator_peer_id = swarm.validators().next().unwrap().peer_id();
+    let vfn_peer_id = swarm
+        .add_validator_fullnode(
+            &swarm.versions().max().unwrap(),
+            full_node_config,
+            validator_peer_id,
+        )
+        .unwrap();
+
+    // Start the validator and fullnode (make sure they boot up)
+    swarm
+        .validator_mut(validator_peer_id)
+        .unwrap()
+        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .unwrap();
+    for fullnode in swarm.full_nodes_mut() {
+        fullnode
+            .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+            .unwrap();
+    }
+
+    // Stop the fullnode
+    swarm.fullnode_mut(vfn_peer_id).unwrap().stop();
+
+    // Execute a number of transactions on the validator
+    let validator_client = swarm
+        .validator(validator_peer_id)
+        .unwrap()
+        .json_rpc_client();
+    let transaction_factory = swarm.chain_info().transaction_factory();
+    let mut account_0 = create_and_fund_account(&mut swarm, 1000);
+    let mut account_1 = create_and_fund_account(&mut swarm, 1000);
+    execute_transactions(
+        &mut swarm,
+        &validator_client,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        epoch_changes,
+    );
+
+    // Restart the fullnode and verify it can sync
+    swarm.fullnode_mut(vfn_peer_id).unwrap().restart().unwrap();
+    swarm
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .unwrap();
+
+    // Execute more transactions on the validator and verify the fullnode catches up
+    execute_transactions(
+        &mut swarm,
+        &validator_client,
+        &transaction_factory,
+        &mut account_1,
+        &account_0,
+        epoch_changes,
+    );
+    swarm
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .unwrap();
+}
+
+/// Executes transactions using the given transaction factory, client and
+/// accounts. If `force_epoch_changes` is true, also execute transactions to
+/// force reconfigurations.
+fn execute_transactions(
+    swarm: &mut LocalSwarm,
+    json_rpc_client: &BlockingClient,
+    transaction_factory: &TransactionFactory,
+    account_0: &mut LocalAccount,
+    account_1: &LocalAccount,
+    force_epoch_changes: bool,
+) {
+    for _ in 0..10 {
+        // Execute simple transfer transactions
+        transfer_coins(
+            json_rpc_client,
+            transaction_factory,
+            account_0,
+            account_1,
+            1,
+        );
+
+        // Cause an epoch change if required
+        if force_epoch_changes {
+            let root_account = swarm.chain_info().root_account;
+            enable_open_publishing(json_rpc_client, transaction_factory, root_account).unwrap();
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

This PR adds the final component to the state sync driver: the bootstrapper. This is the component required to bootstrap a node up to the latest epoch ending ledger info version before it can begin syncing continuously from that point. To achieve this, the PR offers several commits:
1. First, we add several new smoke tests to test that a fullnode can bootstrap correctly. At this point, the tests fail because bootstrapping is not supported.
2. Next, we provide some small cleanups to the state sync utils and ensure errors are thrown correctly whenever we terminate an active data stream.
3. Finally, we add the boostrapper component and plug it into the state sync driver. This is the missing piece of the puzzle that enables the new smoke tests to pass!
4. Simplify some of the unit tests (for now). We'll need to build a bigger framework to start testing the functionality.

One this PR lands, I'll start adding further smoke tests (e.g., for validator functionality) and more comprehensive unit and integration tests to verify edge cases.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New smoke tests have been added for the new functionality.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906