### PR TITLE
[data-client] change data client config type to u64

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
@@ -160,15 +159,15 @@ impl Default for DataStreamingServiceConfig {
 #[derive(Copy, Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default)]
 pub struct DiemDataClientConfig {
-    pub response_timeout_ms: Duration, // Timeout (in milliseconds) when waiting for a response
-    pub summary_poll_interval_ms: Duration, // Interval (in milliseconds) between data summary polls
+    pub response_timeout_ms: u64, // Timeout (in milliseconds) when waiting for a response
+    pub summary_poll_interval_ms: u64, // Interval (in milliseconds) between data summary polls
 }
 
 impl Default for DiemDataClientConfig {
     fn default() -> Self {
         Self {
-            response_timeout_ms: Duration::from_millis(3_000),
-            summary_poll_interval_ms: Duration::from_millis(1_000),
+            response_timeout_ms: 3_000,
+            summary_poll_interval_ms: 1_000,
         }
     }
 }

--- a/state-sync/diem-data-client/src/diemnet/mod.rs
+++ b/state-sync/diem-data-client/src/diemnet/mod.rs
@@ -95,7 +95,7 @@ impl DiemNetDataClient {
         let poller = DataSummaryPoller::new(
             time_service,
             client.clone(),
-            client.data_client_config.summary_poll_interval_ms,
+            Duration::from_millis(client.data_client_config.summary_poll_interval_ms),
         );
         (client, poller)
     }
@@ -223,7 +223,7 @@ impl DiemNetDataClient {
             .send_request(
                 peer,
                 request.clone(),
-                self.data_client_config.response_timeout_ms,
+                Duration::from_millis(self.data_client_config.response_timeout_ms),
             )
             .await;
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This is a small PR which changes the type of [`DiemDataClientConfig`'s fields from `Duration`](https://github.com/diem/diem/blob/4958cf2ff7ecc9dbc9fef944f51c0e1aa1638035/config/src/config/state_sync_config.rs#L163-L164) to `u64`. This improves the `DiemDataClientConfig`'s readability and makes it less error-prone.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manually tested the config changes and re-ran existing tests in `diem/state-sync/`.

## Related PRs

https://github.com/diem/diem/pull/9949

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
