### PR TITLE
[forge] Add support for more experiment optional args

### DIFF
--- a/testsuite/forge/src/interface/network.rs
+++ b/testsuite/forge/src/interface/network.rs
@@ -3,6 +3,7 @@
 
 use super::Test;
 use crate::{CoreContext, Result, Swarm, TestReport};
+use transaction_emitter::EmitJobRequest;
 
 /// The testing interface which defines a test written with full control over an existing network.
 /// Tests written against this interface will have access to both the Root account as well as the
@@ -16,14 +17,21 @@ pub struct NetworkContext<'t> {
     core: CoreContext,
     swarm: &'t mut dyn Swarm,
     pub report: &'t mut TestReport,
+    pub global_job: EmitJobRequest,
 }
 
 impl<'t> NetworkContext<'t> {
-    pub fn new(core: CoreContext, swarm: &'t mut dyn Swarm, report: &'t mut TestReport) -> Self {
+    pub fn new(
+        core: CoreContext,
+        swarm: &'t mut dyn Swarm,
+        report: &'t mut TestReport,
+        global_job: EmitJobRequest,
+    ) -> Self {
         Self {
             core,
             swarm,
             report,
+            global_job,
         }
     }
 


### PR DESCRIPTION
Added support for all optional args used be in CT:

```
--account-per-client
--workers-per-ac
--wait-millis
--burst
--emit-to-validator
```
also added support to run single test instead of whole suite

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

```
./scripts/fgi/run -T dev_czh_pull_10011 --accounts-per-client 50 --workers-per-ac 4 --wait-millis 1000 --burst --emit-to-validator true --suite bench  
```

```
====json-report-begin===
{
  "metrics": [
    {
      "test_name": "all up",
      "metric": "submitted_txn",
      "value": 1004300.0
    },
    {
      "test_name": "all up",
      "metric": "expired_txn",
      "value": 0.0
    },
    {
      "test_name": "all up",
      "metric": "avg_tps",
      "value": 0.0
    },
    {
      "test_name": "all up",
      "metric": "avg_latency",
      "value": 0.0
    },
    {
      "test_name": "all up",
      "metric": "p99_latency",
      "value": 0.0
    }
  ],
  "text": "all up : 0 TPS, 0 ms latency, 0 ms p99 latency,no expired txns"
}
====json-report-end===

test result: ok. 1 passed; 0 failed; 0 filtered out
```

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
