### PR TITLE
[forge] Add test recovery between two tests runs

### DIFF
--- a/testsuite/forge-cli/src/main.rs
+++ b/testsuite/forge-cli/src/main.rs
@@ -349,9 +349,9 @@ fn pre_release_suite() -> ForgeConfig<'static> {
             &FixedTpsTest,
             &PerformanceBenchmark,
             &NonZeroGasPrice,
-            &PartialNodesDown,
             &ReconfigurationTest,
             &StateSyncPerformance,
+            &PartialNodesDown,
         ])
 }
 

--- a/testsuite/forge/src/interface/network.rs
+++ b/testsuite/forge/src/interface/network.rs
@@ -3,6 +3,7 @@
 
 use super::Test;
 use crate::{CoreContext, Result, Swarm, TestReport};
+use std::{thread, time::Duration};
 
 /// The testing interface which defines a test written with full control over an existing network.
 /// Tests written against this interface will have access to both the Root account as well as the
@@ -10,6 +11,15 @@ use crate::{CoreContext, Result, Swarm, TestReport};
 pub trait NetworkTest: Test {
     /// Executes the test against the given context.
     fn run<'t>(&self, ctx: &mut NetworkContext<'t>) -> Result<()>;
+
+    /// TODO need to implement proper node recovery check:
+    /// endpoint check
+    /// commit seq check
+    /// node health check
+    fn recovery(&self) -> Result<()> {
+        thread::sleep(Duration::from_secs(10));
+        Ok(())
+    }
 }
 
 pub struct NetworkContext<'t> {

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -279,6 +279,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                     NetworkContext::new(CoreContext::from_rng(&mut rng), &mut *swarm, &mut report);
                 let result = run_test(|| test.run(&mut network_ctx));
                 summary.handle_result(test.name().to_owned(), result)?;
+                test.recovery()?;
             }
 
             report.print_report();


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
