### PR TITLE
[move-tools] Better error messages if coverage map doesnt exist

### DIFF
--- a/language/tools/move-cli/src/package/cli.rs
+++ b/language/tools/move-cli/src/package/cli.rs
@@ -195,7 +195,7 @@ impl From<UnitTestResult> for ExitStatus {
 
 impl CoverageSummaryOptions {
     pub fn handle_command(&self, config: move_package::BuildConfig, path: &Path) -> Result<()> {
-        let coverage_map = CoverageMap::from_binary_file(path.join(".coverage_map.mvcov"));
+        let coverage_map = CoverageMap::from_binary_file(path.join(".coverage_map.mvcov"))?;
         let package = config.compile_package(path, &mut Vec::new())?;
         let modules: Vec<_> = package
             .modules()?

--- a/language/tools/move-coverage/src/bin/coverage-summaries.rs
+++ b/language/tools/move-coverage/src/bin/coverage-summaries.rs
@@ -110,7 +110,7 @@ fn main() {
         let coverage_map = if args.is_raw_trace_file {
             CoverageMap::from_trace_file(&input_trace_path)
         } else {
-            CoverageMap::from_binary_file(&input_trace_path)
+            CoverageMap::from_binary_file(&input_trace_path).unwrap()
         };
         let unified_exec_map = coverage_map.to_unified_exec_map();
         if !args.csv_output {

--- a/language/tools/move-coverage/src/bin/move-trace-conversion.rs
+++ b/language/tools/move-coverage/src/bin/move-trace-conversion.rs
@@ -35,7 +35,7 @@ fn main() {
     if !args.use_trace_map {
         let coverage_map = if let Some(old_coverage_path) = &args.update {
             let path = Path::new(&old_coverage_path);
-            let old_coverage_map = CoverageMap::from_binary_file(&path);
+            let old_coverage_map = CoverageMap::from_binary_file(&path).unwrap();
             old_coverage_map.update_coverage_from_trace_file(&input_path)
         } else {
             CoverageMap::from_trace_file(&input_path)

--- a/language/tools/move-coverage/src/bin/source-coverage.rs
+++ b/language/tools/move-coverage/src/bin/source-coverage.rs
@@ -44,7 +44,7 @@ fn main() {
     let coverage_map = if args.is_raw_trace_file {
         CoverageMap::from_trace_file(&args.input_trace_path)
     } else {
-        CoverageMap::from_binary_file(&args.input_trace_path)
+        CoverageMap::from_binary_file(&args.input_trace_path).unwrap()
     };
 
     let bytecode_bytes = fs::read(&args.module_binary_path).expect("Unable to read bytecode file");

--- a/language/tools/move-disassembler/src/main.rs
+++ b/language/tools/move-disassembler/src/main.rs
@@ -118,8 +118,11 @@ fn main() {
     let mut disassembler = Disassembler::new(source_mapping, disassembler_options);
 
     if let Some(file_path) = &args.code_coverage_path {
-        disassembler
-            .add_coverage_map(CoverageMap::from_binary_file(file_path).to_unified_exec_map());
+        disassembler.add_coverage_map(
+            CoverageMap::from_binary_file(file_path)
+                .unwrap()
+                .to_unified_exec_map(),
+        );
     }
 
     let dissassemble_string = disassembler.disassemble().expect("Unable to dissassemble");


### PR DESCRIPTION
This PR fixes the bad panics related to coverage maps detailed in #9983. Now, if you try to run the command without generating the coverage map, you will get:
```
Error: No such file or directory (os error 2): Coverage map file '"./.coverage_map.mvcov"' doesn't exist
```

No further help is provided in the error message, as the `move package coverage -h` command displays additional information and help that would solve this problem (running tests with the `--coverage` flag):
```
$ mpm coverage -h
move-package-coverage 0.1.0
Inspect test coverage for this package. A previous test run with the `--coverage` flag must have previously been run
``` 

This closes #9983 however there is further work left (for a future PR) to change what flag turns off tracing support in the VM. 