### PR TITLE
migrate forge interfaces to use rest client and update tests

### DIFF
--- a/crates/diem-rest-client/src/lib.rs
+++ b/crates/diem-rest-client/src/lib.rs
@@ -395,7 +395,7 @@ impl Client {
             .await?;
 
         if !response.status().is_success() {
-            return Err(anyhow::anyhow!("health check failed",));
+            return Err(anyhow::anyhow!("health check failed"));
         }
 
         Ok(())

--- a/testsuite/forge/src/backend/k8s/cluster_helper.rs
+++ b/testsuite/forge/src/backend/k8s/cluster_helper.rs
@@ -1,9 +1,10 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{get_validators, k8s_retry_strategy, nodes_healthcheck, Result, Validator};
+use crate::{get_validators, k8s_retry_strategy, nodes_healthcheck, Result};
 use anyhow::{bail, format_err};
 use diem_logger::*;
+use futures::future::try_join_all;
 use hyper::{Client, Uri};
 use hyper_proxy::{Intercept, Proxy, ProxyConnector};
 use hyper_tls::HttpsConnector;
@@ -29,7 +30,6 @@ use std::{
     str,
 };
 use tempfile::TempDir;
-use tokio::runtime::Runtime;
 
 const HELM_BIN: &str = "helm";
 const KUBECTL_BIN: &str = "kubectl";
@@ -222,7 +222,7 @@ pub fn uninstall_from_k8s_cluster() -> Result<()> {
     Ok(())
 }
 
-pub fn clean_k8s_cluster(
+pub async fn clean_k8s_cluster(
     helm_repo: String,
     base_num_validators: usize,
     base_validator_image_tag: String,
@@ -331,23 +331,20 @@ pub fn clean_k8s_cluster(
     upgrade_testnet(&helm_repo, &testnet_upgrade_options)?;
 
     // wait for genesis to run again, and get the updated validators
-    let rt = Runtime::new().unwrap();
-    let mut validators = rt.block_on(async {
-        let kube_client = create_k8s_client().await;
-        wait_genesis_job(&kube_client, &new_era).await.unwrap();
-        let vals = get_validators(kube_client.clone(), &base_validator_image_tag)
-            .await
-            .unwrap();
-        vals
-    });
-    let all_nodes = Box::new(validators.values_mut().map(|v| v as &mut dyn Validator));
-
+    let kube_client = create_k8s_client().await;
+    wait_genesis_job(&kube_client, &new_era).await.unwrap();
+    let vals = get_validators(kube_client.clone(), &base_validator_image_tag)
+        .await
+        .unwrap();
+    let all_nodes = vals.values().collect();
     // healthcheck on each of the validators wait until they all healthy
-    if require_validator_healthcheck {
-        let unhealthy_nodes = nodes_healthcheck(all_nodes).unwrap();
-        if !unhealthy_nodes.is_empty() {
-            bail!("Unhealthy validators after cleanup: {:?}", unhealthy_nodes);
-        }
+    let unhealthy_nodes = if require_validator_healthcheck {
+        nodes_healthcheck(all_nodes).await.unwrap()
+    } else {
+        vec![]
+    };
+    if !unhealthy_nodes.is_empty() {
+        bail!("Unhealthy validators after cleanup: {:?}", unhealthy_nodes);
     }
 
     Ok(new_era)
@@ -454,7 +451,7 @@ async fn submit_update_nodegroup_config_request(
     Ok(update_id)
 }
 
-pub fn set_eks_nodegroup_size(
+pub async fn set_eks_nodegroup_size(
     cluster_name: String,
     num_validators: usize,
     auth_with_k8s_env: bool,
@@ -511,25 +508,27 @@ pub fn set_eks_nodegroup_size(
         * (VALIDATOR_SCALING_FACTOR + UTILITIES_SCALING_FACTOR + TRUSTED_SCALING_FACTOR);
 
     // submit the scaling requests
-    let rt = Runtime::new()?;
-    let validators_update_id = rt.block_on(submit_update_nodegroup_config_request(
+    let validators_update_id = submit_update_nodegroup_config_request(
         &eks_client,
         &cluster_name,
         "validators",
         validator_scaling,
-    ))?;
-    let utilities_update_id = rt.block_on(submit_update_nodegroup_config_request(
+    )
+    .await?;
+    let utilities_update_id = submit_update_nodegroup_config_request(
         &eks_client,
         &cluster_name,
         "utilities",
         utilities_scaling,
-    ))?;
-    let trusted_update_id = rt.block_on(submit_update_nodegroup_config_request(
+    )
+    .await?;
+    let trusted_update_id = submit_update_nodegroup_config_request(
         &eks_client,
         &cluster_name,
         "trusted",
         trusted_scaling,
-    ))?;
+    )
+    .await?;
 
     // wait for nodegroup updates
     let updates: Vec<(&str, &str)> = vec![
@@ -537,57 +536,67 @@ pub fn set_eks_nodegroup_size(
         ("utilities", &utilities_update_id),
         ("trusted", &trusted_update_id),
     ];
-    updates
-        .into_par_iter()
-        .for_each(|(nodegroup_name, update_id)| {
-            let rt = Runtime::new().unwrap();
-            rt.block_on(async {
-                diem_retrier::retry_async(k8s_retry_strategy(), || {
-                    let client = eks_client.clone();
-                    let describe_update_request = DescribeUpdateRequest {
-                        addon_name: None,
-                        name: cluster_name.clone(),
-                        nodegroup_name: Some(nodegroup_name.to_string()),
-                        update_id: update_id.to_string(),
-                    };
-                    Box::pin(async move {
-                        let describe_update =
-                            match client.describe_update(describe_update_request).await {
-                                Ok(resp) => resp.update.unwrap(),
-                                Err(err) => bail!(err),
-                            };
-                        if let Some(s) = describe_update.status {
-                            match s.as_str() {
-                                "Failed" => bail!("Nodegroup update failed"),
-                                "Successful" => {
-                                    println!(
-                                        "{} nodegroup update {} successful!!!",
-                                        &nodegroup_name, update_id
-                                    );
-                                    Ok(())
-                                }
-                                &_ => {
-                                    println!(
-                                        "Waiting for {} update {}: {} ...",
-                                        &nodegroup_name, update_id, s
-                                    );
-                                    bail!("Waiting for valid update status")
-                                }
-                            }
-                        } else {
-                            bail!("Failed to describe nodegroup update")
-                        }
-                    })
-                })
-                .await
-            })
-            .unwrap();
-        });
+    try_join_all(updates.into_iter().map(|(nodegroup_name, update_id)| {
+        describe_update(
+            eks_client.clone(),
+            cluster_name.clone(),
+            nodegroup_name.to_string(),
+            update_id.to_string(),
+        )
+    }))
+    .await
+    .unwrap();
 
-    rt.block_on(async { nodegroup_state_check(desire_nodegroup_size).await })
-        .unwrap();
+    nodegroup_state_check(desire_nodegroup_size).await.unwrap();
 
     Ok(())
+}
+
+async fn describe_update(
+    eks_client: EksClient,
+    cluster_name: String,
+    nodegroup_name: String,
+    update_id: String,
+) -> Result<()> {
+    diem_retrier::retry_async(k8s_retry_strategy(), || {
+        let client = eks_client.clone();
+        let nodegroup_name = nodegroup_name.clone();
+        let update_id = update_id.clone();
+        let request = DescribeUpdateRequest {
+            addon_name: None,
+            name: cluster_name.clone(),
+            nodegroup_name: Some(nodegroup_name.clone()),
+            update_id: update_id.clone(),
+        };
+        Box::pin(async move {
+            let describe_update = match client.describe_update(request).await {
+                Ok(resp) => resp.update.unwrap(),
+                Err(err) => bail!(err),
+            };
+            if let Some(s) = describe_update.status {
+                match s.as_str() {
+                    "Failed" => bail!("Nodegroup update failed"),
+                    "Successful" => {
+                        println!(
+                            "{} nodegroup update {} successful!!!",
+                            &nodegroup_name, update_id
+                        );
+                        Ok(())
+                    }
+                    &_ => {
+                        println!(
+                            "Waiting for {} update {}: {} ...",
+                            &nodegroup_name, update_id, s
+                        );
+                        bail!("Waiting for valid update status")
+                    }
+                }
+            } else {
+                bail!("Failed to describe nodegroup update")
+            }
+        })
+    })
+    .await
 }
 
 pub fn scale_sts_replica(sts_name: &str, replica_num: u64) -> Result<()> {

--- a/testsuite/forge/src/interface/factory.rs
+++ b/testsuite/forge/src/interface/factory.rs
@@ -7,10 +7,11 @@ use rand::rngs::StdRng;
 use std::num::NonZeroUsize;
 
 /// Trait used to represent a interface for constructing a launching new networks
+#[async_trait::async_trait]
 pub trait Factory {
     fn versions<'a>(&'a self) -> Box<dyn Iterator<Item = Version> + 'a>;
 
-    fn launch_swarm(
+    async fn launch_swarm(
         &self,
         rng: &mut StdRng,
         node_num: NonZeroUsize,

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -261,14 +261,15 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
             );
             let initial_version = self.initial_version();
             let genesis_version = self.genesis_version();
+            let runtime = Runtime::new().unwrap();
             let mut rng = ::rand::rngs::StdRng::from_seed(OsRng.gen());
-            let mut swarm = self.factory.launch_swarm(
+            let mut swarm = runtime.block_on(self.factory.launch_swarm(
                 &mut rng,
                 self.tests.initial_validator_count,
                 &initial_version,
                 &genesis_version,
                 self.tests.genesis_config.as_ref(),
-            )?;
+            ))?;
 
             // Run PublicUsageTests
             for test in self.filter_tests(self.tests.public_usage_tests.iter()) {
@@ -283,7 +284,6 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
 
             // Run NFTPublicUsageTests
             if !self.tests.nft_public_usage_tests.is_empty() {
-                let runtime = Runtime::new().unwrap();
                 runtime.block_on(
                     swarm
                         .chain_info()

--- a/testsuite/smoke-test/src/client.rs
+++ b/testsuite/smoke-test/src/client.rs
@@ -9,114 +9,101 @@ use crate::{
 };
 use forge::{NodeExt, Swarm};
 use std::time::{Duration, Instant};
-use tokio::runtime::Runtime;
 
-#[test]
-fn test_create_mint_transfer_block_metadata() {
-    let mut swarm = new_local_swarm(1);
+#[tokio::test]
+async fn test_create_mint_transfer_block_metadata() {
+    let mut swarm = new_local_swarm(1).await;
 
-    let runtime = Runtime::new().unwrap();
     // This script does 4 transactions
-    runtime.block_on(async {
-        check_create_mint_transfer(&mut swarm).await;
+    check_create_mint_transfer(&mut swarm).await;
 
-        // Test if we commit not only user transactions but also block metadata transactions,
-        // assert committed version > # of user transactions
-        let client = swarm.validators().next().unwrap().rest_client();
-        let version = client
-            .get_ledger_information()
-            .await
-            .unwrap()
-            .into_inner()
-            .version;
-        assert!(
-            version > 4,
-            "BlockMetadata txn not produced, current version: {}",
-            version
-        );
-    });
+    // Test if we commit not only user transactions but also block metadata transactions,
+    // assert committed version > # of user transactions
+    let client = swarm.validators().next().unwrap().rest_client();
+    let version = client
+        .get_ledger_information()
+        .await
+        .unwrap()
+        .into_inner()
+        .version;
+    assert!(
+        version > 4,
+        "BlockMetadata txn not produced, current version: {}",
+        version
+    );
 }
 
-#[test]
-fn test_basic_fault_tolerance() {
+#[tokio::test]
+async fn test_basic_fault_tolerance() {
     // A configuration with 4 validators should tolerate single node failure.
-    let mut swarm = new_local_swarm(4);
+    let mut swarm = new_local_swarm(4).await;
     swarm.validators_mut().nth(3).unwrap().stop();
-    let runtime = Runtime::new().unwrap();
-    runtime.block_on(check_create_mint_transfer(&mut swarm));
+    check_create_mint_transfer(&mut swarm).await;
 }
 
-#[test]
-fn test_basic_restartability() {
-    let mut swarm = new_local_swarm(4);
+#[tokio::test]
+async fn test_basic_restartability() {
+    let mut swarm = new_local_swarm(4).await;
     let client = swarm.validators().next().unwrap().rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
-    let runtime = Runtime::new().unwrap();
+    let mut account_0 = create_and_fund_account(&mut swarm, 100).await;
+    let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
-    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
-    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
-
-    runtime.block_on(async {
-        transfer_coins(
-            &client,
-            &transaction_factory,
-            &mut account_0,
-            &account_1,
-            10,
-        )
-        .await;
-        assert_balance(&client, &account_0, 90).await;
-        assert_balance(&client, &account_1, 20).await;
-    });
+    transfer_coins(
+        &client,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        10,
+    )
+    .await;
+    assert_balance(&client, &account_0, 90).await;
+    assert_balance(&client, &account_1, 20).await;
 
     let validator = swarm.validators_mut().next().unwrap();
-    validator.restart().unwrap();
+    validator.restart().await.unwrap();
     validator
         .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .await
         .unwrap();
 
-    runtime.block_on(async {
-        assert_balance(&client, &account_0, 90).await;
-        assert_balance(&client, &account_1, 20).await;
+    assert_balance(&client, &account_0, 90).await;
+    assert_balance(&client, &account_1, 20).await;
 
-        transfer_coins(
-            &client,
-            &transaction_factory,
-            &mut account_0,
-            &account_1,
-            10,
-        )
-        .await;
-        assert_balance(&client, &account_0, 80).await;
-        assert_balance(&client, &account_1, 30).await;
-    });
+    transfer_coins(
+        &client,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        10,
+    )
+    .await;
+    assert_balance(&client, &account_0, 80).await;
+    assert_balance(&client, &account_1, 30).await;
 }
 
-#[test]
-fn test_concurrent_transfers_single_node() {
-    let mut swarm = new_local_swarm(1);
+#[tokio::test]
+async fn test_concurrent_transfers_single_node() {
+    let mut swarm = new_local_swarm(1).await;
     let client = swarm.validators().next().unwrap().rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
-    let runtime = Runtime::new().unwrap();
-    runtime.block_on(async {
-        let mut account_0 = create_and_fund_account(&mut swarm, 100).await;
-        let account_1 = create_and_fund_account(&mut swarm, 10).await;
+    let mut account_0 = create_and_fund_account(&mut swarm, 100).await;
+    let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
-        assert_balance(&client, &account_0, 100).await;
-        assert_balance(&client, &account_1, 10).await;
+    assert_balance(&client, &account_0, 100).await;
+    assert_balance(&client, &account_1, 10).await;
 
-        for _ in 0..20 {
-            let txn = account_0.sign_with_transaction_builder(transaction_factory.peer_to_peer(
-                diem_sdk::transaction_builder::Currency::XUS,
-                account_1.address(),
-                1,
-            ));
-            client.submit_and_wait(&txn).await.unwrap();
-        }
-        transfer_coins(&client, &transaction_factory, &mut account_0, &account_1, 1).await;
-        assert_balance(&client, &account_0, 79).await;
-        assert_balance(&client, &account_1, 31).await;
-    });
+    for _ in 0..20 {
+        let txn = account_0.sign_with_transaction_builder(transaction_factory.peer_to_peer(
+            diem_sdk::transaction_builder::Currency::XUS,
+            account_1.address(),
+            1,
+        ));
+        client.submit_and_wait(&txn).await.unwrap();
+    }
+    transfer_coins(&client, &transaction_factory, &mut account_0, &account_1, 1).await;
+    assert_balance(&client, &account_0, 79).await;
+    assert_balance(&client, &account_1, 31).await;
 }

--- a/testsuite/smoke-test/src/key_manager.rs
+++ b/testsuite/smoke-test/src/key_manager.rs
@@ -16,11 +16,13 @@ use diem_time_service::TimeService;
 use diem_types::chain_id::ChainId;
 use forge::Node;
 use std::{convert::TryInto, thread, thread::sleep, time::Duration};
+use tokio::runtime::Runtime;
 
 #[test]
 fn test_key_manager_consensus_rotation() {
+    let runtime = Runtime::new().unwrap();
     // Create and launch a local validator swarm
-    let swarm = new_local_swarm(1);
+    let swarm = runtime.block_on(new_local_swarm(1));
     let validator = swarm.validators().next().unwrap();
 
     // Fetch the first node config in the swarm

--- a/testsuite/smoke-test/src/replay_tooling.rs
+++ b/testsuite/smoke-test/src/replay_tooling.rs
@@ -19,7 +19,7 @@ impl Test for ReplayTooling {
 impl PublicUsageTest for ReplayTooling {
     fn run<'t>(&self, ctx: &mut PublicUsageContext<'t>) -> Result<()> {
         let client = ctx.rest_client();
-        // todo: try async call to json_debugger calls
+        // we need turn this into async for making this test fully async
         let json_debugger = DiemDebugger::json_rpc(ctx.url())?;
 
         let treasury_account_address =

--- a/testsuite/smoke-test/src/smoke_test_environment.rs
+++ b/testsuite/smoke-test/src/smoke_test_environment.rs
@@ -6,12 +6,13 @@ use once_cell::sync::Lazy;
 use rand::rngs::OsRng;
 use std::num::NonZeroUsize;
 
-pub fn new_local_swarm(num_validators: usize) -> LocalSwarm {
+pub async fn new_local_swarm(num_validators: usize) -> LocalSwarm {
     static FACTORY: Lazy<LocalFactory> = Lazy::new(|| LocalFactory::from_workspace().unwrap());
 
     ::diem_logger::Logger::new().init();
 
     FACTORY
         .new_swarm(OsRng, NonZeroUsize::new(num_validators).unwrap())
+        .await
         .unwrap()
 }

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -20,10 +20,9 @@ use std::{
     path::PathBuf,
     time::{Duration, Instant},
 };
-use tokio::runtime::Runtime;
 
-#[test]
-fn test_basic_state_synchronization() {
+#[tokio::test]
+async fn test_basic_state_synchronization() {
     // - Start a swarm of 4 nodes (3 nodes forming a QC).
     // - Kill one node and continue submitting transactions to the others.
     // - Restart the node
@@ -31,14 +30,14 @@ fn test_basic_state_synchronization() {
     // - Verify that the restarted node has synced up with the submitted transactions.
 
     // we set a smaller chunk limit (=5) here to properly test multi-chunk state sync
-    let mut swarm = new_local_swarm(4);
+    let mut swarm = new_local_swarm(4).await;
     for validator in swarm.validators_mut() {
         let mut config = validator.config().clone();
         config.state_sync.chunk_limit = 5;
         config.save(validator.config_path()).unwrap();
-        validator.restart().unwrap();
+        validator.restart().await.unwrap();
     }
-    swarm.launch().unwrap(); // Make sure all nodes are healthy and live
+    swarm.launch().await.unwrap(); // Make sure all nodes are healthy and live
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
 
     let client_1 = swarm
@@ -47,29 +46,62 @@ fn test_basic_state_synchronization() {
         .rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
-    let runtime = Runtime::new().unwrap();
+    let mut account_0 = create_and_fund_account(&mut swarm, 100).await;
+    let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
-    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
-    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
+    transfer_coins(
+        &client_1,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        10,
+    )
+    .await;
+    assert_balance(&client_1, &account_0, 90).await;
+    assert_balance(&client_1, &account_1, 20).await;
 
-    runtime.block_on(async {
-        transfer_coins(
-            &client_1,
-            &transaction_factory,
-            &mut account_0,
-            &account_1,
-            10,
-        )
-        .await;
-        assert_balance(&client_1, &account_0, 90).await;
-        assert_balance(&client_1, &account_1, 20).await;
-    });
     // Stop a node
     let node_to_restart = validator_peer_ids[0];
     swarm.validator_mut(node_to_restart).unwrap().stop();
 
     // Do a transfer and ensure it still executes
-    runtime.block_on(async {
+    transfer_coins(
+        &client_1,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        1,
+    )
+    .await;
+    assert_balance(&client_1, &account_0, 89).await;
+    assert_balance(&client_1, &account_1, 21).await;
+
+    // Restart killed node and wait for all nodes to catchup
+    swarm
+        .validator_mut(node_to_restart)
+        .unwrap()
+        .start()
+        .unwrap();
+    swarm
+        .validator_mut(node_to_restart)
+        .unwrap()
+        .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .await
+        .unwrap();
+    swarm
+        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(60))
+        .await
+        .unwrap();
+
+    // Connect to the newly recovered node and verify its state
+    let client_0 = swarm.validator(node_to_restart).unwrap().rest_client();
+    assert_balance(&client_0, &account_0, 89).await;
+    assert_balance(&client_0, &account_1, 21).await;
+
+    // Test multiple chunk sync
+    swarm.validator_mut(node_to_restart).unwrap().stop();
+
+    for _ in 0..10 {
         transfer_coins(
             &client_1,
             &transaction_factory,
@@ -78,9 +110,10 @@ fn test_basic_state_synchronization() {
             1,
         )
         .await;
-        assert_balance(&client_1, &account_0, 89).await;
-        assert_balance(&client_1, &account_1, 21).await;
-    });
+    }
+
+    assert_balance(&client_1, &account_0, 79).await;
+    assert_balance(&client_1, &account_1, 31).await;
 
     // Restart killed node and wait for all nodes to catchup
     swarm
@@ -92,59 +125,20 @@ fn test_basic_state_synchronization() {
         .validator_mut(node_to_restart)
         .unwrap()
         .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .await
         .unwrap();
     swarm
         .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(60))
+        .await
         .unwrap();
 
-    // Connect to the newly recovered node and verify its state
-    let client_0 = swarm.validator(node_to_restart).unwrap().rest_client();
-    runtime.block_on(async {
-        assert_balance(&client_0, &account_0, 89).await;
-        assert_balance(&client_0, &account_1, 21).await;
-    });
-    // Test multiple chunk sync
-    swarm.validator_mut(node_to_restart).unwrap().stop();
-
-    runtime.block_on(async {
-        for _ in 0..10 {
-            transfer_coins(
-                &client_1,
-                &transaction_factory,
-                &mut account_0,
-                &account_1,
-                1,
-            )
-            .await;
-        }
-
-        assert_balance(&client_1, &account_0, 79).await;
-        assert_balance(&client_1, &account_1, 31).await;
-    });
-    // Restart killed node and wait for all nodes to catchup
-    swarm
-        .validator_mut(node_to_restart)
-        .unwrap()
-        .start()
-        .unwrap();
-    swarm
-        .validator_mut(node_to_restart)
-        .unwrap()
-        .wait_until_healthy(Instant::now() + Duration::from_secs(10))
-        .unwrap();
-    swarm
-        .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(60))
-        .unwrap();
-
-    runtime.block_on(async {
-        assert_balance(&client_0, &account_0, 79).await;
-        assert_balance(&client_0, &account_1, 31).await;
-    });
+    assert_balance(&client_0, &account_0, 79).await;
+    assert_balance(&client_0, &account_1, 31).await;
 }
 
-#[test]
-fn test_startup_sync_state() {
-    let mut swarm = new_local_swarm(4);
+#[tokio::test]
+async fn test_startup_sync_state() {
+    let mut swarm = new_local_swarm(4).await;
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
     let client_1 = swarm
         .validator(validator_peer_ids[1])
@@ -152,22 +146,19 @@ fn test_startup_sync_state() {
         .rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
-    let runtime = Runtime::new().unwrap();
+    let mut account_0 = create_and_fund_account(&mut swarm, 100).await;
+    let account_1 = create_and_fund_account(&mut swarm, 10).await;
 
-    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
-    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
-
-    let txn = runtime.block_on(transfer_coins(
+    let txn = transfer_coins(
         &client_1,
         &transaction_factory,
         &mut account_0,
         &account_1,
         10,
-    ));
-    runtime.block_on(async {
-        assert_balance(&client_1, &account_0, 90).await;
-        assert_balance(&client_1, &account_1, 20).await;
-    });
+    )
+    .await;
+    assert_balance(&client_1, &account_0, 90).await;
+    assert_balance(&client_1, &account_1, 20).await;
 
     // Stop a node
     let node_to_restart = validator_peer_ids[0];
@@ -191,40 +182,39 @@ fn test_startup_sync_state() {
         .validator_mut(node_to_restart)
         .unwrap()
         .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .await
         .unwrap();
 
     let client_0 = swarm.validator(node_to_restart).unwrap().rest_client();
-    runtime.block_on(async {
-        // Wait for the txn to by synced to the restarted node
-        client_0.wait_for_signed_transaction(&txn).await.unwrap();
-        assert_balance(&client_0, &account_0, 90).await;
-        assert_balance(&client_0, &account_1, 20).await;
+    // Wait for the txn to by synced to the restarted node
+    client_0.wait_for_signed_transaction(&txn).await.unwrap();
+    assert_balance(&client_0, &account_0, 90).await;
+    assert_balance(&client_0, &account_1, 20).await;
 
-        let txn = transfer_coins(
-            &client_1,
-            &transaction_factory,
-            &mut account_0,
-            &account_1,
-            10,
-        )
-        .await;
-        client_0.wait_for_signed_transaction(&txn).await.unwrap();
+    let txn = transfer_coins(
+        &client_1,
+        &transaction_factory,
+        &mut account_0,
+        &account_1,
+        10,
+    )
+    .await;
+    client_0.wait_for_signed_transaction(&txn).await.unwrap();
 
-        assert_balance(&client_0, &account_0, 80).await;
-        assert_balance(&client_0, &account_1, 30).await;
-    });
+    assert_balance(&client_0, &account_0, 80).await;
+    assert_balance(&client_0, &account_1, 30).await;
 }
 
-#[test]
-fn test_state_sync_multichunk_epoch() {
-    let mut swarm = new_local_swarm(4);
+#[tokio::test]
+async fn test_state_sync_multichunk_epoch() {
+    let mut swarm = new_local_swarm(4).await;
     for validator in swarm.validators_mut() {
         let mut config = validator.config().clone();
         config.state_sync.chunk_limit = 5;
         config.save(validator.config_path()).unwrap();
-        validator.restart().unwrap();
+        validator.restart().await.unwrap();
     }
-    swarm.launch().unwrap(); // Make sure all nodes are healthy and live
+    swarm.launch().await.unwrap(); // Make sure all nodes are healthy and live
     let validator_peer_ids = swarm.validators().map(|v| v.peer_id()).collect::<Vec<_>>();
 
     let client_0 = swarm
@@ -233,21 +223,18 @@ fn test_state_sync_multichunk_epoch() {
         .rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
-    let runtime = Runtime::new().unwrap();
-    runtime
-        .block_on(enable_open_publishing(
-            &client_0,
-            &transaction_factory,
-            swarm.chain_info().root_account,
-        ))
-        .unwrap();
+    enable_open_publishing(
+        &client_0,
+        &transaction_factory,
+        swarm.chain_info().root_account,
+    )
+    .await
+    .unwrap();
 
-    let mut account_0 = runtime.block_on(create_and_fund_account(&mut swarm, 100));
-    let account_1 = runtime.block_on(create_and_fund_account(&mut swarm, 10));
-    runtime.block_on(async {
-        assert_balance(&client_0, &account_0, 100).await;
-        assert_balance(&client_0, &account_1, 10).await;
-    });
+    let mut account_0 = create_and_fund_account(&mut swarm, 100).await;
+    let account_1 = create_and_fund_account(&mut swarm, 10).await;
+    assert_balance(&client_0, &account_0, 100).await;
+    assert_balance(&client_0, &account_1, 10).await;
 
     // we bring this validator back up with waypoint s.t. the waypoint sync spans multiple epochs,
     // and each epoch spanning multiple chunks
@@ -255,18 +242,16 @@ fn test_state_sync_multichunk_epoch() {
     swarm.validator_mut(node_to_restart).unwrap().stop();
 
     // submit more transactions to make the current epoch (=1) span > 1 chunk (= 5 versions)
-    runtime.block_on(async {
-        for _ in 0..7 {
-            transfer_coins(
-                &client_0,
-                &transaction_factory,
-                &mut account_0,
-                &account_1,
-                10,
-            )
-            .await;
-        }
-    });
+    for _ in 0..7 {
+        transfer_coins(
+            &client_0,
+            &transaction_factory,
+            &mut account_0,
+            &account_1,
+            10,
+        )
+        .await;
+    }
 
     let script_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
@@ -293,38 +278,37 @@ fn test_state_sync_multichunk_epoch() {
             ],
         )),
     ));
-    runtime.block_on(async {
-        client_0.submit_and_wait(&txn).await.unwrap();
-        // Bump epoch by trigger a reconfig for multiple epochs
-        for curr_epoch in 2u64..=3 {
-            // bumps epoch from curr_epoch -> curr_epoch + 1
-            enable_open_publishing(
-                &client_0,
-                &transaction_factory,
-                swarm.chain_info().root_account,
-            )
-            .await
-            .unwrap();
+    client_0.submit_and_wait(&txn).await.unwrap();
+    // Bump epoch by trigger a reconfig for multiple epochs
+    for curr_epoch in 2u64..=3 {
+        // bumps epoch from curr_epoch -> curr_epoch + 1
+        enable_open_publishing(
+            &client_0,
+            &transaction_factory,
+            swarm.chain_info().root_account,
+        )
+        .await
+        .unwrap();
 
-            let next_block_epoch = *client_0
-                .get_epoch_configuration()
-                .await
-                .unwrap()
-                .into_inner()
-                .next_block_epoch
-                .inner();
-            assert_eq!(next_block_epoch, curr_epoch + 1);
-        }
-    });
+        let next_block_epoch = *client_0
+            .get_epoch_configuration()
+            .await
+            .unwrap()
+            .into_inner()
+            .next_block_epoch
+            .inner();
+        assert_eq!(next_block_epoch, curr_epoch + 1);
+    }
 
     let json_rpc_client_0 = swarm
         .validator(validator_peer_ids[0])
         .unwrap()
-        .json_rpc_client();
+        .async_json_rpc_client();
     // bring back dead validator with waypoint
     let epoch_change_proof: EpochChangeProof = bcs::from_bytes(
         json_rpc_client_0
             .get_state_proof(0)
+            .await
             .unwrap()
             .into_inner()
             .epoch_change_proof
@@ -357,8 +341,10 @@ fn test_state_sync_multichunk_epoch() {
         .validator_mut(node_to_restart)
         .unwrap()
         .wait_until_healthy(Instant::now() + Duration::from_secs(10))
+        .await
         .unwrap();
     swarm
         .wait_for_all_nodes_to_catchup(Instant::now() + Duration::from_secs(60))
+        .await
         .unwrap();
 }

--- a/testsuite/testcases/src/lib.rs
+++ b/testsuite/testcases/src/lib.rs
@@ -18,8 +18,8 @@ use std::{
 };
 use tokio::runtime::Runtime;
 
-fn batch_update<'t>(
-    ctx: &mut NetworkContext<'t>,
+async fn batch_update(
+    ctx: &mut NetworkContext<'_>,
     validators_to_update: &[PeerId],
     version: &Version,
 ) -> Result<()> {
@@ -27,13 +27,14 @@ fn batch_update<'t>(
         ctx.swarm().upgrade_validator(*validator, version)?;
     }
 
-    ctx.swarm().health_check()?;
+    ctx.swarm().health_check().await?;
     let deadline = Instant::now() + Duration::from_secs(60);
     for validator in validators_to_update {
         ctx.swarm()
             .validator_mut(*validator)
             .unwrap()
-            .wait_until_healthy(deadline)?;
+            .wait_until_healthy(deadline)
+            .await?;
     }
 
     Ok(())

--- a/testsuite/testcases/src/partial_nodes_down_test.rs
+++ b/testsuite/testcases/src/partial_nodes_down_test.rs
@@ -4,7 +4,7 @@
 use crate::generate_traffic;
 use forge::{NetworkContext, NetworkTest, Result, Test};
 use std::thread;
-use tokio::time::Duration;
+use tokio::{runtime::Runtime, time::Duration};
 
 pub struct PartialNodesDown;
 
@@ -35,10 +35,11 @@ impl NetworkTest for PartialNodesDown {
         let txn_stat = generate_traffic(ctx, &up_nodes, duration, 0, None)?;
         ctx.report
             .report_txn_stats(self.name().to_string(), txn_stat, duration);
+        let runtime = Runtime::new()?;
         for n in &down_nodes {
             let node = ctx.swarm().validator_mut(*n).unwrap();
             println!("Node {} is going to restart", node.name());
-            node.start()?;
+            runtime.block_on(node.start())?;
         }
 
         Ok(())

--- a/testsuite/testcases/src/state_sync_performance.rs
+++ b/testsuite/testcases/src/state_sync_performance.rs
@@ -9,7 +9,7 @@ use rand::{
     Rng, SeedableRng,
 };
 use std::{thread, time::Instant};
-use tokio::time::Duration;
+use tokio::{runtime::Runtime, time::Duration};
 
 const STATE_SYNC_COMMITTED_COUNTER_NAME: &str = "diem_state_sync_version.synced";
 
@@ -65,7 +65,8 @@ impl NetworkTest for StateSyncPerformance {
         // do data cleanup
         fullnode.clear_storage()?;
         println!("The fullnode is going to restart");
-        fullnode.start()?;
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(fullnode.start())?;
         println!(
             "The fullnode is now up. Waiting for it to state sync to the expected version: {}",
             validator_synced_version


### PR DESCRIPTION
## Motivation

#9193

1. updated forge interfaces factory, node, and swarm to use rest client
2. updated forge to use async debugger client
2. updated forge backends for the interfaces change
3. updated smoke tests, and switched most of them into tokio tests

## Related PRs

#10032