### PR TITLE
migrate more test utils used by smoke tests to use rest api client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7989,6 +7989,7 @@ name = "smoke-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "backup-cli",
  "base64",
  "bcs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3383,6 +3383,7 @@ name = "forge"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "base64",
  "debug-interface",
  "diem-config",
@@ -3426,6 +3427,7 @@ name = "forge-cli"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "diem-rest-client",
  "diem-sdk",
  "diem-workspace-hack",
  "forge",
@@ -4386,6 +4388,7 @@ dependencies = [
  "hex",
  "reqwest",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/api/doc/openapi.yaml
+++ b/api/doc/openapi.yaml
@@ -1061,6 +1061,7 @@ components:
         - gas_used
         - success
         - vm_status
+        - accumulator_root_hash
       properties:
         version:
           $ref: '#/components/schemas/Uint64'
@@ -1081,6 +1082,8 @@ components:
           type: string
           description: |
             Human readable transaction execution result message from Diem VM.
+        accumulator_root_hash:
+          $ref: '#/components/schemas/HexEncodedBytes'
     UserTransaction:
       title: User Transaction
       type: object

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -3,7 +3,7 @@
 
 use crate::tests::{assert_json, find_value, new_test_context, pretty, TestContext};
 
-use diem_api_types::HexEncodedBytes;
+use diem_api_types::{HashValue, HexEncodedBytes};
 use diem_crypto::{
     hash::CryptoHash,
     multi_ed25519::{MultiEd25519PrivateKey, MultiEd25519PublicKey},
@@ -291,6 +291,7 @@ async fn test_get_transactions_output_user_transaction_with_script_function_payl
             "previous_block_votes": [],
             "proposer": context.validator_owner.to_hex_literal(),
             "timestamp": metadata_txn.timestamp_usec().to_string(),
+            "accumulator_root_hash": HashValue::from(context.context.get_accumulator_root_hash(1).unwrap()).to_string(),
         }),
     );
 
@@ -353,6 +354,7 @@ async fn test_get_transactions_output_user_transaction_with_script_function_payl
                 "signature": format!("0x{}", hex::encode(sig.to_bytes())),
             },
             "timestamp": metadata_txn.timestamp_usec().to_string(),
+            "accumulator_root_hash": HashValue::from(context.context.get_accumulator_root_hash(2).unwrap()).to_string(),
         }),
     )
 }

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -7,6 +7,7 @@ use crate::{
     ScriptPayload, ScriptWriteSet, Transaction, TransactionInfo, TransactionOnChainData,
     TransactionPayload, UserTransactionRequest, WriteSet, WriteSetChange, WriteSetPayload,
 };
