### PR TITLE
[data-client] Print less debug info for GlobalDataSummary

### DIFF
--- a/state-sync/diem-data-client/src/diemnet/mod.rs
+++ b/state-sync/diem-data-client/src/diemnet/mod.rs
@@ -234,8 +234,6 @@ impl DiemNetDataClient {
 
         match result {
             Ok(response) => {
-                // TODO(khiemngo): consider logging response payload
-                // after we override Debug for some response types with large payload.
                 debug!(
                     (LogSchema::new(LogEntry::StorageServiceResponse)
                         .event(LogEvent::ResponseSuccess)
@@ -507,7 +505,6 @@ impl DataSummaryPoller {
             self.data_client.update_summary(peer, storage_summary);
             self.data_client.update_global_summary_cache();
 
-            // TODO(khiemngo): implement overriding Debug for GlobalDataSummary struct
             debug!(
                 (LogSchema::new(LogEntry::PeerStates)
                     .event(LogEvent::AggregateSummary)

--- a/state-sync/diem-data-client/src/lib.rs
+++ b/state-sync/diem-data-client/src/lib.rs
@@ -280,7 +280,7 @@ impl OptimalChunkSizes {
 }
 
 /// A summary of all data that is currently advertised in the network.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct AdvertisedData {
     /// The ranges of account states advertised, e.g., if a range is
     /// (X,Y), it means all account states are held for every version X->Y
@@ -305,6 +305,20 @@ pub struct AdvertisedData {
     /// is (X,Y), it means all transaction outputs for versions X->Y
     /// (inclusive) are available.
     pub transaction_outputs: Vec<CompleteDataRange<Version>>,
+}
+
+impl fmt::Debug for AdvertisedData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let sync_lis = (&self.synced_ledger_infos)
+            .iter()
+            .map(|LedgerInfoWithSignatures::V0(ledger)| format!("{}", ledger))
+            .join(", ");
+        write!(
+            f,
+            "account_states: {:?}, epoch_ending_ledger_infos: {:?}, synced_ledger_infos: [{}], transactions: {:?}, transaction_outputs: {:?}",
+            &self.account_states, &self.epoch_ending_ledger_infos, sync_lis, &self.transactions, &self.transaction_outputs
+        )
+    }
 }
 
 impl AdvertisedData {

--- a/types/src/ledger_info.rs
+++ b/types/src/ledger_info.rs
@@ -195,7 +195,12 @@ pub struct LedgerInfoWithV0 {
 
 impl Display for LedgerInfoWithV0 {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.ledger_info)
+        write!(
+            f,
+            "LedgerInfo {{ commit_info: BlockInfo {{ epoch: {:?}, version: {:?} }} }}",
+            self.ledger_info.commit_info().epoch(),
+            self.ledger_info.commit_info().version()
+        )
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

`GlobalDataSummary` could be huge and a data client may end up logging a lot of info about `GlobalDataSummary`. This small PR helps avoid the problem by logging only important info that is useful for debugging.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Manually test by printing out the debug information.

## Related PRs

#9994 

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
