### PR TITLE
[move-prover] Fixing error with auto trace wrongly applied

### DIFF
--- a/language/move-model/src/spec_translator.rs
+++ b/language/move-model/src/spec_translator.rs
@@ -617,7 +617,7 @@ impl<'a, 'b, T: ExpGenerator<'a>> ExpRewriterFunctions for SpecTranslator<'a, 'b
                     )
                 }
             }
-            ExpData::Call(id, Operation::Trace(_), args) => {
+            ExpData::Call(id, Operation::Trace(TraceKind::User), args) => {
                 // Generate an error if a TRACE is applied to an expression where it is not
                 // allowed, i.e. if there are free LocalVar terms, excluding locals from lets.
                 let loc = env.get_node_loc(*id);

--- a/language/move-prover/tests/sources/functional/trace.exp
+++ b/language/move-prover/tests/sources/functional/trace.exp
@@ -19,6 +19,21 @@ error: post-condition does not hold
    =     at tests/sources/functional/trace.move:18: add_invalid (spec)
    =         `ensures result == a + b;` = <redacted>
 
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/trace.move:37:5
+   │
+37 │     invariant forall addr: address: exists<R>(addr) ==> global<R>(addr).x < 5;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/trace.move:28: publish_invalid
+   =     at tests/sources/functional/trace.move:32: publish_invalid (spec)
+   =         `let addr = Signer::address_of(s);` = <redacted>
+   =     at tests/sources/functional/trace.move:28: publish_invalid
+   =         s = <redacted>
+   =         x = <redacted>
+   =     at tests/sources/functional/trace.move:29: publish_invalid
+   =     at tests/sources/functional/trace.move:37
+
 error: post-condition does not hold
    ┌─ tests/sources/functional/trace.move:33:9
    │
@@ -38,6 +53,7 @@ error: post-condition does not hold
    =         s = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/trace.move:29: publish_invalid
+   =     at tests/sources/functional/trace.move:37
    =     at tests/sources/functional/trace.move:30: publish_invalid
    =     at tests/sources/functional/trace.move:33: publish_invalid (spec)
    =         `ensures exists<R>(addr) ==> global<R>(addr).x == x;` = <redacted>

--- a/language/move-prover/tests/sources/functional/trace.move
+++ b/language/move-prover/tests/sources/functional/trace.move
@@ -32,4 +32,7 @@ module 0x42::TestTracing {
         let addr = Signer::address_of(s);
         ensures exists<R>(addr) ==> global<R>(addr).x == x;
     }
+
+    // Test whether auto trace on expressions in quantifiers does not trigger error
+    invariant forall addr: address: exists<R>(addr) ==> global<R>(addr).x < 5;
 }

--- a/language/move-prover/tests/sources/functional/trace.simplify_exp
+++ b/language/move-prover/tests/sources/functional/trace.simplify_exp
@@ -19,6 +19,18 @@ error: post-condition does not hold
    =     at tests/sources/functional/trace.move:18: add_invalid (spec)
    =         `ensures result == a + b;` = <redacted>
 
+error: global memory invariant does not hold
+   ┌─ tests/sources/functional/trace.move:37:5
+   │
+37 │     invariant forall addr: address: exists<R>(addr) ==> global<R>(addr).x < 5;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/trace.move:28: publish_invalid
+   =         s = <redacted>
+   =         x = <redacted>
+   =     at tests/sources/functional/trace.move:29: publish_invalid
+   =     at tests/sources/functional/trace.move:37
+
 error: post-condition does not hold
    ┌─ tests/sources/functional/trace.move:33:9
    │
@@ -34,6 +46,7 @@ error: post-condition does not hold
    =         s = <redacted>
    =         x = <redacted>
    =     at tests/sources/functional/trace.move:29: publish_invalid
+   =     at tests/sources/functional/trace.move:37
    =     at tests/sources/functional/trace.move:30: publish_invalid
    =     at tests/sources/functional/trace.move:32: publish_invalid (spec)
    =     at ../move-stdlib/sources/Signer.move:13: address_of


### PR DESCRIPTION
This ignores autogenerated TRACE expressions which are on untraceable items instead of generating an error, as happens with a user provided explicit TRACE.


## Motivation

Bug fix

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

New test

## Related PRs

NA