+use diem_crypto::HashValue;
 use diem_transaction_builder::error_explain;
 use diem_types::{
     access_path::{AccessPath, Path},
@@ -74,7 +75,7 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
         data: TransactionOnChainData,
     ) -> Result<Transaction> {
         use diem_types::transaction::Transaction::*;
-        let info = self.into_transaction_info(data.version, &data.info);
+        let info = self.into_transaction_info(data.version, &data.info, data.accumulator_root_hash);
         let events = self.try_into_events(&data.events)?;
         Ok(match data.transaction {
             UserTransaction(txn) => {
@@ -93,6 +94,7 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
         &self,
         version: u64,
         info: &diem_types::transaction::TransactionInfo,
+        accumulator_root_hash: HashValue,
     ) -> TransactionInfo {
         TransactionInfo {
             version: version.into(),
@@ -102,6 +104,7 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
             gas_used: info.gas_used().into(),
             success: info.status().is_success(),
             vm_status: self.explain_vm_status(info.status()),
+            accumulator_root_hash: accumulator_root_hash.into(),
         }
     }
 

--- a/crates/diem-rest-client/src/dpn.rs
+++ b/crates/diem-rest-client/src/dpn.rs
@@ -7,8 +7,10 @@ use serde::{Deserialize, Serialize};
 
 pub use diem_types::account_config::{diem_root_address, BalanceResource, CORE_CODE_ADDRESS};
 pub use diem_types::on_chain_config::{
-    config_struct_tag, DiemVersion as OnChainDiemVersion, OnChainConfig,
+    config_struct_tag, ConfigurationResource, DiemVersion as OnChainDiemVersion, OnChainConfig,
 };
+
+use crate::types::EventHandle;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Diem {
@@ -44,4 +46,12 @@ pub struct DiemConfig<T> {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DiemVersion {
     pub major: U64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Configuration {
+    #[serde(rename = "epoch")]
+    pub next_block_epoch: U64,
+    pub last_reconfiguration_time: U64,
+    pub events: EventHandle,
 }

--- a/crates/diem-rest-client/src/types.rs
+++ b/crates/diem-rest-client/src/types.rs
@@ -1,10 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_api_types::U64;
+use diem_api_types::{Address, U64};
 use diem_types::transaction::authenticator::AuthenticationKey;
 use move_core_types::{language_storage::StructTag, parser::parse_struct_tag};
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::str::FromStr;
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]
@@ -63,4 +63,27 @@ pub struct DiemAccount {
     pub authentication_key: AuthenticationKey,
     #[serde(deserialize_with = "deserialize_from_string")]
     pub sequence_number: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EventHandle {
+    counter: U64,
+    guid: EventHandleGUID,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EventHandleGUID {
+    len_bytes: u8,
+    guid: GUID,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GUID {
+    id: ID,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ID {
+    creation_num: U64,
+    addr: Address,
 }

--- a/json-rpc/integration-tests/Cargo.toml
+++ b/json-rpc/integration-tests/Cargo.toml
@@ -14,6 +14,7 @@ bcs = "0.1.2"
 hex = "0.4.3"
 reqwest = { version = "0.11.2", features = ["blocking", "json"], default_features = false }
 serde_json = "1.0.64"
+tokio = { version = "1.8.1", features = ["full"] }
 
 diem-json-rpc-types = { path = "../types" }
 diem-sdk = { path = "../../sdk" }

--- a/json-rpc/integration-tests/src/helper.rs
+++ b/json-rpc/integration-tests/src/helper.rs
@@ -16,6 +16,7 @@ use diem_sdk::{
 };
 use forge::PublicUsageContext;
 use serde_json::{json, Value};
+use tokio::runtime::Runtime;
 
 pub struct JsonRpcTestHelper {
     url: String,
@@ -158,7 +159,8 @@ impl JsonRpcTestHelper {
         let mut parent = ctx.random_account();
         let child1 = ctx.random_account();
         let child2 = ctx.random_account();
-        ctx.create_parent_vasp_account(parent.authentication_key())?;
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(ctx.create_parent_vasp_account(parent.authentication_key()))?;
         self.submit_and_wait(&parent.sign_with_transaction_builder(
             factory.create_child_vasp_account(Currency::XUS, child1.authentication_key(), false, 0),
         ));
@@ -166,9 +168,9 @@ impl JsonRpcTestHelper {
             factory.create_child_vasp_account(Currency::XUS, child2.authentication_key(), false, 0),
         ));
 
-        ctx.fund(parent.address(), amount)?;
-        ctx.fund(child1.address(), amount)?;
-        ctx.fund(child2.address(), amount)?;
+        runtime.block_on(ctx.fund(parent.address(), amount))?;
+        runtime.block_on(ctx.fund(child1.address(), amount))?;
+        runtime.block_on(ctx.fund(child2.address(), amount))?;
 
         Ok((parent, child1, child2))
     }

--- a/testsuite/forge-cli/Cargo.toml
+++ b/testsuite/forge-cli/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
 diem-sdk = { path = "../../sdk" }
+diem-rest-client = { path = "../../crates/diem-rest-client"}
 forge = { path = "../forge" }
 itertools = "0.10.0"
 rand_core = "0.6.2"

--- a/testsuite/forge/Cargo.toml
+++ b/testsuite/forge/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = { version = "1.0", features = ["backtrace"] }
+async-trait = "0.1.42"
 base64 = "0.13.0"
 futures = "0.3.12"
 hyper = { version = "0.14.4", features = ["full"] }

--- a/testsuite/forge/src/interface/chain_info.rs
+++ b/testsuite/forge/src/interface/chain_info.rs
@@ -152,11 +152,6 @@ impl<'t> ChainInfo<'t> {
     }
 
     pub fn into_nft_public_info(self) -> NFTPublicInfo<'t> {
-        NFTPublicInfo::new(
-            self.json_rpc_url.clone(),
-            self.chain_id,
-            self.rest_api_url.clone(),
-            self.root_account,
-        )
+        NFTPublicInfo::new(self.chain_id, self.rest_api_url.clone(), self.root_account)
     }
 }

--- a/testsuite/forge/src/interface/nft.rs
+++ b/testsuite/forge/src/interface/nft.rs
@@ -3,8 +3,8 @@
 
 use super::Test;
 use crate::{CoreContext, Result, TestReport};
+use diem_rest_client::Client as RestClient;
 use diem_sdk::{
-    client::BlockingClient,
     crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform},
     move_types::account_address::AccountAddress,
     transaction_builder::TransactionFactory,
@@ -15,13 +15,15 @@ use diem_sdk::{
 };
 use diem_transaction_builder::experimental_stdlib;
 use rand::{rngs::StdRng, SeedableRng};
+use reqwest::Url;
 
 /// The testing interface which defines a test written from the perspective of the a public user of
 /// the NFT network in a "testnet" like environment where there exists a source for minting NFTs
 /// and a means of creating new accounts.
+#[async_trait::async_trait]
 pub trait NFTPublicUsageTest: Test {
     /// Executes the test against the given context.
-    fn run<'t>(&self, ctx: &mut NFTPublicUsageContext<'t>) -> Result<()>;
+    async fn run<'t>(&self, ctx: &mut NFTPublicUsageContext<'t>) -> Result<()>;
 }
 
 pub struct NFTPublicUsageContext<'t> {
@@ -43,16 +45,12 @@ impl<'t> NFTPublicUsageContext<'t> {
         }
     }
 
-    pub fn client(&self) -> BlockingClient {
-        BlockingClient::new(&self.public_info.json_rpc_url)
+    pub fn client(&self) -> RestClient {
+        RestClient::new(self.public_info.rest_api_url.clone())
     }
 
     pub fn url(&self) -> &str {
-        &self.public_info.json_rpc_url
-    }
-
-    pub fn rest_api_url(&self) -> &str {
-        &self.public_info.rest_api_url
+        self.public_info.rest_api_url.as_str()
     }
 
     pub fn core(&self) -> &CoreContext {
@@ -75,7 +73,7 @@ impl<'t> NFTPublicUsageContext<'t> {
         TransactionFactory::new(self.chain_id())
     }
 
-    pub fn mint_bars(&mut self, address: AccountAddress, amount: u64) -> Result<()> {
+    pub async fn mint_bars(&mut self, address: AccountAddress, amount: u64) -> Result<()> {
         let mint_nft_txn = self.public_info.bars_account.sign_with_transaction_builder(
             self.transaction_factory().payload(
                 experimental_stdlib::encode_mint_bars_script_function(
@@ -86,14 +84,14 @@ impl<'t> NFTPublicUsageContext<'t> {
                 ),
             ),
         );
-        self.public_info.json_rpc_client.submit(&mint_nft_txn)?;
         self.public_info
-            .json_rpc_client
-            .wait_for_signed_transaction(&mint_nft_txn, None, None)?;
+            .rest_client
+            .submit_and_wait(&mint_nft_txn)
+            .await?;
         Ok(())
     }
 
-    pub fn create_user_account(&mut self, auth_key: AuthenticationKey) -> Result<()> {
+    pub async fn create_user_account(&mut self, auth_key: AuthenticationKey) -> Result<()> {
         let create_account_txn = self.public_info.bars_account.sign_with_transaction_builder(
             self.transaction_factory().payload(
                 experimental_stdlib::encode_create_account_script_function(
@@ -104,52 +102,46 @@ impl<'t> NFTPublicUsageContext<'t> {
             ),
         );
         self.public_info
-            .json_rpc_client
-            .submit(&create_account_txn)?;
-        self.public_info
-            .json_rpc_client
-            .wait_for_signed_transaction(&create_account_txn, None, None)?;
+            .rest_client
+            .submit_and_wait(&create_account_txn)
+            .await?;
         Ok(())
     }
 }
 
 pub struct NFTPublicInfo<'t> {
-    json_rpc_url: String,
     chain_id: ChainId,
-    rest_api_url: String,
-    json_rpc_client: BlockingClient,
+    rest_api_url: Url,
+    rest_client: RestClient,
     root_account: &'t mut LocalAccount,
     bars_account: LocalAccount,
 }
 
 impl<'t> NFTPublicInfo<'t> {
     pub fn new(
-        json_rpc_url: String,
         chain_id: ChainId,
-        rest_api_url: String,
+        rest_api_url_str: String,
         root_account: &'t mut LocalAccount,
     ) -> Self {
         let bars_key = Ed25519PrivateKey::generate(&mut StdRng::from_seed([1; 32]));
         let bars_address = AuthenticationKey::ed25519(&bars_key.public_key()).derived_address();
+        let rest_api_url = Url::parse(&rest_api_url_str).unwrap();
         Self {
-            json_rpc_url: json_rpc_url.clone(),
-            chain_id,
+            rest_client: RestClient::new(rest_api_url.clone()),
             rest_api_url,
-            json_rpc_client: BlockingClient::new(json_rpc_url),
+            chain_id,
             root_account,
             bars_account: LocalAccount::new(bars_address, bars_key, 0),
         }
     }
 
-    pub fn init_nft_environment(&mut self) -> Result<()> {
+    pub async fn init_nft_environment(&mut self) -> Result<()> {
         // send a transaction to initialize nft
         let init_nft_txn = self.root_account.sign_with_transaction_builder(
             TransactionFactory::new(self.chain_id)
                 .payload(experimental_stdlib::encode_nft_initialize_script_function()),
         );
-        self.json_rpc_client.submit(&init_nft_txn)?;
-        self.json_rpc_client
-            .wait_for_signed_transaction(&init_nft_txn, None, None)?;
+        self.rest_client.submit_and_wait(&init_nft_txn).await?;
 
         // create an account for bars
         let bars_account_creation_txn = self.root_account.sign_with_transaction_builder(
@@ -161,9 +153,9 @@ impl<'t> NFTPublicInfo<'t> {
                 ),
             ),
         );
-        self.json_rpc_client.submit(&bars_account_creation_txn)?;
-        self.json_rpc_client
-            .wait_for_signed_transaction(&bars_account_creation_txn, None, None)?;
+        self.rest_client
+            .submit_and_wait(&bars_account_creation_txn)
+            .await?;
 
         Ok(())
     }

--- a/testsuite/smoke-test/Cargo.toml
+++ b/testsuite/smoke-test/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.38"
+async-trait = "0.1.42"
 bcs = "0.1.2"
 proptest = "1.0.0"
 tokio = { version = "1.8.1", features = ["full"] }

--- a/testsuite/smoke-test/src/event_fetcher.rs
+++ b/testsuite/smoke-test/src/event_fetcher.rs
@@ -18,67 +18,71 @@ impl PublicUsageTest for EventFetcher {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
+        runtime.block_on(self.async_run(ctx))
+    }
+}
 
-        let client = ctx.client();
+impl EventFetcher {
+    async fn async_run(&self, ctx: &mut PublicUsageContext<'_>) -> Result<()> {
+        let client = ctx.rest_client();
         let factory = ctx.transaction_factory();
 
         let mut account1 = ctx.random_account();
-        ctx.create_parent_vasp_account(account1.authentication_key())?;
-        ctx.fund(account1.address(), 100_000_000)?;
+
+        ctx.create_parent_vasp_account(account1.authentication_key())
+            .await?;
+        ctx.fund(account1.address(), 100_000_000).await?;
 
         let account2 = ctx.random_account();
-        ctx.create_parent_vasp_account(account2.authentication_key())?;
-        ctx.fund(account2.address(), 100_000_000)?;
+        ctx.create_parent_vasp_account(account2.authentication_key())
+            .await?;
+        ctx.fund(account2.address(), 100_000_000).await?;
 
         let txn = account1.sign_with_transaction_builder(factory.peer_to_peer(
             Currency::XUS,
             account2.address(),
             3_000_000,
         ));
-        client.submit(&txn)?;
-        client.wait_for_signed_transaction(&txn, None, None)?;
+        client.submit_and_wait(&txn).await?;
 
         let txn = account1.sign_with_transaction_builder(factory.peer_to_peer(
             Currency::XUS,
             account2.address(),
             4_000_000,
         ));
-        client.submit(&txn)?;
-        client.wait_for_signed_transaction(&txn, None, None)?;
+        client.submit_and_wait(&txn).await?;
 
         let events_fetcher = DiemEventsFetcher::new(ctx.url())?;
 
-        runtime.block_on(async move {
-            let (sent_handle, received_handle) = events_fetcher
-                .get_payment_event_handles(account1.address())
-                .await
-                .unwrap()
-                .unwrap();
-            let mut sent_events = events_fetcher.get_all_events(&sent_handle).await.unwrap();
-            let received_events = events_fetcher
-                .get_all_events(&received_handle)
-                .await
-                .unwrap();
+        let (sent_handle, received_handle) = events_fetcher
+            .get_payment_event_handles(account1.address())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut sent_events = events_fetcher.get_all_events(&sent_handle).await.unwrap();
+        let received_events = events_fetcher
+            .get_all_events(&received_handle)
+            .await
+            .unwrap();
 
-            assert_eq!(received_events.len(), 1);
-            assert_eq!(received_handle.count(), 1);
-            assert_eq!(sent_handle.count(), 2);
-            assert_eq!(sent_events.len(), 2);
-            let evt1 = sent_events.pop().unwrap();
-            let evt2 = sent_events.pop().unwrap();
+        assert_eq!(received_events.len(), 1);
+        assert_eq!(received_handle.count(), 1);
+        assert_eq!(sent_handle.count(), 2);
+        assert_eq!(sent_events.len(), 2);
+        let evt1 = sent_events.pop().unwrap();
+        let evt2 = sent_events.pop().unwrap();
 
-            if let EventDataView::SentPayment { amount, .. } = evt1.data {
-                assert_eq!(amount.amount, 4000000);
-            } else {
-                panic!("invalid event");
-            }
+        if let EventDataView::SentPayment { amount, .. } = evt1.data {
+            assert_eq!(amount.amount, 4000000);
+        } else {
+            panic!("invalid event");
+        }
 
-            if let EventDataView::SentPayment { amount, .. } = evt2.data {
-                assert_eq!(amount.amount, 3000000);
-            } else {
-                panic!("invalid event");
-            }
-        });
+        if let EventDataView::SentPayment { amount, .. } = evt2.data {
+            assert_eq!(amount.amount, 3000000);
+        } else {
+            panic!("invalid event");
+        }
 
         Ok(())
     }

--- a/testsuite/smoke-test/src/full_nodes.rs
+++ b/testsuite/smoke-test/src/full_nodes.rs
@@ -53,8 +53,9 @@ fn test_full_node_basic_flow() {
     let vfn_client = swarm.full_node(vfn_peer_id).unwrap().rest_client();
     let pfn_client = swarm.full_node(pfn_peer_id).unwrap().rest_client();
 
-    let mut account_0 = create_and_fund_account(&mut swarm, 10);
-    let account_1 = create_and_fund_account(&mut swarm, 10);
+    let runtime = Runtime::new().unwrap();
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
+    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
 
     swarm
         .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(10))
@@ -151,9 +152,11 @@ fn test_vfn_failover() {
             .unwrap();
     }
 
+    let runtime = Runtime::new().unwrap();
+
     // Setup accounts
-    let mut account_0 = create_and_fund_account(&mut swarm, 100);
-    let account_1 = create_and_fund_account(&mut swarm, 100);
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
+    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
 
     swarm
         .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(10))
@@ -165,7 +168,6 @@ fn test_vfn_failover() {
     // submit client requests directly to VFN of dead V
     swarm.validator_mut(validator).unwrap().stop();
 
-    let runtime = Runtime::new().unwrap();
     runtime.block_on(async {
         transfer_coins(
             &vfn_client,
@@ -265,14 +267,15 @@ fn test_private_full_node() {
     let validator_client = swarm.validators().next().unwrap().rest_client();
     let user_client = swarm.full_node(user).unwrap().rest_client();
 
-    let mut account_0 = create_and_fund_account(&mut swarm, 100);
-    let account_1 = create_and_fund_account(&mut swarm, 10);
+    let runtime = Runtime::new().unwrap();
+
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
+    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
 
     swarm
         .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(60))
         .unwrap();
 
-    let runtime = Runtime::new().unwrap();
     runtime.block_on(async {
         // send txn from user node and check both validator and user node have correct balance
         transfer_coins(

--- a/testsuite/smoke-test/src/genesis.rs
+++ b/testsuite/smoke-test/src/genesis.rs
@@ -72,8 +72,10 @@ fn test_genesis_transaction_flow() {
         .wait_until_healthy(Instant::now() + Duration::from_secs(10))
         .unwrap();
 
-    let mut account_0 = create_and_fund_account(&mut swarm, 10);
-    let account_1 = create_and_fund_account(&mut swarm, 10);
+    let runtime = Runtime::new().unwrap();
+
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
+    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
 
     println!("2. Set sync_only = true for all nodes and restart");
     for validator in swarm.validators_mut() {
@@ -195,7 +197,6 @@ fn test_genesis_transaction_flow() {
         .validator(validator_peer_ids[0])
         .unwrap()
         .rest_client();
-    let runtime = Runtime::new().unwrap();
     runtime.block_on(async {
         transfer_coins(
             &client_0,

--- a/testsuite/smoke-test/src/replay_tooling.rs
+++ b/testsuite/smoke-test/src/replay_tooling.rs
@@ -1,12 +1,12 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use diem_sdk::{
-    client::views::VMStatusView, transaction_builder::Currency,
-    types::account_address::AccountAddress,
-};
+use anyhow::bail;
+use diem_rest_client::Transaction;
+use diem_sdk::{transaction_builder::Currency, types::account_address::AccountAddress};
 use diem_transaction_replay::DiemDebugger;
 use forge::{PublicUsageContext, PublicUsageTest, Result, Test};
+use tokio::runtime::Runtime;
 
 pub struct ReplayTooling;
 
@@ -18,36 +18,40 @@ impl Test for ReplayTooling {
 
 impl PublicUsageTest for ReplayTooling {
     fn run<'t>(&self, ctx: &mut PublicUsageContext<'t>) -> Result<()> {
-        let client = ctx.client();
+        let client = ctx.rest_client();
+        // todo: try async call to json_debugger calls
         let json_debugger = DiemDebugger::json_rpc(ctx.url())?;
 
         let treasury_account_address =
             AccountAddress::from_hex("0000000000000000000000000b1e55ed")?;
 
-        let treasury_account = client
-            .get_account(treasury_account_address)?
-            .into_inner()
-            .unwrap();
+        let runtime = Runtime::new().unwrap();
+        let treasury_account = runtime
+            .block_on(client.get_account(treasury_account_address))?
+            .into_inner();
         let mut account1 = ctx.random_account();
         let account2 = ctx.random_account();
-        ctx.create_parent_vasp_account(account1.authentication_key())?;
-        ctx.create_parent_vasp_account(account2.authentication_key())?;
-        ctx.fund(account1.address(), 100)?;
-        ctx.fund(account2.address(), 100)?;
+        runtime.block_on(ctx.create_parent_vasp_account(account1.authentication_key()))?;
+        runtime.block_on(ctx.create_parent_vasp_account(account2.authentication_key()))?;
+        runtime.block_on(ctx.fund(account1.address(), 100))?;
+        runtime.block_on(ctx.fund(account2.address(), 100))?;
         let txn = account1.sign_with_transaction_builder(ctx.transaction_factory().peer_to_peer(
             Currency::XUS,
             account2.address(),
             3,
         ));
-        client.submit(&txn)?;
-        let txn = client
-            .wait_for_signed_transaction(&txn, None, None)?
-            .into_inner();
-
+        let txn = runtime.block_on(client.submit_and_wait(&txn))?.into_inner();
+        let (txn_version, txn_gas_used) = match txn {
+            Transaction::UserTransaction(user_txn) => {
+                (user_txn.info.version.0, user_txn.info.gas_used.0)
+            }
+            _ => bail!("unexpected transaction type: {:?}", txn),
+        };
         let replay_result = json_debugger
-            .execute_past_transactions(txn.version, 1, false)?
+            .execute_past_transactions(txn_version, 1, false)?
             .pop()
             .unwrap();
+        assert_eq!(replay_result.gas_used(), txn_gas_used);
 
         let script_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../diem-move/transaction-replay/examples/account_exists.move")
@@ -58,23 +62,28 @@ impl PublicUsageTest for ReplayTooling {
                 script_path.to_str().unwrap(),
                 account1.address(),
                 0,
-                txn.version,
+                txn_version,
                 None,
             )?
             .unwrap();
 
-        let account_creation_txn = client
-            .get_account_transaction(
+        let account_creation_txn = runtime
+            .block_on(client.get_account_transactions(
                 treasury_account_address,
-                treasury_account.sequence_number,
-                false,
-            )?
+                Some(treasury_account.sequence_number),
+                Some(1),
+            ))?
             .into_inner()
+            .into_iter()
+            .next()
             .unwrap();
 
-        assert_eq!(account_creation_txn.version + 1, bisect_result);
-        assert_eq!(replay_result.gas_used(), txn.gas_used);
-        assert_eq!(VMStatusView::Executed, txn.vm_status);
+        match account_creation_txn {
+            Transaction::UserTransaction(user_txn) => {
+                assert_eq!(user_txn.info.version.0 + 1, bisect_result);
+            }
+            _ => bail!("unexpected transaction type: {:?}", account_creation_txn),
+        }
 
         Ok(())
     }

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -35,43 +35,44 @@ impl PublicUsageTest for BasicClient {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
+        runtime.block_on(self.async_run(ctx))
+    }
+}
 
-        runtime.block_on(async move {
-            let client = Client::new(reqwest::Url::parse(ctx.rest_api_url()).unwrap());
+impl BasicClient {
+    async fn async_run(&self, ctx: &mut PublicUsageContext<'_>) -> Result<()> {
+        let client = Client::new(reqwest::Url::parse(ctx.rest_api_url()).unwrap());
+        client.get_ledger_information().await?;
 
-            client.get_ledger_information().await.unwrap();
+        let mut account1 = ctx.random_account();
+        ctx.create_parent_vasp_account(account1.authentication_key())
+            .await?;
+        ctx.fund(account1.address(), 10).await?;
+        let account2 = ctx.random_account();
+        ctx.create_parent_vasp_account(account2.authentication_key())
+            .await?;
+        ctx.fund(account2.address(), 10).await?;
 
-            let mut account1 = ctx.random_account();
-            ctx.create_parent_vasp_account(account1.authentication_key())
-                .unwrap();
-            ctx.fund(account1.address(), 10).unwrap();
-            let account2 = ctx.random_account();
-            ctx.create_parent_vasp_account(account2.authentication_key())
-                .unwrap();
-            ctx.fund(account2.address(), 10).unwrap();
+        let tx = account1.sign_with_transaction_builder(ctx.transaction_factory().peer_to_peer(
+            diem_sdk::transaction_builder::Currency::XUS,
+            account2.address(),
+            1,
+        ));
+        let pending_txn = client.submit(&tx).await.unwrap().into_inner();
 
-            let tx =
-                account1.sign_with_transaction_builder(ctx.transaction_factory().peer_to_peer(
-                    diem_sdk::transaction_builder::Currency::XUS,
-                    account2.address(),
-                    1,
-                ));
-            let pending_txn = client.submit(&tx).await.unwrap().into_inner();
+        client.wait_for_transaction(&pending_txn).await.unwrap();
 
-            client.wait_for_transaction(&pending_txn).await.unwrap();
+        client
+            .get_transaction(pending_txn.hash.into())
+            .await
+            .unwrap();
 
-            client
-                .get_transaction(pending_txn.hash.into())
-                .await
-                .unwrap();
+        client
+            .get_account_resources(testnet_dd_account_address())
+            .await
+            .unwrap();
 
-            client
-                .get_account_resources(testnet_dd_account_address())
-                .await
-                .unwrap();
-
-            client.get_transactions(None, None).await.unwrap();
-        });
+        client.get_transactions(None, None).await.unwrap();
 
         Ok(())
     }

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -47,10 +47,11 @@ fn test_basic_state_synchronization() {
         .rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
-    let mut account_0 = create_and_fund_account(&mut swarm, 100);
-    let account_1 = create_and_fund_account(&mut swarm, 10);
-
     let runtime = Runtime::new().unwrap();
+
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
+    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
+
     runtime.block_on(async {
         transfer_coins(
             &client_1,
@@ -151,10 +152,11 @@ fn test_startup_sync_state() {
         .rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
-    let mut account_0 = create_and_fund_account(&mut swarm, 100);
-    let account_1 = create_and_fund_account(&mut swarm, 10);
-
     let runtime = Runtime::new().unwrap();
+
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
+    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
+
     let txn = runtime.block_on(transfer_coins(
         &client_1,
         &transaction_factory,
@@ -240,8 +242,8 @@ fn test_state_sync_multichunk_epoch() {
         ))
         .unwrap();
 
-    let mut account_0 = create_and_fund_account(&mut swarm, 100);
-    let account_1 = create_and_fund_account(&mut swarm, 10);
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
+    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
     runtime.block_on(async {
         assert_balance(&client_0, &account_0, 100).await;
         assert_balance(&client_0, &account_1, 10).await;

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -202,8 +202,9 @@ fn test_validator_sync(mut swarm: LocalSwarm) {
         .unwrap()
         .rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
-    let mut account_0 = create_and_fund_account(&mut swarm, 1000);
-    let mut account_1 = create_and_fund_account(&mut swarm, 1000);
+    let runtime = Runtime::new().unwrap();
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 1000));
+    let mut account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 1000));
     execute_transactions(
         &mut swarm,
         &validator_client_0,

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -120,8 +120,9 @@ fn test_full_node_sync(full_node_config: NodeConfig, mut swarm: LocalSwarm, epoc
     // Execute a number of transactions on the validator
     let validator_client = swarm.validator(validator_peer_id).unwrap().rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
-    let mut account_0 = create_and_fund_account(&mut swarm, 1000);
-    let mut account_1 = create_and_fund_account(&mut swarm, 1000);
+    let runtime = Runtime::new().unwrap();
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 1000));
+    let mut account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 1000));
     execute_transactions(
         &mut swarm,
         &validator_client,

--- a/testsuite/smoke-test/src/storage.rs
+++ b/testsuite/smoke-test/src/storage.rs
@@ -38,10 +38,10 @@ fn test_db_restore() {
         .rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
-    // set up: two accounts, a lot of money
-    let mut account_0 = create_and_fund_account(&mut swarm, 1000000);
-    let account_1 = create_and_fund_account(&mut swarm, 1000000);
     let runtime = Runtime::new().unwrap();
+    // set up: two accounts, a lot of money
+    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 1000000));
+    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 1000000));
     let mut expected_balance_0 = 999999;
     let mut expected_balance_1 = 1000001;
     runtime.block_on(async {

--- a/testsuite/smoke-test/src/transaction.rs
+++ b/testsuite/smoke-test/src/transaction.rs
@@ -1,13 +1,19 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::bail;
+use diem_rest_client::{
+    diem_api_types::{HexEncodedBytes, ScriptPayload, TransactionPayload},
+    Transaction,
+};
 use diem_sdk::{
-    client::{views::TransactionDataView, SignedTransaction},
+    client::SignedTransaction,
     crypto::{ed25519::Ed25519PrivateKey, PrivateKey, SigningKey, Uniform},
     transaction_builder::Currency,
     types::{account_config::XUS_NAME, transaction::authenticator::AuthenticationKey},
 };
 use forge::{PublicUsageContext, PublicUsageTest, Result, Test};
+use tokio::runtime::Runtime;
 
 pub struct ExternalTransactionSigner;
 
@@ -19,7 +25,14 @@ impl Test for ExternalTransactionSigner {
 
 impl PublicUsageTest for ExternalTransactionSigner {
     fn run<'t>(&self, ctx: &mut PublicUsageContext<'t>) -> Result<()> {
-        let client = ctx.client();
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(self.async_run(ctx))
+    }
+}
+
+impl ExternalTransactionSigner {
+    async fn async_run(&self, ctx: &mut PublicUsageContext<'_>) -> Result<()> {
+        let client = ctx.rest_client();
 
         // generate key pair
         let private_key = Ed25519PrivateKey::generate(ctx.rng());
@@ -28,12 +41,13 @@ impl PublicUsageTest for ExternalTransactionSigner {
         // create transfer parameters
         let sender_auth_key = AuthenticationKey::ed25519(&public_key);
         let sender_address = sender_auth_key.derived_address();
-        ctx.create_parent_vasp_account(sender_auth_key)?;
-        ctx.fund(sender_address, 10_000_000)?;
+        ctx.create_parent_vasp_account(sender_auth_key).await?;
+        ctx.fund(sender_address, 10_000_000).await?;
 
         let receiver = ctx.random_account();
-        ctx.create_parent_vasp_account(receiver.authentication_key())?;
-        ctx.fund(receiver.address(), 1_000_000)?;
+        ctx.create_parent_vasp_account(receiver.authentication_key())
+            .await?;
+        ctx.fund(receiver.address(), 1_000_000).await?;
 
         let amount = 1_000_000;
         let test_gas_unit_price = 1;
@@ -41,9 +55,9 @@ impl PublicUsageTest for ExternalTransactionSigner {
 
         // prepare transfer transaction
         let test_sequence_number = client
-            .get_account(sender_address)?
+            .get_account(sender_address)
+            .await?
             .into_inner()
-            .unwrap()
             .sequence_number;
 
         let currency_code = XUS_NAME;
@@ -64,51 +78,66 @@ impl PublicUsageTest for ExternalTransactionSigner {
         let signature = private_key.sign(&unsigned_txn);
 
         // submit the transaction
-        let txn = SignedTransaction::new(unsigned_txn, public_key, signature);
-        client.submit(&txn)?;
-        client.wait_for_signed_transaction(&txn, None, None)?;
+        let txn = SignedTransaction::new(unsigned_txn.clone(), public_key, signature);
+        client.submit_and_wait(&txn).await?;
 
         // query the transaction and check it contains the same values as requested
         let txn = client
-            .get_account_transaction(sender_address, test_sequence_number, false)?
+            .get_account_transactions(sender_address, Some(test_sequence_number), Some(1))
+            .await?
             .into_inner()
+            .into_iter()
+            .next()
             .unwrap();
 
-        match txn.transaction {
-            TransactionDataView::UserTransaction {
-                sender,
-                sequence_number,
-                max_gas_amount,
-                gas_unit_price,
-                gas_currency,
-                script,
-                ..
-            } => {
-                assert_eq!(sender, sender_address);
-                assert_eq!(sequence_number, test_sequence_number);
-                assert_eq!(gas_unit_price, test_gas_unit_price);
-                assert_eq!(gas_currency, currency_code.to_string());
-                assert_eq!(max_gas_amount, test_max_gas_amount);
-
-                assert_eq!(script.r#type, "peer_to_peer_with_metadata");
-                assert_eq!(script.type_arguments.unwrap(), vec!["XUS"]);
+        match txn {
+            Transaction::UserTransaction(user_txn) => {
+                assert_eq!(*user_txn.request.sender.inner(), sender_address);
+                assert_eq!(user_txn.request.sequence_number.0, test_sequence_number);
+                assert_eq!(user_txn.request.gas_unit_price.0, test_gas_unit_price);
                 assert_eq!(
-                    script.arguments.unwrap(),
-                    vec![
-                        format!("{{ADDRESS: {:?}}}", receiver.address()),
-                        format!("{{U64: {}}}", amount),
-                        "{U8Vector: 0x}".to_string(),
-                        "{U8Vector: 0x}".to_string()
-                    ]
+                    user_txn.request.gas_currency_code,
+                    currency_code.to_string()
                 );
-                // legacy fields
-                assert_eq!(script.receiver.unwrap(), receiver.address());
-                assert_eq!(script.amount.unwrap(), amount);
-                assert_eq!(script.currency.unwrap(), currency_code.to_string());
-                assert!(script.metadata.unwrap().inner().is_empty());
-                assert!(script.metadata_signature.unwrap().inner().is_empty());
+                assert_eq!(user_txn.request.max_gas_amount.0, test_max_gas_amount);
+
+                if let TransactionPayload::ScriptPayload(ScriptPayload {
+                    code,
+                    type_arguments,
+                    arguments,
+                }) = user_txn.request.payload
+                {
+                    let expected_code = match unsigned_txn.clone().into_payload() {
+                        diem_types::transaction::TransactionPayload::Script(script) => {
+                            HexEncodedBytes::from(script.code().to_vec())
+                        }
+                        _ => bail!("unexpected transaction payload: {:?}", &unsigned_txn),
+                    };
+                    assert_eq!(code.bytecode, expected_code);
+                    assert_eq!(
+                        type_arguments
+                            .into_iter()
+                            .map(|t| t.to_string())
+                            .collect::<Vec<String>>(),
+                        vec!["0x1::XUS::XUS"]
+                    );
+                    assert_eq!(
+                        arguments
+                            .into_iter()
+                            .map(|arg| arg.as_str().unwrap().to_owned())
+                            .collect::<Vec<String>>(),
+                        vec![
+                            receiver.address().to_hex_literal(),
+                            amount.to_string(),
+                            "0x".to_string(),
+                            "0x".to_string()
+                        ]
+                    );
+                } else {
+                    bail!("unexpected transaction playload")
+                }
             }
-            _ => panic!("Query should get user transaction"),
+            _ => bail!("Query should get user transaction"),
         }
         Ok(())
     }


### PR DESCRIPTION
## Motivation

#9193 
Migrate smoke tests to use rest api client:
1. Added getting epoch configuration to rest client
2. Update smoke test to use rest api client to get epoch
3. Migrate forge interface public usage context and chain info to use rest client
4. Migrate nft smoke test to use rest api client
5. [api] add accumulator_root_hash to onchain Transaction for forge fork_check

## Test Plan

CI build

## Related PRs

#10032
