### PR TITLE
[State Sync] Add simple smoke tests for validator behaviour.

### DIFF
--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -138,6 +138,12 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         )?;
         let mut transactions = txn_list_with_proof.transactions;
         transactions.drain(..txns_to_skip as usize);
+        if txns_to_skip == num_txns {
+            info!(
+                "Skipping all transactions in the given chunk! Num transactions: {:?}",
+                num_txns
+            );
+        }
 
         // Execute transactions.
         let state_view = self.state_view(&latest_view, &persisted_view);

--- a/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/stream_engine.rs
@@ -614,31 +614,8 @@ impl DataStreamEngine for ContinuousTransactionStreamEngine {
             request => invalid_stream_request!(request),
         };
 
-        // If the stream has a target end, verify we can get there.
+        // Verify we can satisfy the next version
         let (next_request_version, _) = self.next_request_version_and_epoch;
-        match &self.request {
-            StreamRequest::ContinuouslyStreamTransactions(request) => {
-                if let Some(target) = &request.target {
-                    return AdvertisedData::contains_range(
-                        next_request_version,
-                        target.ledger_info().version(),
-                        advertised_ranges,
-                    );
-                }
-            }
-            StreamRequest::ContinuouslyStreamTransactionOutputs(request) => {
-                if let Some(target) = &request.target {
-                    return AdvertisedData::contains_range(
-                        next_request_version,
-                        target.ledger_info().version(),
-                        advertised_ranges,
-                    );
-                }
-            }
-            request => invalid_stream_request!(request),
-        };
-
-        // The stream has no target end. Verify we can satisfy the next version.
         AdvertisedData::contains_range(
             next_request_version,
             next_request_version,

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/streaming_service.rs
@@ -674,7 +674,9 @@ async fn test_stream_continuous_outputs_target() {
         .await;
     assert_ok!(result);
 
-    // Request a stream where data is missing (the target version is higher than advertised)
+    // Request a stream where data is missing (the target version is higher than
+    // advertised) and verify the stream is still created. This covers the case
+    // where the advertised data is lagging behind the target requested by consensus.
     let result = streaming_client
         .continuously_stream_transaction_outputs(
             MIN_ADVERTISED_TRANSACTION_OUTPUT,
@@ -686,7 +688,7 @@ async fn test_stream_continuous_outputs_target() {
             )),
         )
         .await;
-    assert_matches!(result, Err(Error::DataIsUnavailable(_)));
+    assert_ok!(result);
 }
 
 #[tokio::test]
@@ -748,7 +750,9 @@ async fn test_stream_continuous_transactions_target() {
         .await;
     assert_ok!(result);
 
-    // Request a stream where data is missing (the target version is higher than advertised)
+    // Request a stream where data is missing (the target version is higher than
+    // advertised) and verify the stream is still created. This covers the case
+    // where the advertised data is lagging behind the target requested by consensus.
     let result = streaming_client
         .continuously_stream_transactions(
             MIN_ADVERTISED_TRANSACTION,
@@ -761,7 +765,7 @@ async fn test_stream_continuous_transactions_target() {
             )),
         )
         .await;
-    assert_matches!(result, Err(Error::DataIsUnavailable(_)));
+    assert_ok!(result);
 }
 
 #[tokio::test]

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -229,7 +229,7 @@ impl VerifiedEpochStates {
 }
 
 /// A simple component that manages the bootstrapping of the node
