### PR TITLE
[data-client] Add Metric Counters to Data Client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,6 +1677,7 @@ dependencies = [
  "diem-id-generator",
  "diem-infallible",
  "diem-logger",
+ "diem-metrics",
  "diem-time-service",
  "diem-types",
  "diem-workspace-hack",

--- a/state-sync/diem-data-client/Cargo.toml
+++ b/state-sync/diem-data-client/Cargo.toml
@@ -22,6 +22,7 @@ diem-crypto = { path = "../../crates/diem-crypto" }
 diem-id-generator = { path = "../../crates/diem-id-generator" }
 diem-infallible = { path = "../../crates/diem-infallible" }
 diem-logger = { path = "../../crates/diem-logger" }
+diem-metrics = { path = "../../crates/diem-metrics" }
 diem-time-service = { path = "../../crates/diem-time-service", features = ["async"] }
 diem-types = { path = "../../types" }
 diem-workspace-hack = { version = "0.1", path = "../../crates/diem-workspace-hack" }

--- a/state-sync/diem-data-client/src/diemnet/metrics.rs
+++ b/state-sync/diem-data-client/src/diemnet/metrics.rs
@@ -1,0 +1,61 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use diem_crypto::_once_cell::sync::Lazy;
+use diem_metrics::{
+    register_histogram_vec, register_int_counter_vec, HistogramTimer, HistogramVec, IntCounterVec,
+};
+
+/// The special label TOTAL_COUNT stores the sum of all values in the counter.
+pub const TOTAL_COUNT_LABEL: &str = "TOTAL_COUNT";
+
+/// Counter for tracking sent requests
+pub static SENT_REQUESTS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "diem_data_client_sent_requests",
+        "Counters related to sent requests",
+        &["request_types"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking success responses
+pub static SUCCESS_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "diem_data_client_success_responses",
+        "Counters related to success responses",
+        &["response_type"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking error responses
+pub static ERROR_RESPONSES: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "diem_data_client_error_responses",
+        "Counters related to error responses",
+        &["response_type"]
+    )
+    .unwrap()
+});
+
+/// Counter for tracking request latencies
+pub static REQUEST_LATENCIES: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "diem_data_client_request_latencies",
+        "Counters related to request latencies",
+        &["request_type"]
+    )
+    .unwrap()
+});
+
+/// Increments the given counter with the provided label values.
+pub fn increment_counter(counter: &Lazy<IntCounterVec>, label: String) {
+    counter.with_label_values(&[&label]).inc();
+    counter.with_label_values(&[TOTAL_COUNT_LABEL]).inc();
+}
+
+/// Starts the timer for the provided histogram and label values.
+pub fn start_timer(histogram: &Lazy<HistogramVec>, label: String) -> HistogramTimer {
+    histogram.with_label_values(&[&label]).start_timer()
+}


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds metric counters to `diem-data-client` to keep track the following:
- the number of requests sent (per request type and total)
- the number of success responses (per request type and total)
- the number of error responses (per request type and total)
- the number of peer selection errors (per request type and total)
- request latencies (per request type)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

No test plan is required. Re-ran existing tests to make sure this PR does not fail existing tests.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
