### PR TITLE
[language][prover] rename bytecode, interpreter and boogie-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,34 +492,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "boogie-backend"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytecode",
- "codespan",
- "codespan-reporting",
- "diem-workspace-hack",
- "futures",
- "itertools 0.10.1",
- "log",
- "move-binary-format",
- "move-command-line-common",
- "move-core-types",
- "move-model",
- "num 0.4.0",
- "once_cell",
- "pretty",
- "rand 0.8.4",
- "regex",
- "serde 1.0.130",
- "serde_json",
- "tera",
- "tokio",
-]
-
-[[package]]
 name = "bounded-executor"
 version = "0.1.0"
 dependencies = [
@@ -563,57 +535,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
-name = "bytecode"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "codespan",
- "codespan-reporting",
- "datatest-stable",
- "diem-workspace-hack",
- "im",
- "itertools 0.10.1",
- "log",
- "move-binary-format",
- "move-borrow-graph",
- "move-bytecode-verifier",
- "move-command-line-common",
- "move-core-types",
- "move-ir-to-bytecode",
- "move-model",
- "move-prover-test-utils",
- "move-read-write-set-types",
- "move-stdlib",
- "num 0.4.0",
- "once_cell",
- "paste",
- "petgraph 0.5.1",
- "serde 1.0.130",
- "serde_json",
-]
-
-[[package]]
-name = "bytecode-interpreter"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bytecode",
- "bytecode-interpreter-crypto",
- "codespan-reporting",
- "datatest-stable",
- "diem-workspace-hack",
- "itertools 0.10.1",
- "move-binary-format",
- "move-core-types",
- "move-model",
- "move-prover-test-utils",
- "move-vm-runtime",
- "num 0.4.0",
- "serde 1.0.130",
- "structopt 0.3.21",
-]
-
-[[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
 dependencies = [
@@ -630,11 +551,11 @@ name = "bytecode-interpreter-testsuite"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytecode-interpreter",
  "datatest-stable",
  "diem-workspace-hack",
  "move-command-line-common",
  "move-prover-test-utils",
+ "move-stackless-bytecode-interpreter",
  "move-stdlib",
  "move-unit-test",
 ]
@@ -1795,7 +1716,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bcs",
- "bytecode-interpreter",
  "diem-framework",
  "diem-types",
  "diem-vm",
@@ -1804,6 +1724,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-model",
+ "move-stackless-bytecode-interpreter",
  "move-vm-runtime",
  "move-vm-types",
  "structopt 0.3.21",
@@ -5190,7 +5111,6 @@ name = "move-docgen"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytecode",
  "codespan",
  "codespan-reporting",
  "datatest-stable",
@@ -5201,6 +5121,7 @@ dependencies = [
  "move-model",
  "move-prover",
  "move-prover-test-utils",
+ "move-stackless-bytecode",
  "num 0.4.0",
  "once_cell",
  "regex",
@@ -5401,9 +5322,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "atty",
- "boogie-backend",
- "bytecode",
- "bytecode-interpreter",
  "clap",
  "codespan",
  "codespan-reporting",
@@ -5422,7 +5340,10 @@ dependencies = [
  "move-errmapgen",
  "move-ir-types",
  "move-model",
+ "move-prover-boogie-backend",
  "move-prover-test-utils",
+ "move-stackless-bytecode",
+ "move-stackless-bytecode-interpreter",
  "num 0.4.0",
  "once_cell",
  "pretty",
@@ -5435,6 +5356,34 @@ dependencies = [
  "tokio",
  "toml",
  "walkdir",
+]
+
+[[package]]
+name = "move-prover-boogie-backend"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "codespan",
+ "codespan-reporting",
+ "diem-workspace-hack",
+ "futures",
+ "itertools 0.10.1",
+ "log",
+ "move-binary-format",
+ "move-command-line-common",
+ "move-core-types",
+ "move-model",
+ "move-stackless-bytecode",
+ "num 0.4.0",
+ "once_cell",
+ "pretty",
+ "rand 0.8.4",
+ "regex",
+ "serde 1.0.130",
+ "serde_json",
+ "tera",
+ "tokio",
 ]
 
 [[package]]
@@ -5472,6 +5421,57 @@ dependencies = [
  "move-vm-types",
  "once_cell",
  "serde 1.0.130",
+]
+
+[[package]]
+name = "move-stackless-bytecode"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "codespan",
+ "codespan-reporting",
+ "datatest-stable",
+ "diem-workspace-hack",
+ "im",
+ "itertools 0.10.1",
+ "log",
+ "move-binary-format",
+ "move-borrow-graph",
+ "move-bytecode-verifier",
+ "move-command-line-common",
+ "move-core-types",
+ "move-ir-to-bytecode",
+ "move-model",
+ "move-prover-test-utils",
+ "move-read-write-set-types",
+ "move-stdlib",
+ "num 0.4.0",
+ "once_cell",
+ "paste",
+ "petgraph 0.5.1",
+ "serde 1.0.130",
+ "serde_json",
+]
+
+[[package]]
+name = "move-stackless-bytecode-interpreter"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytecode-interpreter-crypto",
+ "codespan-reporting",
+ "datatest-stable",
+ "diem-workspace-hack",
+ "itertools 0.10.1",
+ "move-binary-format",
+ "move-core-types",
+ "move-model",
+ "move-prover-test-utils",
+ "move-stackless-bytecode",
+ "move-vm-runtime",
+ "num 0.4.0",
+ "serde 1.0.130",
+ "structopt 0.3.21",
 ]
 
 [[package]]
@@ -5516,7 +5516,6 @@ name = "move-transactional-test-runner"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytecode-interpreter",
  "colored",
  "datatest-stable",
  "diem-workspace-hack",
@@ -5532,6 +5531,7 @@ dependencies = [
  "move-ir-compiler",
  "move-ir-types",
  "move-resource-viewer",
+ "move-stackless-bytecode-interpreter",
  "move-stdlib",
  "move-symbol-pool",
  "move-vm-runtime",
@@ -5549,7 +5549,6 @@ name = "move-unit-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytecode-interpreter",
  "colored",
  "datatest-stable",
  "diem-workspace-hack",
@@ -5561,6 +5560,7 @@ dependencies = [
  "move-core-types",
  "move-model",
  "move-resource-viewer",
+ "move-stackless-bytecode-interpreter",
  "move-stdlib",
  "move-vm-runtime",
  "move-vm-test-utils",
@@ -6660,7 +6660,6 @@ name = "prover-lab"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytecode",
  "chrono",
  "clap",
  "codespan-reporting",
@@ -6672,6 +6671,7 @@ dependencies = [
  "move-model",
  "move-prover",
  "move-prover-test-utils",
+ "move-stackless-bytecode",
  "num 0.4.0",
  "plotters",
  "serde 1.0.130",
@@ -6685,7 +6685,6 @@ name = "prover-mutation"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytecode",
  "chrono",
  "clap",
  "codespan",
@@ -6698,6 +6697,7 @@ dependencies = [
  "move-model",
  "move-prover",
  "move-prover-test-utils",
+ "move-stackless-bytecode",
  "num 0.4.0",
  "plotters",
  "serde 1.0.130",
@@ -6933,7 +6933,6 @@ name = "read-write-set"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytecode",
  "diem-workspace-hack",
  "move-binary-format",
  "move-bytecode-utils",
@@ -6941,6 +6940,7 @@ dependencies = [
  "move-model",
  "move-read-write-set-types",
  "move-resource-viewer",
+ "move-stackless-bytecode",
  "read-write-set-dynamic",
 ]
 
@@ -8146,12 +8146,12 @@ name = "spec-flatten"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytecode",
  "diem-workspace-hack",
  "itertools 0.10.1",
  "move-compiler",
  "move-model",
  "move-prover",
+ "move-stackless-bytecode",
  "pretty",
  "structopt 0.3.21",
 ]

--- a/diem-move/e2e-tests-replay/Cargo.toml
+++ b/diem-move/e2e-tests-replay/Cargo.toml
@@ -14,7 +14,7 @@ structopt = "0.3.21"
 walkdir = "2.3.1"
 
 diem-workspace-hack = { path = "../../crates/diem-workspace-hack" }
-bytecode-interpreter = { path = "../../language/move-prover/interpreter" }
+move-stackless-bytecode-interpreter = { path = "../../language/move-prover/interpreter" }
 diem-types = { path = "../../types", features = ["fuzzing"] }
 diem-framework = { path = "../../diem-move/diem-framework" }
 diem-vm = { path = "../../diem-move/diem-vm" }

--- a/diem-move/e2e-tests-replay/src/lib.rs
+++ b/diem-move/e2e-tests-replay/src/lib.rs
@@ -9,15 +9,6 @@ use std::{
 };
 use walkdir::WalkDir;
 
-use bytecode_interpreter::{
-    concrete::{
-        runtime::{convert_move_struct_tag, convert_move_value},
-        ty::BaseType,
-        value::GlobalState,
-    },
-    shared::bridge::{adapt_move_vm_change_set, adapt_move_vm_result},
-    StacklessBytecodeInterpreter,
-};
 use diem_types::{
     access_path::Path as AP,
     account_address::AccountAddress,
@@ -56,6 +47,15 @@ use move_core_types::{
     language_storage::{ModuleId, TypeTag},
     value::MoveValue,
     vm_status::{KeptVMStatus, VMStatus},
+};
+use move_stackless_bytecode_interpreter::{
+    concrete::{
+        runtime::{convert_move_struct_tag, convert_move_value},
+        ty::BaseType,
+        value::GlobalState,
+    },
+    shared::bridge::{adapt_move_vm_change_set, adapt_move_vm_result},
+    StacklessBytecodeInterpreter,
 };
 use move_vm_runtime::{move_vm::MoveVM, session::Session};
 use move_vm_types::gas_schedule::GasStatus;

--- a/diem-move/e2e-tests-replay/src/main.rs
+++ b/diem-move/e2e-tests-replay/src/main.rs
@@ -5,10 +5,12 @@ use anyhow::{bail, Result};
 use std::collections::{BTreeMap, BTreeSet};
 use structopt::StructOpt;
 
-use bytecode_interpreter::{concrete::settings::InterpreterSettings, StacklessBytecodeInterpreter};
 use diem_framework::diem_stdlib_files;
 use diem_types::on_chain_config::{DiemVersion, DIEM_MAX_KNOWN_VERSION};
 use move_model::run_model_builder;
+use move_stackless_bytecode_interpreter::{
+    concrete::settings::InterpreterSettings, StacklessBytecodeInterpreter,
+};
 
 use diem_e2e_tests_replay::{self, ReplayFlags};
 

--- a/language/move-prover/Cargo.toml
+++ b/language/move-prover/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dependencies]
-# diem dependencies
-boogie-backend = { path = "boogie-backend" }
+# move dependencies
+move-prover-boogie-backend = { path = "boogie-backend" }
 move-command-line-common = { path = "../move-command-line-common" }
 move-binary-format = { path = "../move-binary-format" }
 move-compiler = { path = "../move-compiler" }
@@ -16,8 +16,8 @@ move-model = { path = "../move-model" }
 move-docgen = { path = "move-docgen" }
 move-abigen = { path = "move-abigen" }
 move-errmapgen = { path = "move-errmapgen" }
-bytecode = { path = "bytecode" }
-bytecode-interpreter = { path = "interpreter" }
+move-stackless-bytecode = { path = "bytecode" }
+move-stackless-bytecode-interpreter = { path = "interpreter" }
 move-ir-types = { path = "../move-ir/types" }
 move-core-types = { path = "../move-core/types" }
 

--- a/language/move-prover/boogie-backend/Cargo.toml
+++ b/language/move-prover/boogie-backend/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "boogie-backend"
+name = "move-prover-boogie-backend"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
 description = "Move prover Boogie backend"
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1.42"
-bytecode = { path = "../bytecode" }
+move-stackless-bytecode = { path = "../bytecode" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-model = { path = "../../move-model" }
 move-binary-format = { path = "../../move-binary-format" }

--- a/language/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/language/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -4,7 +4,6 @@
 //! Helpers for emitting Boogie code.
 
 use crate::options::BoogieOptions;
-use bytecode::function_target::FunctionTarget;
 use itertools::Itertools;
 use move_model::{
     ast::{MemoryLabel, TempIndex},
@@ -15,6 +14,7 @@ use move_model::{
     symbol::Symbol,
     ty::{PrimitiveType, Type},
 };
+use move_stackless_bytecode::function_target::FunctionTarget;
 
 pub const MAX_MAKE_VEC_ARGS: usize = 4;
 

--- a/language/move-prover/boogie-backend/src/boogie_wrapper.rs
+++ b/language/move-prover/boogie-backend/src/boogie_wrapper.rs
@@ -15,7 +15,6 @@ use once_cell::sync::Lazy;
 use pretty::RcDoc;
 use regex::Regex;
 
-use bytecode::function_target_pipeline::{FunctionTargetsHolder, FunctionVariant};
 use move_binary_format::file_format::FunctionDefinitionIndex;
 use move_model::{
     ast::TempIndex,
@@ -23,6 +22,7 @@ use move_model::{
     model::{FunId, GlobalEnv, Loc, ModuleId, NodeId, QualifiedId, StructId},
     ty::{PrimitiveType, Type},
 };
+use move_stackless_bytecode::function_target_pipeline::{FunctionTargetsHolder, FunctionVariant};
 
 // DEBUG
 // use backtrace::Backtrace;

--- a/language/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/language/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -9,18 +9,18 @@ use itertools::Itertools;
 #[allow(unused_imports)]
 use log::{debug, info, log, warn, Level};
 
-use bytecode::{
-    function_target::FunctionTarget,
-    function_target_pipeline::{FunctionTargetsHolder, VerificationFlavor},
-    mono_analysis,
-    stackless_bytecode::{BorrowEdge, BorrowNode, Bytecode, Constant, HavocKind, Operation},
-};
 use move_model::{
     code_writer::CodeWriter,
     emit, emitln,
     model::{GlobalEnv, StructEnv},
     pragmas::{ADDITION_OVERFLOW_UNCHECKED_PRAGMA, SEED_PRAGMA, TIMEOUT_PRAGMA},
     ty::{PrimitiveType, Type},
+};
+use move_stackless_bytecode::{
+    function_target::FunctionTarget,
+    function_target_pipeline::{FunctionTargetsHolder, VerificationFlavor},
+    mono_analysis,
+    stackless_bytecode::{BorrowEdge, BorrowNode, Bytecode, Constant, HavocKind, Operation},
 };
 
 use crate::{
@@ -35,15 +35,15 @@ use crate::{
     options::BoogieOptions,
     spec_translator::SpecTranslator,
 };
-use bytecode::{
-    function_target_pipeline::FunctionVariant,
-    stackless_bytecode::{AbortAction, PropKind},
-};
 use codespan::LineIndex;
 use move_model::{
     ast::{TempIndex, TraceKind},
     model::{Loc, NodeId},
     ty::{TypeDisplayContext, BOOL_TYPE},
+};
+use move_stackless_bytecode::{
+    function_target_pipeline::FunctionVariant,
+    stackless_bytecode::{AbortAction, PropKind},
 };
 
 pub struct BoogieTranslator<'env> {

--- a/language/move-prover/boogie-backend/src/lib.rs
+++ b/language/move-prover/boogie-backend/src/lib.rs
@@ -11,13 +11,13 @@ use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use tera::{Context, Tera};
 
-use bytecode::mono_analysis;
 use move_model::{
     code_writer::CodeWriter,
     emit, emitln,
     model::GlobalEnv,
     ty::{PrimitiveType, Type},
 };
+use move_stackless_bytecode::mono_analysis;
 
 use crate::{
     boogie_helpers::{boogie_type, boogie_type_suffix},

--- a/language/move-prover/boogie-backend/src/spec_translator.rs
+++ b/language/move-prover/boogie-backend/src/spec_translator.rs
@@ -30,11 +30,11 @@ use crate::{
     },
     options::BoogieOptions,
 };
-use bytecode::mono_analysis::MonoInfo;
 use move_model::{
     ast::{Exp, MemoryLabel, QuantKind, SpecFunDecl, SpecVarDecl, TempIndex},
     model::{QualifiedInstId, SpecVarId},
 };
+use move_stackless_bytecode::mono_analysis::MonoInfo;
 use std::cell::RefCell;
 
 #[derive(Clone)]

--- a/language/move-prover/bytecode/Cargo.toml
+++ b/language/move-prover/bytecode/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bytecode"
+name = "move-stackless-bytecode"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
 description = "Move stackless bytecode"

--- a/language/move-prover/bytecode/tests/testsuite.rs
+++ b/language/move-prover/bytecode/tests/testsuite.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::anyhow;
-use bytecode::{
+use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
+use move_command_line_common::testing::EXP_EXT;
+use move_model::{model::GlobalEnv, options::ModelBuilderOptions, run_model_builder_with_options};
+use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
+use move_stackless_bytecode::{
     borrow_analysis::BorrowAnalysisProcessor,
     clean_and_optimize::CleanAndOptimizeProcessor,
     data_invariant_instrumentation::DataInvariantInstrumentationProcessor,
@@ -26,10 +30,6 @@ use bytecode::{
     verification_analysis::VerificationAnalysisProcessor,
     well_formed_instrumentation::WellFormedInstrumentationProcessor,
 };
-use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
-use move_command_line_common::testing::EXP_EXT;
-use move_model::{model::GlobalEnv, options::ModelBuilderOptions, run_model_builder_with_options};
-use move_prover_test_utils::{baseline_test::verify_or_update_baseline, extract_test_directives};
 use std::path::Path;
 
 fn get_tested_transformation_pipeline(

--- a/language/move-prover/interpreter-testsuite/Cargo.toml
+++ b/language/move-prover/interpreter-testsuite/Cargo.toml
@@ -13,7 +13,7 @@ diem-workspace-hack = { version = "0.1", path = "../../../crates/diem-workspace-
 [dev-dependencies]
 
 # diem dependencies
-bytecode-interpreter = { path = "../interpreter" }
+move-stackless-bytecode-interpreter = { path = "../interpreter" }
 move-command-line-common = { path = "../../move-command-line-common" }
 move-prover-test-utils = { path = "../test-utils" }
 move-stdlib = { path = "../../move-stdlib" }

--- a/language/move-prover/interpreter/Cargo.toml
+++ b/language/move-prover/interpreter/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bytecode-interpreter"
+name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
 authors = ["Diem Association <opensource@diem.com>"]
 publish = false
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 
 [dependencies]
 # diem dependencies
-bytecode = { path = "../bytecode" }
+move-stackless-bytecode = { path = "../bytecode" }
 bytecode-interpreter-crypto = { path = "crypto" }
 move-binary-format = { path = "../../move-binary-format" }
 move-core-types = { path = "../../move-core/types" }

--- a/language/move-prover/interpreter/src/concrete/evaluator.rs
+++ b/language/move-prover/interpreter/src/concrete/evaluator.rs
@@ -7,7 +7,6 @@ use itertools::Itertools;
 use num::{BigInt, ToPrimitive, Zero};
 use std::{cell::Cell, collections::BTreeMap, rc::Rc};
 
-use bytecode::{function_target::FunctionTarget, function_target_pipeline::FunctionTargetsHolder};
 use move_core_types::account_address::AccountAddress;
 use move_model::{
     ast::{
@@ -16,6 +15,9 @@ use move_model::{
     },
     model::{FieldId, ModuleEnv, ModuleId, NodeId, SpecFunId, StructId},
     ty as MTy,
+};
+use move_stackless_bytecode::{
+    function_target::FunctionTarget, function_target_pipeline::FunctionTargetsHolder,
 };
 
 use crate::{

--- a/language/move-prover/interpreter/src/concrete/player.rs
+++ b/language/move-prover/interpreter/src/concrete/player.rs
@@ -6,14 +6,6 @@
 use num::{BigInt, ToPrimitive, Zero};
 use std::{collections::BTreeMap, rc::Rc};
 
-use bytecode::{
-    function_target::FunctionTarget,
-    function_target_pipeline::FunctionTargetsHolder,
-    stackless_bytecode::{
-        AbortAction, AssignKind, BorrowEdge, BorrowNode, Bytecode, Constant, HavocKind, Label,
-        Operation, PropKind,
-    },
-};
 use bytecode_interpreter_crypto::{
     ed25519_deserialize_public_key, ed25519_deserialize_signature, ed25519_verify_signature,
     sha2_256_of, sha3_256_of,
@@ -27,6 +19,14 @@ use move_model::{
     ast::{Exp, MemoryLabel, TempIndex},
     model::{FunId, FunctionEnv, ModuleId, StructId},
     ty as MT,
+};
+use move_stackless_bytecode::{
+    function_target::FunctionTarget,
+    function_target_pipeline::FunctionTargetsHolder,
+    stackless_bytecode::{
+        AbortAction, AssignKind, BorrowEdge, BorrowNode, Bytecode, Constant, HavocKind, Label,
+        Operation, PropKind,
+    },
 };
 
 use crate::{

--- a/language/move-prover/interpreter/src/concrete/runtime.rs
+++ b/language/move-prover/interpreter/src/concrete/runtime.rs
@@ -6,7 +6,6 @@
 //! of the interpreter should never directly interact with the statement player (in `player.rs`) nor
 //! the expression evaluator (in `evaluator.rs`).
 
-use bytecode::{function_target::FunctionTarget, function_target_pipeline::FunctionTargetsHolder};
 use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
     language_storage::{StructTag, TypeTag},
@@ -16,6 +15,9 @@ use move_core_types::{
 use move_model::{
     model::{AbilitySet, FunctionEnv, GlobalEnv, TypeParameter},
     ty as MT,
+};
+use move_stackless_bytecode::{
+    function_target::FunctionTarget, function_target_pipeline::FunctionTargetsHolder,
 };
 
 use crate::{

--- a/language/move-prover/interpreter/src/concrete/ty.rs
+++ b/language/move-prover/interpreter/src/concrete/ty.rs
@@ -15,7 +15,6 @@
 
 use std::fmt;
 
-use bytecode::stackless_bytecode::Constant;
 use move_core_types::{
     identifier::Identifier,
     language_storage::{StructTag, TypeTag},
@@ -25,6 +24,7 @@ use move_model::{
     model::{GlobalEnv, ModuleId, StructId},
     ty as MT,
 };
+use move_stackless_bytecode::stackless_bytecode::Constant;
 
 use crate::shared::ident::StructIdent;
 

--- a/language/move-prover/interpreter/src/lib.rs
+++ b/language/move-prover/interpreter/src/lib.rs
@@ -5,13 +5,6 @@ use anyhow::{bail, Result};
 use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
 use structopt::StructOpt;
 
-use bytecode::{
-    function_target_pipeline::{
-        FunctionTargetProcessor, FunctionTargetsHolder, ProcessorResultDisplay,
-    },
-    options::ProverOptions,
-    pipeline_factory::default_pipeline_with_options,
-};
 use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
     account_address::AccountAddress,
@@ -26,6 +19,13 @@ use move_core_types::{
 use move_model::{
     model::{FunctionEnv, GlobalEnv},
     ty::{PrimitiveType as ModelPrimitiveType, Type as ModelType},
+};
+use move_stackless_bytecode::{
+    function_target_pipeline::{
+        FunctionTargetProcessor, FunctionTargetsHolder, ProcessorResultDisplay,
+    },
+    options::ProverOptions,
+    pipeline_factory::default_pipeline_with_options,
 };
 
 pub mod concrete;

--- a/language/move-prover/interpreter/src/shared/ident.rs
+++ b/language/move-prover/interpreter/src/shared/ident.rs
@@ -3,9 +3,11 @@
 
 use std::fmt;
 
-use bytecode::{function_target::FunctionTarget, function_target_pipeline::FunctionVariant};
 use move_core_types::account_address::AccountAddress;
 use move_model::model::{ModuleEnv, StructEnv};
+use move_stackless_bytecode::{
+    function_target::FunctionTarget, function_target_pipeline::FunctionVariant,
+};
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct ModuleIdent {

--- a/language/move-prover/interpreter/src/shared/variant.rs
+++ b/language/move-prover/interpreter/src/shared/variant.rs
@@ -1,11 +1,11 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use bytecode::{
+use move_model::model::FunctionEnv;
+use move_stackless_bytecode::{
     function_target::FunctionTarget,
     function_target_pipeline::{FunctionTargetsHolder, FunctionVariant, VerificationFlavor},
 };
-use move_model::model::FunctionEnv;
 
 // TODO (mengxu): find a better way to determine which variant to call
 pub fn choose_variant<'env>(

--- a/language/move-prover/lab/Cargo.toml
+++ b/language/move-prover/lab/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # diem dependencies
 move-model = { path = "../../move-model" }
 move-prover = { path = ".." }
-bytecode = { path = "../bytecode"}
+move-stackless-bytecode = { path = "../bytecode"}
 
 # FB external dependencies
 z3tracer = "0.8.0"

--- a/language/move-prover/lab/src/benchmark.rs
+++ b/language/move-prover/lab/src/benchmark.rs
@@ -5,7 +5,6 @@
 // benchmark data back into memory.
 
 use anyhow::anyhow;
-use bytecode::options::ProverOptions;
 use clap::{App, Arg};
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 use itertools::Itertools;
@@ -17,6 +16,7 @@ use move_model::{
 use move_prover::{
     check_errors, cli::Options, create_and_process_bytecode, generate_boogie, verify_boogie,
 };
+use move_stackless_bytecode::options::ProverOptions;
 use std::{
     fmt::Debug,
     fs::File,

--- a/language/move-prover/move-docgen/Cargo.toml
+++ b/language/move-prover/move-docgen/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # diem dependencies
 move-compiler = { path = "../../move-compiler" }
 move-model = { path = "../../move-model" }
-bytecode = { path = "../bytecode" }
+move-stackless-bytecode = { path = "../bytecode" }
 
 # external dependencies
 codespan = "0.11.1"

--- a/language/move-prover/mutation/Cargo.toml
+++ b/language/move-prover/mutation/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 # diem dependencies
 move-model = { path = "../../move-model" }
 move-prover = { path = ".." }
-bytecode = { path = "../bytecode"}
+move-stackless-bytecode = { path = "../bytecode"}
 
 # FB external dependencies
 z3tracer = "0.8.0"

--- a/language/move-prover/mutation/src/mutator.rs
+++ b/language/move-prover/mutation/src/mutator.rs
@@ -3,7 +3,6 @@
 
 // Functions for running move programs with mutations and reporting errors if found
 
-use bytecode::{mutation_tester::MutationManager, options::ProverOptions};
 use clap::{App, Arg};
 use codespan_reporting::term::termcolor::{ColorChoice, StandardStream};
 use itertools::Itertools;
@@ -16,6 +15,7 @@ use move_model::{
 use move_prover::{
     check_errors, cli::Options, create_and_process_bytecode, generate_boogie, verify_boogie,
 };
+use move_stackless_bytecode::{mutation_tester::MutationManager, options::ProverOptions};
 use std::{
     io::Write,
     path::PathBuf,

--- a/language/move-prover/src/cli.rs
+++ b/language/move-prover/src/cli.rs
@@ -21,8 +21,6 @@ use simplelog::{
     CombinedLogger, Config, ConfigBuilder, LevelPadding, SimpleLogger, TermLogger, TerminalMode,
 };
 
-use boogie_backend::options::{BoogieOptions, VectorTheory};
-use bytecode::options::{AutoTraceLevel, ProverOptions};
 use codespan_reporting::diagnostic::Severity;
 use move_abigen::AbigenOptions;
 use move_docgen::DocgenOptions;
@@ -30,6 +28,8 @@ use move_errmapgen::ErrmapOptions;
 use move_model::{
     model::VerificationScope, options::ModelBuilderOptions, simplifier::SimplificationPass,
 };
+use move_prover_boogie_backend::options::{BoogieOptions, VectorTheory};
+use move_stackless_bytecode::options::{AutoTraceLevel, ProverOptions};
 
 /// Atomic used to prevent re-initialization of logging.
 static LOGGER_CONFIGURED: AtomicBool = AtomicBool::new(false);

--- a/language/move-prover/src/lib.rs
+++ b/language/move-prover/src/lib.rs
@@ -5,15 +5,6 @@
 
 use crate::cli::Options;
 use anyhow::anyhow;
-use boogie_backend::{
-    add_prelude, boogie_wrapper::BoogieWrapper, bytecode_translator::BoogieTranslator,
-};
-use bytecode::{
-    escape_analysis::EscapeAnalysisProcessor,
-    function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
-    pipeline_factory,
-    read_write_set_analysis::{self, ReadWriteSetProcessor},
-};
 use codespan_reporting::{
     diagnostic::Severity,
     term::termcolor::{Buffer, ColorChoice, StandardStream, WriteColor},
@@ -27,6 +18,15 @@ use move_model::{
     code_writer::CodeWriter,
     model::{FunctionVisibility, GlobalEnv},
     parse_addresses_from_options, run_model_builder_with_options,
+};
+use move_prover_boogie_backend::{
+    add_prelude, boogie_wrapper::BoogieWrapper, bytecode_translator::BoogieTranslator,
+};
+use move_stackless_bytecode::{
+    escape_analysis::EscapeAnalysisProcessor,
+    function_target_pipeline::{FunctionTargetPipeline, FunctionTargetsHolder},
+    pipeline_factory,
+    read_write_set_analysis::{self, ReadWriteSetProcessor},
 };
 use std::{
     collections::BTreeSet,

--- a/language/move-prover/tools/spec-flatten/Cargo.toml
+++ b/language/move-prover/tools/spec-flatten/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 
 # move dependencies
-bytecode = { path = "../../bytecode" }
+move-stackless-bytecode = { path = "../../bytecode" }
 move-compiler = { path = "../../../move-compiler" }
 move-model = { path = "../../../move-model" }
 move-prover = { path = "../.." }

--- a/language/move-prover/tools/spec-flatten/src/exp_trimming.rs
+++ b/language/move-prover/tools/spec-flatten/src/exp_trimming.rs
@@ -4,11 +4,11 @@
 use anyhow::Result;
 use std::collections::BTreeMap;
 
-use bytecode::function_target::FunctionTarget;
 use move_model::{
     ast::{ConditionKind, Spec},
     model::{FunId, QualifiedId},
 };
+use move_stackless_bytecode::function_target::FunctionTarget;
 
 use crate::workflow::{prepare_with_override, prove, WorkflowOptions};
 

--- a/language/move-prover/tools/spec-flatten/src/lib.rs
+++ b/language/move-prover/tools/spec-flatten/src/lib.rs
@@ -5,8 +5,8 @@ use anyhow::{anyhow, Result};
 use std::{collections::BTreeMap, str::FromStr};
 use structopt::StructOpt;
 
-use bytecode::function_target_pipeline::{FunctionVariant, VerificationFlavor};
 use move_model::ast::SpecBlockTarget;
+use move_stackless_bytecode::function_target_pipeline::{FunctionVariant, VerificationFlavor};
 
 mod ast_print;
 mod workflow;

--- a/language/move-prover/tools/spec-flatten/src/workflow.rs
+++ b/language/move-prover/tools/spec-flatten/src/workflow.rs
@@ -5,10 +5,6 @@ use anyhow::{anyhow, Result};
 use std::collections::BTreeMap;
 use structopt::StructOpt;
 
-use bytecode::{
-    function_target_pipeline::FunctionTargetsHolder, options::ProverOptions,
-    pipeline_factory::default_pipeline_with_options,
-};
 use move_compiler::shared::{parse_named_address, NumericalAddress};
 use move_model::{
     ast::Spec,
@@ -18,6 +14,10 @@ use move_model::{
     simplifier::SimplificationPass,
 };
 use move_prover::{cli::Options as CliOptions, generate_boogie, verify_boogie};
+use move_stackless_bytecode::{
+    function_target_pipeline::FunctionTargetsHolder, options::ProverOptions,
+    pipeline_factory::default_pipeline_with_options,
+};
 
 /// Options passed into the workflow pipeline.
 #[derive(StructOpt, Clone)]

--- a/language/testing-infra/transactional-test-runner/Cargo.toml
+++ b/language/testing-infra/transactional-test-runner/Cargo.toml
@@ -19,7 +19,7 @@ structopt = "0.3.21"
 tempfile = "3.2.0"
 
 
-bytecode-interpreter = { path = "../../move-prover/interpreter" }
+move-stackless-bytecode-interpreter = { path = "../../move-prover/interpreter" }
 move-bytecode-source-map = { path = "../../move-ir-compiler/move-bytecode-source-map" }
 move-disassembler = { path = "../../tools/move-disassembler" }
 move-binary-format = { path = "../../move-binary-format" }

--- a/language/tools/move-unit-test/Cargo.toml
+++ b/language/tools/move-unit-test/Cargo.toml
@@ -27,7 +27,7 @@ move-vm-test-utils = { path = "../../move-vm/test-utils" }
 move-resource-viewer = { path = "../move-resource-viewer" }
 move-binary-format = { path = "../../move-binary-format" }
 move-model = { path = "../../move-model" }
-bytecode-interpreter = { path = "../../move-prover/interpreter" }
+move-stackless-bytecode-interpreter = { path = "../../move-prover/interpreter" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 diem-workspace-hack = { version = "0.1", path = "../../../crates/diem-workspace-hack" }
 

--- a/language/tools/move-unit-test/src/test_runner.rs
+++ b/language/tools/move-unit-test/src/test_runner.rs
@@ -6,11 +6,6 @@ use crate::{
     test_reporter::{FailureReason, TestFailure, TestResults, TestRunInfo, TestStatistics},
 };
 use anyhow::Result;
-use bytecode_interpreter::{
-    concrete::{settings::InterpreterSettings, value::GlobalState},
-    shared::bridge::{adapt_move_vm_change_set, adapt_move_vm_result},
-    StacklessBytecodeInterpreter,
-};
 use colored::*;
 use move_binary_format::{errors::VMResult, file_format::CompiledModule};
 use move_bytecode_utils::Modules;
@@ -31,6 +26,11 @@ use move_model::{
     run_model_builder_with_options_and_compilation_flags,
 };
 use move_resource_viewer::MoveValueAnnotator;
+use move_stackless_bytecode_interpreter::{
+    concrete::{settings::InterpreterSettings, value::GlobalState},
+    shared::bridge::{adapt_move_vm_change_set, adapt_move_vm_result},
+    StacklessBytecodeInterpreter,
+};
 use move_vm_runtime::{move_vm::MoveVM, native_functions::NativeFunctionTable};
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::gas_schedule::{zero_cost_schedule, GasStatus};

--- a/language/tools/read-write-set/Cargo.toml
+++ b/language/tools/read-write-set/Cargo.toml
@@ -15,7 +15,7 @@ move-binary-format = { path = "../../move-binary-format" }
 move-bytecode-utils = { path = "../move-bytecode-utils" }
 move-core-types = { path = "../../move-core/types" }
 move-model = { path = "../../move-model" }
-prover_bytecode = { path = "../../move-prover/bytecode", package="bytecode" }
+prover_bytecode = { path = "../../move-prover/bytecode", package="move-stackless-bytecode" }
 move-resource-viewer = { path = "../move-resource-viewer" }
 move-read-write-set-types = { path = "types" }
 read-write-set-dynamic = { path = "dynamic" }


### PR DESCRIPTION
This renames the following prover crates, in preparation for publishing them on crates.io:
- `bytecode` => `move-stackless-bytecode`
- `interpreter` => `move-stackless-bytecode-interpreter`
- `boogie-backend` => `move-prover-boogie-backend`