### PR TITLE
[move-tutorial] Fix "Coin" to be "BasicCoin" in step 1 of tutorial

### DIFF
--- a/language/documentation/tutorial/step_1/BasicCoin/sources/FirstModule.move
+++ b/language/documentation/tutorial/step_1/BasicCoin/sources/FirstModule.move
@@ -1,4 +1,4 @@
-module 0xCAFE::Coin {
+module 0xCAFE::BasicCoin {
     struct Coin has key {
         value: u64,
     }


### PR DESCRIPTION
This updates the name of the module in step 1 to match the code in the tutorial text.

This closes #9982 