### PR TITLE
[consensus] add one missing checks on 2-chain timeout

### DIFF
--- a/consensus/consensus-types/src/vote.rs
+++ b/consensus/consensus-types/src/vote.rs
@@ -193,10 +193,7 @@ impl Vote {
                     == (self.epoch(), self.vote_data.proposed().round()),
                 "2-chain timeout has different (epoch, round) than Vote"
             );
-            timeout
-                .quorum_cert()
-                .verify(validator)
-                .context("Failed to verify QC from 2-chain timeout")?;
+            timeout.verify(validator)?;
             validator
                 .verify(self.author(), &timeout.signing_format(), signature)
                 .context("Failed to verify 2-chain timeout signature")?;

--- a/consensus/consensus-types/src/vote_msg.rs
+++ b/consensus/consensus-types/src/vote_msg.rs
@@ -54,6 +54,10 @@ impl VoteMsg {
             self.vote().epoch() == self.sync_info.epoch(),
             "VoteMsg has different epoch"
         );
+        ensure!(
+            self.vote().vote_data().proposed().round() > self.sync_info.highest_round(),
+            "Vote Round should be higher than SyncInfo"
+        );
         if let Some((timeout, _)) = self.vote().two_chain_timeout() {
             ensure!(
                 timeout.hqc_round() <= self.sync_info.highest_certified_round(),

--- a/consensus/safety-rules/src/error.rs
+++ b/consensus/safety-rules/src/error.rs
@@ -53,6 +53,8 @@ pub enum Error {
     InvalidOrderedLedgerInfo(String),
     #[error("Waypoint out of date: Previous waypoint version {0}, updated version {1}, current epoch {2}, provided epoch {3}")]
     WaypointOutOfDate(u64, u64, u64, u64),
+    #[error("Invalid Timeout: {0}")]
+    InvalidTimeout(String),
 }
 
 impl From<serde_json::Error> for Error {

--- a/consensus/safety-rules/src/safety_rules_2chain.rs
+++ b/consensus/safety-rules/src/safety_rules_2chain.rs
@@ -22,7 +22,9 @@ impl SafetyRules {
         self.signer()?;
         let mut safety_data = self.persistent_storage.safety_data()?;
         self.verify_epoch(timeout.epoch(), &safety_data)?;
-        self.verify_qc(timeout.quorum_cert())?;
+        timeout
+            .verify(&self.epoch_state()?.verifier)
+            .map_err(|e| Error::InvalidTimeout(e.to_string()))?;
         if let Some(tc) = timeout_cert {
             self.verify_tc(tc)?;
         }

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -961,6 +961,15 @@ fn test_2chain_timeout(constructor: &Callback) {
             .unwrap_err(),
         Error::NotSafeToTimeout(4, 1, 3, 2)
     );
+    assert!(matches!(
+        safety_rules
+            .sign_timeout_with_qc(
+                &TwoChainTimeout::new(1, 1, a3.vote_proposal.block().quorum_cert().clone(),),
+                Some(make_timeout_cert(2, &genesis_qc, &signer)).as_ref()
+            )
+            .unwrap_err(),
+        Error::InvalidTimeout(_)
+    ));
 }
 
 /// Test that we can succesfully sign a valid commit vote


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Add the missing round > qc_round check for struct timeout.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

Added a negative test case.

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