-pub struct Bootstrapper<M, S> {
+pub struct Bootstrapper<MempoolNotifier, StorageSyncer> {
     // The currently active data stream (provided by the data streaming service)
     active_data_stream: Option<DataStreamListener>,
 
@@ -246,25 +246,27 @@ pub struct Bootstrapper<M, S> {
     event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
 
     // The handler for notifications to mempool
-    mempool_notification_handler: MempoolNotificationHandler<M>,
+    mempool_notification_handler: MempoolNotificationHandler<MempoolNotifier>,
 
     // The client through which to stream data from the Diem network
     streaming_service_client: StreamingServiceClient,
 
     // The storage synchronizer used to update local storage
-    storage_synchronizer: Arc<Mutex<S>>,
+    storage_synchronizer: Arc<Mutex<StorageSyncer>>,
 
     // The epoch states verified by this node (held in memory)
     verified_epoch_states: VerifiedEpochStates,
 }
 
-impl<M: MempoolNotificationSender, S: StorageSynchronizerInterface> Bootstrapper<M, S> {
+impl<MempoolNotifier: MempoolNotificationSender, StorageSyncer: StorageSynchronizerInterface>
+    Bootstrapper<MempoolNotifier, StorageSyncer>
+{
     pub fn new(
         driver_configuration: DriverConfiguration,
         event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
-        mempool_notification_handler: MempoolNotificationHandler<M>,
+        mempool_notification_handler: MempoolNotificationHandler<MempoolNotifier>,
         streaming_service_client: StreamingServiceClient,
-        storage_synchronizer: Arc<Mutex<S>>,
+        storage_synchronizer: Arc<Mutex<StorageSyncer>>,
     ) -> Self {
         // Load the latest epoch state from storage
         let latest_storage_summary = storage_synchronizer

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -4,6 +4,7 @@
 use crate::{
     driver::DriverConfiguration,
     error::Error,
+    notification_handlers::MempoolNotificationHandler,
     storage_synchronizer::{StorageStateSummary, StorageSynchronizerInterface},
     utils,
 };
@@ -21,11 +22,12 @@ use diem_types::{
     epoch_change::Verifier,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
+    transaction::{Transaction, TransactionListWithProof, TransactionOutputListWithProof, Version},
     waypoint::Waypoint,
 };
 use event_notifications::EventSubscriptionService;
 use futures::channel::oneshot;
+use mempool_notifications::MempoolNotificationSender;
 use std::{collections::BTreeMap, sync::Arc};
 
 /// A simple container for verified epoch states and epoch ending ledger infos
@@ -227,7 +229,7 @@ impl VerifiedEpochStates {
 }
 
 /// A simple component that manages the bootstrapping of the node
-pub struct Bootstrapper<S> {
+pub struct Bootstrapper<M, S> {
     // The currently active data stream (provided by the data streaming service)
     active_data_stream: Option<DataStreamListener>,
 
@@ -243,6 +245,9 @@ pub struct Bootstrapper<S> {
     // The event subscription service to notify listeners of on-chain events
     event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
 
+    // The handler for notifications to mempool
+    mempool_notification_handler: MempoolNotificationHandler<M>,
+
     // The client through which to stream data from the Diem network
     streaming_service_client: StreamingServiceClient,
 
@@ -253,10 +258,11 @@ pub struct Bootstrapper<S> {
     verified_epoch_states: VerifiedEpochStates,
 }
 
-impl<S: StorageSynchronizerInterface> Bootstrapper<S> {
+impl<M: MempoolNotificationSender, S: StorageSynchronizerInterface> Bootstrapper<M, S> {
     pub fn new(
         driver_configuration: DriverConfiguration,
         event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
+        mempool_notification_handler: MempoolNotificationHandler<M>,
         streaming_service_client: StreamingServiceClient,
         storage_synchronizer: Arc<Mutex<S>>,
     ) -> Self {
@@ -274,6 +280,7 @@ impl<S: StorageSynchronizerInterface> Bootstrapper<S> {
             bootstrapped: false,
             driver_configuration,
             event_subscription_service,
+            mempool_notification_handler,
             streaming_service_client,
             storage_synchronizer,
             verified_epoch_states,
@@ -620,55 +627,71 @@ impl<S: StorageSynchronizerInterface> Bootstrapper<S> {
         let highest_known_ledger_info = self.get_highest_known_ledger_info()?;
 
         // Execute/apply and commit the transactions/outputs
-        let committed_events = match self.driver_configuration.config.bootstrapping_mode {
-            BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
-                if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
-                    self.storage_synchronizer
-                        .lock()
-                        .apply_and_commit_transaction_outputs(
-                            transaction_outputs_with_proof,
-                            highest_known_ledger_info,
-                            end_of_epoch_ledger_info,
+        let (committed_events, committed_transactions) =
+            match self.driver_configuration.config.bootstrapping_mode {
+                BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
+                    if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
+                        let committed_transactions = transaction_outputs_with_proof
+                            .transactions_and_outputs
+                            .iter()
+                            .map(|(txn, _)| txn.clone())
+                            .collect();
+                        let committed_events = self
+                            .storage_synchronizer
+                            .lock()
+                            .apply_and_commit_transaction_outputs(
+                                transaction_outputs_with_proof,
+                                highest_known_ledger_info,
+                                end_of_epoch_ledger_info,
+                            );
+                        (committed_events, committed_transactions)
+                    } else {
+                        self.terminate_active_stream(
+                            notification_id,
+                            NotificationFeedback::PayloadTypeIsIncorrect,
                         )
-                } else {
-                    self.terminate_active_stream(
-                        notification_id,
-                        NotificationFeedback::PayloadTypeIsIncorrect,
-                    )
-                    .await?;
-                    return Err(Error::InvalidPayload(
-                        "Did not receive transaction outputs with proof!".into(),
-                    ));
+                        .await?;
+                        return Err(Error::InvalidPayload(
+                            "Did not receive transaction outputs with proof!".into(),
+                        ));
+                    }
                 }
-            }
-            BootstrappingMode::ExecuteTransactionsFromGenesis => {
-                if let Some(transaction_list_with_proof) = transaction_list_with_proof {
-                    self.storage_synchronizer
-                        .lock()
-                        .execute_and_commit_transactions(
-                            transaction_list_with_proof,
-                            highest_known_ledger_info,
-                            end_of_epoch_ledger_info,
+                BootstrappingMode::ExecuteTransactionsFromGenesis => {
+                    if let Some(transaction_list_with_proof) = transaction_list_with_proof {
+                        let committed_transactions =
+                            transaction_list_with_proof.transactions.clone();
+                        let committed_events = self
+                            .storage_synchronizer
+                            .lock()
+                            .execute_and_commit_transactions(
+                                transaction_list_with_proof,
+                                highest_known_ledger_info,
+                                end_of_epoch_ledger_info,
+                            );
+                        (committed_events, committed_transactions)
+                    } else {
+                        self.terminate_active_stream(
+                            notification_id,
+                            NotificationFeedback::PayloadTypeIsIncorrect,
                         )
-                } else {
-                    self.terminate_active_stream(
-                        notification_id,
-                        NotificationFeedback::PayloadTypeIsIncorrect,
-                    )
-                    .await?;
-                    return Err(Error::InvalidPayload(
-                        "Did not receive transactions with proof!".into(),
-                    ));
+                        .await?;
+                        return Err(Error::InvalidPayload(
+                            "Did not receive transactions with proof!".into(),
+                        ));
+                    }
                 }
-            }
-            bootstrapping_mode => {
-                unimplemented!("Bootstrapping mode not supported: {:?}", bootstrapping_mode)
-            }
-        };
+                bootstrapping_mode => {
+                    unimplemented!("Bootstrapping mode not supported: {:?}", bootstrapping_mode)
+                }
+            };
 
-        // Notify the event subscription service of new events
-        self.notify_committed_events(notification_id, committed_events)
-            .await
+        // Notify listeners of committed events and transactions
+        self.notify_committed_events_and_transactions(
+            notification_id,
+            committed_events,
+            committed_transactions,
+        )
+        .await
     }
 
     /// Verifies the first payload version matches the version we wish to sync
@@ -770,18 +793,23 @@ impl<S: StorageSynchronizerInterface> Bootstrapper<S> {
             .get_epoch_ending_ledger_info(payload_end_version))
     }
 
-    /// Notifies the event subscription service of committed events
-    async fn notify_committed_events(
+    /// Notifies mempool of the committed transactions and notifies the event
+    /// subscription service of committed events.
+    async fn notify_committed_events_and_transactions(
         &mut self,
         notification_id: NotificationId,
         committed_events: Result<Vec<ContractEvent>, Error>,
+        committed_transactions: Vec<Transaction>,
     ) -> Result<(), Error> {
         match committed_events {
             Ok(committed_events) => {
                 let latest_storage_summary =
                     self.storage_synchronizer.lock().get_storage_summary()?;
-                utils::notify_committed_events(
-                    latest_storage_summary,
+
+                utils::notify_committed_events_and_transactions(
+                    &latest_storage_summary,
+                    self.mempool_notification_handler.clone(),
+                    committed_transactions,
                     self.event_subscription_service.clone(),
                     committed_events,
                 )

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    driver::DriverConfiguration, error::Error, notification_handlers::ConsensusSyncRequest,
-    storage_synchronizer::StorageSynchronizerInterface, utils,
+    driver::DriverConfiguration,
+    error::Error,
+    notification_handlers::{ConsensusSyncRequest, MempoolNotificationHandler},
+    storage_synchronizer::StorageSynchronizerInterface,
+    utils,
 };
 use data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
@@ -16,13 +19,14 @@ use diem_types::{
     contract_event::ContractEvent,
     epoch_change::Verifier,
     ledger_info::LedgerInfoWithSignatures,
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
+    transaction::{Transaction, TransactionListWithProof, TransactionOutputListWithProof, Version},
 };
 use event_notifications::EventSubscriptionService;
+use mempool_notifications::MempoolNotificationSender;
 use std::sync::Arc;
 
 /// A simple component that manages the continuous syncing of the node
-pub struct ContinuousSyncer<S> {
+pub struct ContinuousSyncer<M, S> {
     // The currently active data stream (provided by the data streaming service)
     active_data_stream: Option<DataStreamListener>,
 
@@ -32,6 +36,9 @@ pub struct ContinuousSyncer<S> {
     // The event subscription service to notify listeners of on-chain events
     event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
 
+    // The handler for notifications to mempool
+    mempool_notification_handler: MempoolNotificationHandler<M>,
+
     // The client through which to stream data from the Diem network
     streaming_service_client: StreamingServiceClient,
 
@@ -39,10 +46,11 @@ pub struct ContinuousSyncer<S> {
     storage_synchronizer: Arc<Mutex<S>>,
 }
 
-impl<S: StorageSynchronizerInterface> ContinuousSyncer<S> {
+impl<M: MempoolNotificationSender, S: StorageSynchronizerInterface> ContinuousSyncer<M, S> {
     pub fn new(
         driver_configuration: DriverConfiguration,
         event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
+        mempool_notification_handler: MempoolNotificationHandler<M>,
         streaming_service_client: StreamingServiceClient,
         storage_synchronizer: Arc<Mutex<S>>,
     ) -> Self {
@@ -50,6 +58,7 @@ impl<S: StorageSynchronizerInterface> ContinuousSyncer<S> {
             active_data_stream: None,
             driver_configuration,
             event_subscription_service,
+            mempool_notification_handler,
             streaming_service_client,
             storage_synchronizer,
         }
@@ -196,52 +205,68 @@ impl<S: StorageSynchronizerInterface> ContinuousSyncer<S> {
         .await?;
 
         // Execute/apply and commit the transactions/outputs
-        let committed_events = match self.driver_configuration.config.continuous_syncing_mode {
-            ContinuousSyncingMode::ApplyTransactionOutputs => {
-                if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
-                    self.storage_synchronizer
-                        .lock()
-                        .apply_and_commit_transaction_outputs(
-                            transaction_outputs_with_proof,
-                            ledger_info_with_signatures,
-                            None,
+        let (committed_events, committed_transactions) =
+            match self.driver_configuration.config.continuous_syncing_mode {
+                ContinuousSyncingMode::ApplyTransactionOutputs => {
+                    if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
+                        let committed_transactions = transaction_outputs_with_proof
+                            .transactions_and_outputs
+                            .iter()
+                            .map(|(txn, _)| txn.clone())
+                            .collect();
+                        let committed_events = self
+                            .storage_synchronizer
+                            .lock()
+                            .apply_and_commit_transaction_outputs(
+                                transaction_outputs_with_proof,
+                                ledger_info_with_signatures,
+                                None,
+                            );
+                        (committed_events, committed_transactions)
+                    } else {
+                        self.terminate_active_stream(
+                            notification_id,
+                            NotificationFeedback::PayloadTypeIsIncorrect,
                         )
-                } else {
-                    self.terminate_active_stream(
-                        notification_id,
-                        NotificationFeedback::PayloadTypeIsIncorrect,
-                    )
-                    .await?;
-                    return Err(Error::InvalidPayload(
-                        "Did not receive transaction outputs with proof!".into(),
-                    ));
+                        .await?;
+                        return Err(Error::InvalidPayload(
+                            "Did not receive transaction outputs with proof!".into(),
+                        ));
+                    }
                 }
-            }
-            ContinuousSyncingMode::ExecuteTransactions => {
-                if let Some(transaction_list_with_proof) = transaction_list_with_proof {
-                    self.storage_synchronizer
-                        .lock()
-                        .execute_and_commit_transactions(
-                            transaction_list_with_proof,
-                            ledger_info_with_signatures,
-                            None,
+                ContinuousSyncingMode::ExecuteTransactions => {
+                    if let Some(transaction_list_with_proof) = transaction_list_with_proof {
+                        let committed_transactions =
+                            transaction_list_with_proof.transactions.clone();
+                        let committed_events = self
+                            .storage_synchronizer
+                            .lock()
+                            .execute_and_commit_transactions(
+                                transaction_list_with_proof,
+                                ledger_info_with_signatures,
+                                None,
+                            );
+                        (committed_events, committed_transactions)
+                    } else {
+                        self.terminate_active_stream(
+                            notification_id,
+                            NotificationFeedback::PayloadTypeIsIncorrect,
                         )
-                } else {
-                    self.terminate_active_stream(
-                        notification_id,
-                        NotificationFeedback::PayloadTypeIsIncorrect,
-                    )
-                    .await?;
-                    return Err(Error::InvalidPayload(
-                        "Did not receive transactions with proof!".into(),
-                    ));
+                        .await?;
+                        return Err(Error::InvalidPayload(
+                            "Did not receive transactions with proof!".into(),
+                        ));
+                    }
                 }
-            }
-        };
+            };
 
-        // Notify the event subscription service of new events
-        self.notify_committed_events(notification_id, committed_events)
-            .await?;
+        // Notify listeners of committed events and transactions
+        self.notify_committed_events_and_transactions(
+            notification_id,
+            committed_events,
+            committed_transactions,
+        )
+        .await?;
 
         // Update the last commit timestamp for the sync request
         if let Some(sync_request) = consensus_sync_request.lock().as_mut() {
@@ -251,18 +276,23 @@ impl<S: StorageSynchronizerInterface> ContinuousSyncer<S> {
         Ok(())
     }
 
-    /// Notifies the event subscription service of committed events
-    async fn notify_committed_events(
+    /// Notifies mempool of the committed transactions and notifies the event
+    /// subscription service of committed events.
+    async fn notify_committed_events_and_transactions(
         &mut self,
         notification_id: NotificationId,
         committed_events: Result<Vec<ContractEvent>, Error>,
+        committed_transactions: Vec<Transaction>,
     ) -> Result<(), Error> {
         match committed_events {
             Ok(committed_events) => {
                 let latest_storage_summary =
                     self.storage_synchronizer.lock().get_storage_summary()?;
-                utils::notify_committed_events(
-                    latest_storage_summary,
+
+                utils::notify_committed_events_and_transactions(
+                    &latest_storage_summary,
+                    self.mempool_notification_handler.clone(),
+                    committed_transactions,
                     self.event_subscription_service.clone(),
                     committed_events,
                 )

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -26,7 +26,7 @@ use mempool_notifications::MempoolNotificationSender;
 use std::sync::Arc;
 
 /// A simple component that manages the continuous syncing of the node
-pub struct ContinuousSyncer<M, S> {
+pub struct ContinuousSyncer<MempoolNotifier, StorageSyncer> {
     // The currently active data stream (provided by the data streaming service)
     active_data_stream: Option<DataStreamListener>,
 
@@ -37,22 +37,24 @@ pub struct ContinuousSyncer<M, S> {
     event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
 
     // The handler for notifications to mempool
-    mempool_notification_handler: MempoolNotificationHandler<M>,
+    mempool_notification_handler: MempoolNotificationHandler<MempoolNotifier>,
 
     // The client through which to stream data from the Diem network
     streaming_service_client: StreamingServiceClient,
 
     // The storage synchronizer used to update local storage
-    storage_synchronizer: Arc<Mutex<S>>,
+    storage_synchronizer: Arc<Mutex<StorageSyncer>>,
 }
 
-impl<M: MempoolNotificationSender, S: StorageSynchronizerInterface> ContinuousSyncer<M, S> {
+impl<MempoolNotifier: MempoolNotificationSender, StorageSyncer: StorageSynchronizerInterface>
+    ContinuousSyncer<MempoolNotifier, StorageSyncer>
+{
     pub fn new(
         driver_configuration: DriverConfiguration,
         event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
-        mempool_notification_handler: MempoolNotificationHandler<M>,
+        mempool_notification_handler: MempoolNotificationHandler<MempoolNotifier>,
         streaming_service_client: StreamingServiceClient,
-        storage_synchronizer: Arc<Mutex<S>>,
+        storage_synchronizer: Arc<Mutex<StorageSyncer>>,
     ) -> Self {
         Self {
             active_data_stream: None,

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -52,9 +52,9 @@ impl DriverConfiguration {
 }
 
 /// The state sync driver that drives synchronization progress
-pub struct StateSyncDriver<D, M, S> {
+pub struct StateSyncDriver<DataClient, MempoolNotifier, StorageSyncer> {
     // The component that manages the initial bootstrapping of the node
-    bootstrapper: Bootstrapper<M, S>,
+    bootstrapper: Bootstrapper<MempoolNotifier, StorageSyncer>,
 
     // The listener for client notifications
     client_notification_listener: ClientNotificationListener,
@@ -63,10 +63,10 @@ pub struct StateSyncDriver<D, M, S> {
     consensus_notification_handler: ConsensusNotificationHandler,
 
     // The component that manages the continuous syncing of the node
-    continuous_syncer: ContinuousSyncer<M, S>,
+    continuous_syncer: ContinuousSyncer<MempoolNotifier, StorageSyncer>,
 
     // The client for checking the global data summary of our peers
-    diem_data_client: D,
+    diem_data_client: DataClient,
 
     // The configuration for the driver
     driver_configuration: DriverConfiguration,
@@ -75,26 +75,26 @@ pub struct StateSyncDriver<D, M, S> {
     event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
 
     // The handler for notifications to mempool
-    mempool_notification_handler: MempoolNotificationHandler<M>,
+    mempool_notification_handler: MempoolNotificationHandler<MempoolNotifier>,
 
     // The storage synchronizer used to update local storage
-    storage_synchronizer: Arc<Mutex<S>>,
+    storage_synchronizer: Arc<Mutex<StorageSyncer>>,
 }
 
 impl<
-        D: DiemDataClient + Send + Clone + 'static,
-        M: MempoolNotificationSender,
-        S: StorageSynchronizerInterface,
-    > StateSyncDriver<D, M, S>
+        DataClient: DiemDataClient + Send + Clone + 'static,
+        MempoolNotifier: MempoolNotificationSender,
+        StorageSyncer: StorageSynchronizerInterface,
+    > StateSyncDriver<DataClient, MempoolNotifier, StorageSyncer>
 {
     pub fn new(
         client_notification_listener: ClientNotificationListener,
         consensus_notification_handler: ConsensusNotificationHandler,
         driver_configuration: DriverConfiguration,
         event_subscription_service: EventSubscriptionService,
-        mempool_notification_handler: MempoolNotificationHandler<M>,
-        storage_synchronizer: S,
-        diem_data_client: D,
+        mempool_notification_handler: MempoolNotificationHandler<MempoolNotifier>,
+        storage_synchronizer: StorageSyncer,
+        diem_data_client: DataClient,
         streaming_service_client: StreamingServiceClient,
     ) -> Self {
         let event_subscription_service = Arc::new(Mutex::new(event_subscription_service));

--- a/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/notification_handlers.rs
@@ -7,6 +7,7 @@ use consensus_notifications::{
     ConsensusSyncNotification,
 };
 use diem_infallible::Mutex;
+use diem_logger::prelude::*;
 use diem_types::{ledger_info::LedgerInfoWithSignatures, transaction::Transaction};
 use futures::{stream::FusedStream, Stream};
 use mempool_notifications::MempoolNotificationSender;
@@ -101,6 +102,7 @@ impl ConsensusNotificationHandler {
 
         // If we're now at the target, return successfully
         if sync_target_version == latest_committed_version {
+            info!("We're already at the requested sync target version! Returning early.");
             let result = Ok(());
             self.respond_to_sync_notification(sync_notification, result.clone())
                 .await?;
@@ -253,6 +255,7 @@ impl FusedStream for ConsensusNotificationHandler {
 }
 
 /// A simple handler for sending notifications to mempool
+#[derive(Clone)]
 pub struct MempoolNotificationHandler<M> {
     mempool_notification_sender: M,
 }

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -9,7 +9,10 @@ use diem_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
 use diem_rest_client::Client as RestClient;
 use diem_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
 use forge::{LocalSwarm, NodeExt, Swarm, SwarmExt};
-use std::time::{Duration, Instant};
+use std::{
+    fs,
+    time::{Duration, Instant},
+};
 use tokio::runtime::Runtime;
 
 const MAX_CATCH_UP_SECS: u64 = 60; // The max time we'll wait for nodes to catch up
@@ -30,7 +33,7 @@ fn test_full_node_bootstrap_outputs() {
         .continuous_syncing_mode = ContinuousSyncingMode::ApplyTransactionOutputs;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_config, swarm, true)
+    test_full_node_sync(vfn_config, swarm, true);
 }
 
 #[test]
@@ -49,7 +52,7 @@ fn test_full_node_bootstrap_transactions() {
         .continuous_syncing_mode = ContinuousSyncingMode::ExecuteTransactions;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_config, swarm, true)
+    test_full_node_sync(vfn_config, swarm, true);
 }
 
 #[test]
@@ -66,7 +69,7 @@ fn test_full_node_continuous_sync_outputs() {
         .continuous_syncing_mode = ContinuousSyncingMode::ApplyTransactionOutputs;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_config, swarm, false)
+    test_full_node_sync(vfn_config, swarm, false);
 }
 
 #[test]
@@ -83,7 +86,7 @@ fn test_full_node_continuous_sync_transactions() {
         .continuous_syncing_mode = ContinuousSyncingMode::ExecuteTransactions;
 
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_config, swarm, false)
+    test_full_node_sync(vfn_config, swarm, false);
 }
 
 /// A helper method that tests that a full node can sync from a validator after
@@ -142,6 +145,109 @@ fn test_full_node_sync(full_node_config: NodeConfig, mut swarm: LocalSwarm, epoc
         &mut account_1,
         &account_0,
         epoch_changes,
+    );
+    swarm
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .unwrap();
+}
+
+#[test]
+fn test_validator_bootstrap_outputs() {
+    // Create a swarm of 4 validators with state sync v2 enabled (output syncing)
+    let mut swarm = new_local_swarm(4);
+    for validator in swarm.validators_mut() {
+        let mut config = validator.config().clone();
+        config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+        config.state_sync.state_sync_driver.bootstrapping_mode =
+            BootstrappingMode::ApplyTransactionOutputsFromGenesis;
+        config.state_sync.state_sync_driver.continuous_syncing_mode =
+            ContinuousSyncingMode::ApplyTransactionOutputs;
+        config.save(validator.config_path()).unwrap();
+        validator.restart().unwrap();
+    }
+
+    // Test the ability of the validators to sync
+    test_validator_sync(swarm);
+}
+
+#[test]
+fn test_validator_bootstrap_transactions() {
+    // Create a swarm of 4 validators with state sync v2 enabled (transaction syncing)
+    let mut swarm = new_local_swarm(4);
+    for validator in swarm.validators_mut() {
+        let mut config = validator.config().clone();
+        config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+        config.state_sync.state_sync_driver.bootstrapping_mode =
+            BootstrappingMode::ExecuteTransactionsFromGenesis;
+        config.state_sync.state_sync_driver.continuous_syncing_mode =
+            ContinuousSyncingMode::ExecuteTransactions;
+        config.save(validator.config_path()).unwrap();
+        validator.restart().unwrap();
+    }
+
+    // Test the ability of the validators to sync
+    test_validator_sync(swarm);
+}
+
+/// A helper method that tests that a validator can sync after a failure and
+/// continue to stay up-to-date.
+fn test_validator_sync(mut swarm: LocalSwarm) {
+    // Launch the swarm and wait for it to be ready
+    swarm.launch().unwrap();
+
+    // Execute multiple transactions through validator 0
+    let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
+    let validator_client_0 = swarm
+        .validator(validator_peer_ids[0])
+        .unwrap()
+        .rest_client();
+    let transaction_factory = swarm.chain_info().transaction_factory();
+    let mut account_0 = create_and_fund_account(&mut swarm, 1000);
+    let mut account_1 = create_and_fund_account(&mut swarm, 1000);
+    execute_transactions(
+        &mut swarm,
+        &validator_client_0,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        true,
+    );
+    swarm
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .unwrap();
+
+    // Stop validator 1 and delete the storage
+    let validator_1 = validator_peer_ids[1];
+    swarm.validator_mut(validator_1).unwrap().stop();
+    let node_config = swarm.validator_mut(validator_1).unwrap().config().clone();
+    let state_db_path = node_config.storage.dir().join("diemdb");
+    assert!(state_db_path.as_path().exists());
+    fs::remove_dir_all(state_db_path).unwrap();
+
+    // Execute more transactions
+    execute_transactions(
+        &mut swarm,
+        &validator_client_0,
+        &transaction_factory,
+        &mut account_1,
+        &account_0,
+        true,
+    );
+
+    // Restart validator 1 and wait for all nodes to catchup
+    swarm.validator_mut(validator_1).unwrap().start().unwrap();
+    swarm
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .unwrap();
+
+    // Execute multiple transactions and verify validator 1 can sync
+    execute_transactions(
+        &mut swarm,
+        &validator_client_0,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        true,
     );
     swarm
         .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))


### PR DESCRIPTION
## Motivation

This PR adds two new smoke tests to verify (simple) state sync v2 behaviour for validator nodes. It also offers several small cleanups in different commits:
1. Move the `transfer_and_reconfig()` helper method to smoke test utils (to be shared by tests).
2. Add two new smoke tests for basic validator verification for state sync v2. These tests currently fail.
3. Remove the storage synchronizer cache. This will be reintroduced when I land decoupled execute/commit as it requires refactors.
4. Allow continuous streams to be created even if the end of stream target is not yet advertised (useful in case advertised data is lagging slightly behind what consensus knows about).
5. Notify mempool and the event subscription service of committed events and transactions. With this change, the smoke tests added in commit 2 pass. 😄
6. Avoid using single letters for generic types.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

New smoke tests have been added for the new functionality.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906