### PR TITLE
Migrate smoke-tests test utils to call REST API 

### DIFF
--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -109,6 +109,28 @@ impl Transaction {
             Transaction::GenesisTransaction(_) => 0,
         }
     }
+
+    pub fn success(&self) -> bool {
+        match self {
+            Transaction::UserTransaction(txn) => txn.info.success,
+            Transaction::BlockMetadataTransaction(txn) => txn.info.success,
+            Transaction::PendingTransaction(_txn) => false,
+            Transaction::GenesisTransaction(txn) => txn.info.success,
+        }
+    }
+
+    pub fn is_pending(&self) -> bool {
+        matches!(self, Transaction::PendingTransaction(_))
+    }
+
+    pub fn vm_status(&self) -> String {
+        match self {
+            Transaction::UserTransaction(txn) => txn.info.vm_status.clone(),
+            Transaction::BlockMetadataTransaction(txn) => txn.info.vm_status.clone(),
+            Transaction::PendingTransaction(_txn) => "pending".to_owned(),
+            Transaction::GenesisTransaction(txn) => txn.info.vm_status.clone(),
+        }
+    }
 }
 
 impl From<(SignedTransaction, TransactionPayload)> for Transaction {

--- a/crates/diem-rest-client/src/dpn.rs
+++ b/crates/diem-rest-client/src/dpn.rs
@@ -2,10 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use diem_api_types::U64;
-use move_core_types::language_storage::StructTag;
+use move_core_types::{identifier::Identifier, language_storage::StructTag};
 use serde::{Deserialize, Serialize};
 
-pub use diem_types::account_config::{BalanceResource, CORE_CODE_ADDRESS};
+pub use diem_types::account_config::{diem_root_address, BalanceResource, CORE_CODE_ADDRESS};
+pub use diem_types::on_chain_config::{
+    config_struct_tag, DiemVersion as OnChainDiemVersion, OnChainConfig,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Diem {
@@ -27,4 +30,18 @@ impl AccountBalance {
     pub fn currency_code(&self) -> String {
         self.currency.name.to_string()
     }
+}
+
+pub fn diem_version_identifier() -> Identifier {
+    Identifier::new(OnChainDiemVersion::IDENTIFIER).unwrap()
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DiemConfig<T> {
+    pub payload: T,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DiemVersion {
+    pub major: U64,
 }

--- a/testsuite/forge/src/interface/admin.rs
+++ b/testsuite/forge/src/interface/admin.rs
@@ -3,7 +3,9 @@
 
 use super::{ChainInfo, CoreContext, Test};
 use crate::{Result, TestReport};
+use diem_rest_client::Client as RestClient;
 use diem_sdk::{client::BlockingClient, types::LocalAccount};
+use reqwest::Url;
 
 /// The testing interface which defines a test written from the perspective of the Admin of the
 /// network. This means that the test will have access to the Root account but do not control any
@@ -40,6 +42,10 @@ impl<'t> AdminContext<'t> {
 
     pub fn client(&self) -> BlockingClient {
         BlockingClient::new(&self.chain_info.json_rpc_url)
+    }
+
+    pub fn rest_client(&self) -> RestClient {
+        RestClient::new(Url::parse(self.chain_info.rest_api()).unwrap())
     }
 
     pub fn chain_info(&mut self) -> &mut ChainInfo<'t> {

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -172,18 +172,22 @@ pub fn new_epoch_event_key() -> EventKey {
 pub fn access_path_for_config(address: AccountAddress, config_name: Identifier) -> AccessPath {
     AccessPath::new(
         address,
-        AccessPath::resource_access_vec(StructTag {
-            address: CORE_CODE_ADDRESS,
-            module: ConfigurationResource::MODULE_NAME.to_owned(),
-            name: ConfigurationResource::MODULE_NAME.to_owned(),
-            type_params: vec![TypeTag::Struct(StructTag {
-                address: CORE_CODE_ADDRESS,
-                module: config_name.clone(),
-                name: config_name,
-                type_params: vec![],
-            })],
-        }),
+        AccessPath::resource_access_vec(config_struct_tag(config_name)),
     )
+}
+
+pub fn config_struct_tag(config_name: Identifier) -> StructTag {
+    StructTag {
+        address: CORE_CODE_ADDRESS,
+        module: ConfigurationResource::MODULE_NAME.to_owned(),
+        name: ConfigurationResource::MODULE_NAME.to_owned(),
+        type_params: vec![TypeTag::Struct(StructTag {
+            address: CORE_CODE_ADDRESS,
+            module: config_name.clone(),
+            name: config_name,
+            type_params: vec![],
+        })],
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
This is first step to migrate smoke-tests to call REST API (#9193): update test utils to call rest api.

I'm taking the following strategy to ensure I can migrate code efficiently:

1. Migrating small pieces / util functions first, using a tokio Runtime#block_on to call these async functions and leverage compiler to tell me where I need to add runtime.block_on.
2. Eventually we will have runtime doing block_on in the test everywhere. Then it will be easy to convert test into [tokio::test] or adding an async_run for forge test.
