### PR TITLE
[State Sync] Use decoupled execute/apply and commit.

### DIFF
--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -289,7 +289,7 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
         state_sync_network_handles,
         mempool_notifier,
         consensus_listener,
-        db_rw,
+        db_rw.reader,
         chunk_executor,
         node_config,
         waypoint,

--- a/execution/executor-types/src/executed_chunk.rs
+++ b/execution/executor-types/src/executed_chunk.rs
@@ -60,6 +60,10 @@ impl ExecutedChunk {
             .collect()
     }
 
+    pub fn transactions(&self) -> Vec<Transaction> {
+        self.to_commit.iter().map(|(txn, _)| txn).cloned().collect()
+    }
+
     pub fn events_to_commit(&self) -> Vec<ContractEvent> {
         self.to_commit
             .iter()

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -64,22 +64,23 @@ pub trait ChunkExecutorTrait: Send + Sync {
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
     ) -> anyhow::Result<()>;
 
-    /// Commit a previously executed chunks, returns a vector of reconfiguration events in the chunk.
-    fn commit_chunk(&self) -> Result<Vec<ContractEvent>>;
+    /// Commit a previously executed chunk. Returns a vector of reconfiguration
+    /// events in the chunk and the transactions that were committed.
+    fn commit_chunk(&self) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
 
     fn execute_and_commit_chunk(
         &self,
         txn_list_with_proof: TransactionListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
-    ) -> Result<Vec<ContractEvent>>;
+    ) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
 
     fn apply_and_commit_chunk(
         &self,
         txn_output_list_with_proof: TransactionOutputListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
-    ) -> Result<Vec<ContractEvent>>;
+    ) -> Result<(Vec<ContractEvent>, Vec<Transaction>)>;
 }
 
 pub trait BlockExecutorTrait: Send + Sync {

--- a/execution/executor/src/chunk_executor.rs
+++ b/execution/executor/src/chunk_executor.rs
@@ -223,10 +223,13 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         Ok(())
     }
 
-    fn commit_chunk(&self) -> Result<Vec<ContractEvent>> {
+    fn commit_chunk(&self) -> Result<(Vec<ContractEvent>, Vec<Transaction>)> {
         let _timer = DIEM_EXECUTOR_COMMIT_CHUNK_SECONDS.start_timer();
-
-        Ok(self.commit_chunk_impl()?.events_to_commit())
+        let executed_chunk = self.commit_chunk_impl()?;
+        Ok((
+            executed_chunk.events_to_commit(),
+            executed_chunk.transactions(),
+        ))
     }
 
     fn execute_and_commit_chunk(
@@ -234,7 +237,7 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         txn_list_with_proof: TransactionListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
-    ) -> Result<Vec<ContractEvent>> {
+    ) -> Result<(Vec<ContractEvent>, Vec<Transaction>)> {
         // Re-sync with DB, make sure the queue is empty.
         self.reset()?;
 
@@ -247,7 +250,7 @@ impl<V: VMExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         txn_output_list_with_proof: TransactionOutputListWithProof,
         verified_target_li: &LedgerInfoWithSignatures,
         epoch_change_li: Option<&LedgerInfoWithSignatures>,
-    ) -> Result<Vec<ContractEvent>> {
+    ) -> Result<(Vec<ContractEvent>, Vec<Transaction>)> {
         // Re-sync with DB, make sure the queue is empty.
         self.reset()?;
 

--- a/state-sync/state-sync-v1/src/bootstrapper.rs
+++ b/state-sync/state-sync-v1/src/bootstrapper.rs
@@ -13,7 +13,7 @@ use event_notifications::EventSubscriptionService;
 use executor_types::ChunkExecutorTrait;
 use futures::channel::mpsc;
 use mempool_notifications::MempoolNotificationSender;
-use std::{boxed::Box, collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 use storage_interface::DbReader;
 use tokio::runtime::{Builder, Runtime};
 
@@ -25,12 +25,12 @@ pub struct StateSyncBootstrapper {
 }
 
 impl StateSyncBootstrapper {
-    pub fn bootstrap<M: MempoolNotificationSender + 'static>(
+    pub fn bootstrap<C: ChunkExecutorTrait + 'static, M: MempoolNotificationSender + 'static>(
         network: Vec<(NetworkId, StateSyncSender, StateSyncEvents)>,
         mempool_notifier: M,
         consensus_listener: ConsensusNotificationListener,
         storage: Arc<dyn DbReader>,
-        executor: Box<dyn ChunkExecutorTrait>,
+        chunk_executor: Arc<C>,
         node_config: &NodeConfig,
         waypoint: Waypoint,
         event_subscription_service: EventSubscriptionService,
@@ -42,7 +42,8 @@ impl StateSyncBootstrapper {
             .build()
             .expect("[State Sync] Failed to create runtime!");
 
-        let executor_proxy = ExecutorProxy::new(storage, executor, event_subscription_service);
+        let executor_proxy =
+            ExecutorProxy::new(storage, chunk_executor, event_subscription_service);
 
         Self::bootstrap_with_executor_proxy(
             runtime,

--- a/state-sync/state-sync-v1/src/coordinator.rs
+++ b/state-sync/state-sync-v1/src/coordinator.rs
@@ -1776,6 +1776,7 @@ mod tests {
         waypoint::Waypoint,
         PeerId,
     };
+    use executor_types::ChunkExecutorTrait;
     use futures::{channel::oneshot, executor::block_on};
     use mempool_notifications::MempoolNotifier;
     use netcore::transport::ConnectionOrigin;
@@ -2505,8 +2506,8 @@ mod tests {
         vec![waypoint_response, target_response, highest_response]
     }
 
-    fn verify_all_chunk_requests_are_invalid(
-        coordinator: &mut StateSyncCoordinator<ExecutorProxy, MempoolNotifier>,
+    fn verify_all_chunk_requests_are_invalid<C: ChunkExecutorTrait>(
+        coordinator: &mut StateSyncCoordinator<ExecutorProxy<C>, MempoolNotifier>,
         peer_network_id: &PeerNetworkId,
         requests: &[StateSyncMessage],
     ) {
@@ -2520,8 +2521,8 @@ mod tests {
         }
     }
 
-    fn verify_all_chunk_responses_are_invalid(
-        coordinator: &mut StateSyncCoordinator<ExecutorProxy, MempoolNotifier>,
+    fn verify_all_chunk_responses_are_invalid<C: ChunkExecutorTrait>(
+        coordinator: &mut StateSyncCoordinator<ExecutorProxy<C>, MempoolNotifier>,
         peer_network_id: &PeerNetworkId,
         responses: &[StateSyncMessage],
     ) {
@@ -2535,8 +2536,8 @@ mod tests {
         }
     }
 
-    fn verify_all_chunk_responses_are_the_wrong_type(
-        coordinator: &mut StateSyncCoordinator<ExecutorProxy, MempoolNotifier>,
+    fn verify_all_chunk_responses_are_the_wrong_type<C: ChunkExecutorTrait>(
+        coordinator: &mut StateSyncCoordinator<ExecutorProxy<C>, MempoolNotifier>,
         peer_network_id: &PeerNetworkId,
         responses: &[StateSyncMessage],
     ) {
@@ -2550,8 +2551,8 @@ mod tests {
         }
     }
 
-    fn process_new_peer_event(
-        coordinator: &mut StateSyncCoordinator<ExecutorProxy, MempoolNotifier>,
+    fn process_new_peer_event<C: ChunkExecutorTrait>(
+        coordinator: &mut StateSyncCoordinator<ExecutorProxy<C>, MempoolNotifier>,
         peer: &PeerNetworkId,
     ) {
         let connection_metadata = ConnectionMetadata::mock_with_role_and_origin(

--- a/state-sync/state-sync-v1/src/executor_proxy.rs
+++ b/state-sync/state-sync-v1/src/executor_proxy.rs
@@ -52,27 +52,27 @@ pub trait ExecutorProxyTrait: Send {
     fn publish_event_notifications(&mut self, events: Vec<ContractEvent>) -> Result<(), Error>;
 }
 
-pub(crate) struct ExecutorProxy {
+pub(crate) struct ExecutorProxy<C> {
     storage: Arc<dyn DbReader>,
-    executor: Box<dyn ChunkExecutorTrait>,
+    chunk_executor: Arc<C>,
     event_subscription_service: EventSubscriptionService,
 }
 
-impl ExecutorProxy {
+impl<C: ChunkExecutorTrait> ExecutorProxy<C> {
     pub(crate) fn new(
         storage: Arc<dyn DbReader>,
-        executor: Box<dyn ChunkExecutorTrait>,
+        chunk_executor: Arc<C>,
         event_subscription_service: EventSubscriptionService,
     ) -> Self {
         Self {
             storage,
-            executor,
+            chunk_executor,
             event_subscription_service,
         }
     }
 }
 
-impl ExecutorProxyTrait for ExecutorProxy {
+impl<C: ChunkExecutorTrait> ExecutorProxyTrait for ExecutorProxy<C> {
     fn get_local_storage_state(&self) -> Result<SyncState, Error> {
         let storage_info = self.storage.get_startup_info().map_err(|error| {
             Error::UnexpectedError(format!(
@@ -106,7 +106,7 @@ impl ExecutorProxyTrait for ExecutorProxy {
         // track chunk execution time
         let timer = counters::EXECUTE_CHUNK_DURATION.start_timer();
         let events = self
-            .executor
+            .chunk_executor
             .execute_and_commit_chunk(
                 txn_list_with_proof,
                 &verified_target_li,
@@ -377,7 +377,7 @@ mod tests {
             .unwrap();
 
         // Create an executor proxy
-        let chunk_executor = Box::new(ChunkExecutor::<DiemVM>::new(db_rw).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<DiemVM>::new(db_rw).unwrap());
         let mut executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         // Publish a subscribed event
@@ -579,7 +579,7 @@ mod tests {
             .unwrap();
 
         // Create an executor
-        let chunk_executor = Box::new(ChunkExecutor::<DiemVM>::new(db_rw.clone()).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<DiemVM>::new(db_rw.clone()).unwrap());
         let mut executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         // Verify that the initial configs returned to the subscriber don't contain the unknown on-chain config
@@ -622,7 +622,7 @@ mod tests {
     ) -> (
         Vec<TestValidator>,
         Box<BlockExecutor<DiemVM>>,
-        ExecutorProxy,
+        ExecutorProxy<ChunkExecutor<DiemVM>>,
         ReconfigNotificationListener,
     ) {
         // Generate a genesis change set
@@ -662,7 +662,7 @@ mod tests {
 
         // Create the executors
         let block_executor = Box::new(BlockExecutor::<DiemVM>::new(db_rw.clone()));
-        let chunk_executor = Box::new(ChunkExecutor::<DiemVM>::new(db_rw).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<DiemVM>::new(db_rw).unwrap());
         let executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         (

--- a/state-sync/state-sync-v1/src/executor_proxy.rs
+++ b/state-sync/state-sync-v1/src/executor_proxy.rs
@@ -105,7 +105,7 @@ impl<C: ChunkExecutorTrait> ExecutorProxyTrait for ExecutorProxy<C> {
     ) -> Result<(), Error> {
         // track chunk execution time
         let timer = counters::EXECUTE_CHUNK_DURATION.start_timer();
-        let events = self
+        let (events, _) = self
             .chunk_executor
             .execute_and_commit_chunk(
                 txn_list_with_proof,

--- a/state-sync/state-sync-v1/src/fuzzing.rs
+++ b/state-sync/state-sync-v1/src/fuzzing.rs
@@ -14,6 +14,8 @@ use diem_infallible::Mutex;
 use diem_types::{
     ledger_info::LedgerInfoWithSignatures, transaction::TransactionListWithProof, PeerId,
 };
+use diem_vm::DiemVM;
+use executor::chunk_executor::ChunkExecutor;
 use futures::executor::block_on;
 use mempool_notifications::MempoolNotifier;
 use once_cell::sync::Lazy;
@@ -24,8 +26,9 @@ use proptest::{
     strategy::Strategy,
 };
 
-static STATE_SYNC_COORDINATOR: Lazy<Mutex<StateSyncCoordinator<ExecutorProxy, MempoolNotifier>>> =
-    Lazy::new(|| Mutex::new(test_utils::create_validator_coordinator()));
+static STATE_SYNC_COORDINATOR: Lazy<
+    Mutex<StateSyncCoordinator<ExecutorProxy<ChunkExecutor<DiemVM>>, MempoolNotifier>>,
+> = Lazy::new(|| Mutex::new(test_utils::create_validator_coordinator()));
 
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(10))]

--- a/state-sync/state-sync-v1/src/shared_components.rs
+++ b/state-sync/state-sync-v1/src/shared_components.rs
@@ -116,12 +116,12 @@ pub(crate) mod test_utils {
     pub(crate) fn create_coordinator_with_config_and_waypoint(
         node_config: NodeConfig,
         waypoint: Waypoint,
-    ) -> StateSyncCoordinator<ExecutorProxy, MempoolNotifier> {
+    ) -> StateSyncCoordinator<ExecutorProxy<ChunkExecutor<DiemVM>>, MempoolNotifier> {
         create_state_sync_coordinator_for_tests(node_config, waypoint, false)
     }
 
     pub(crate) fn create_validator_coordinator(
-    ) -> StateSyncCoordinator<ExecutorProxy, MempoolNotifier> {
+    ) -> StateSyncCoordinator<ExecutorProxy<ChunkExecutor<DiemVM>>, MempoolNotifier> {
         let mut node_config = NodeConfig::default();
         node_config.base.role = RoleType::Validator;
 
@@ -130,7 +130,7 @@ pub(crate) mod test_utils {
 
     #[cfg(test)]
     pub(crate) fn create_full_node_coordinator(
-    ) -> StateSyncCoordinator<ExecutorProxy, MempoolNotifier> {
+    ) -> StateSyncCoordinator<ExecutorProxy<ChunkExecutor<DiemVM>>, MempoolNotifier> {
         let mut node_config = NodeConfig::default();
         node_config.base.role = RoleType::FullNode;
 
@@ -139,7 +139,7 @@ pub(crate) mod test_utils {
 
     #[cfg(test)]
     pub(crate) fn create_read_only_coordinator(
-    ) -> StateSyncCoordinator<ExecutorProxy, MempoolNotifier> {
+    ) -> StateSyncCoordinator<ExecutorProxy<ChunkExecutor<DiemVM>>, MempoolNotifier> {
         let mut node_config = NodeConfig::default();
         node_config.base.role = RoleType::Validator;
 
@@ -150,7 +150,7 @@ pub(crate) mod test_utils {
         node_config: NodeConfig,
         waypoint: Waypoint,
         read_only_mode: bool,
-    ) -> StateSyncCoordinator<ExecutorProxy, MempoolNotifier> {
+    ) -> StateSyncCoordinator<ExecutorProxy<ChunkExecutor<DiemVM>>, MempoolNotifier> {
         // Generate a genesis change set
         let (genesis, _) = vm_genesis::test_genesis_change_set_and_validators(Some(1));
 
@@ -175,7 +175,7 @@ pub(crate) mod test_utils {
             .unwrap();
 
         // Create executor proxy
-        let chunk_executor = Box::new(ChunkExecutor::<DiemVM>::new(db_rw).unwrap());
+        let chunk_executor = Arc::new(ChunkExecutor::<DiemVM>::new(db_rw).unwrap());
         let executor_proxy = ExecutorProxy::new(db, chunk_executor, event_subscription_service);
 
         // Get initial state

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -17,7 +17,7 @@ use event_notifications::EventSubscriptionService;
 use executor_types::ChunkExecutorTrait;
 use futures::channel::mpsc;
 use mempool_notifications::MempoolNotificationSender;
-use std::{boxed::Box, sync::Arc};
+use std::sync::Arc;
 use storage_interface::DbReaderWriter;
 use tokio::runtime::{Builder, Runtime};
 
@@ -29,13 +29,16 @@ pub struct DriverFactory {
 
 impl DriverFactory {
     /// Creates and spawns a new state sync driver
-    pub fn create_and_spawn_driver<M: MempoolNotificationSender + 'static>(
+    pub fn create_and_spawn_driver<
+        ChunkExecutor: ChunkExecutorTrait + 'static,
+        MempoolNotifier: MempoolNotificationSender + 'static,
+    >(
         create_runtime: bool,
         node_config: &NodeConfig,
         waypoint: Waypoint,
         storage: DbReaderWriter,
-        chunk_executor: Box<dyn ChunkExecutorTrait>,
-        mempool_notification_sender: M,
+        chunk_executor: Arc<ChunkExecutor>,
+        mempool_notification_sender: MempoolNotifier,
         consensus_listener: ConsensusNotificationListener,
         event_subscription_service: EventSubscriptionService,
         diem_data_client: DiemNetDataClient,

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -131,7 +131,7 @@ impl<ChunkExecutor: ChunkExecutorTrait> StorageSynchronizerInterface
         target_ledger_info: LedgerInfoWithSignatures,
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
     ) -> Result<Vec<ContractEvent>, Error> {
-        let committed_events = self
+        let (committed_events, _) = self
             .chunk_executor
             .apply_and_commit_chunk(
                 output_list_with_proof,
@@ -151,7 +151,7 @@ impl<ChunkExecutor: ChunkExecutorTrait> StorageSynchronizerInterface
         target_ledger_info: LedgerInfoWithSignatures,
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
     ) -> Result<Vec<ContractEvent>, Error> {
-        let committed_events = self
+        let (committed_events, _) = self
             .chunk_executor
             .execute_and_commit_chunk(
                 transaction_list_with_proof,

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -57,16 +57,13 @@ pub trait StorageSynchronizerInterface {
 }
 
 /// The implementation of the `StorageSynchronizerInterface` used by state sync
-pub struct StorageSynchronizer {
-    chunk_executor: Box<dyn ChunkExecutorTrait>,
+pub struct StorageSynchronizer<ChunkExecutor> {
+    chunk_executor: Arc<ChunkExecutor>,
     storage: Arc<RwLock<DbReaderWriter>>,
 }
 
-impl StorageSynchronizer {
-    pub fn new(
-        chunk_executor: Box<dyn ChunkExecutorTrait>,
-        storage: Arc<RwLock<DbReaderWriter>>,
-    ) -> Self {
+impl<ChunkExecutor: ChunkExecutorTrait> StorageSynchronizer<ChunkExecutor> {
+    pub fn new(chunk_executor: Arc<ChunkExecutor>, storage: Arc<RwLock<DbReaderWriter>>) -> Self {
         Self {
             chunk_executor,
             storage,
@@ -125,7 +122,9 @@ impl StorageSynchronizer {
     }
 }
 
-impl StorageSynchronizerInterface for StorageSynchronizer {
+impl<ChunkExecutor: ChunkExecutorTrait> StorageSynchronizerInterface
+    for StorageSynchronizer<ChunkExecutor>
+{
     fn apply_and_commit_transaction_outputs(
         &mut self,
         output_list_with_proof: TransactionOutputListWithProof,

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -1,18 +1,23 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::Error;
+use crate::{error::Error, notification_handlers::CommitNotification};
 use diem_infallible::RwLock;
+use diem_logger::prelude::*;
 use diem_types::{
     account_state_blob::AccountStatesChunkWithProof,
-    contract_event::ContractEvent,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
     transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
 };
 use executor_types::{ChunkExecutorTrait, ExecutedTrees};
-use std::sync::Arc;
+use futures::{channel::mpsc, SinkExt, StreamExt};
+use std::{future::Future, sync::Arc};
 use storage_interface::DbReaderWriter;
+use tokio::runtime::{Builder, Runtime};
+
+// The maximum number of chunks that are pending execution or commit
+const MAX_PENDING_CHUNKS: usize = 50;
 
 /// A summary of the state of local storage at a specific snapshot (e.g., version)
 #[derive(Clone, Debug)]
@@ -26,25 +31,25 @@ pub struct StorageStateSummary {
 /// Synchronizes the storage of the node by verifying and storing new data
 /// (e.g., transactions and outputs).
 pub trait StorageSynchronizerInterface {
-    /// Applies and commits a batch of transaction outputs to storage.
+    /// Applies a batch of transaction outputs.
     ///
     /// Note: this assumes that the ledger infos have already been verified.
-    fn apply_and_commit_transaction_outputs(
+    fn apply_transaction_outputs(
         &mut self,
         output_list_with_proof: TransactionOutputListWithProof,
         target_ledger_info: LedgerInfoWithSignatures,
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
-    ) -> Result<Vec<ContractEvent>, Error>;
+    ) -> Result<(), Error>;
 
-    /// Executes and commits a batch of transactions to storage.
+    /// Executes a batch of transactions.
     ///
     /// Note: this assumes that the ledger infos have already been verified.
-    fn execute_and_commit_transactions(
+    fn execute_transactions(
         &mut self,
         transaction_list_with_proof: TransactionListWithProof,
         target_ledger_info: LedgerInfoWithSignatures,
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
-    ) -> Result<Vec<ContractEvent>, Error>;
+    ) -> Result<(), Error>;
 
     /// Returns the latest storage summary
     fn get_storage_summary(&mut self) -> Result<StorageStateSummary, Error>;
@@ -57,19 +62,67 @@ pub trait StorageSynchronizerInterface {
 }
 
 /// The implementation of the `StorageSynchronizerInterface` used by state sync
-pub struct StorageSynchronizer<ChunkExecutor> {
-    chunk_executor: Arc<ChunkExecutor>,
+pub struct StorageSynchronizer {
+    // A channel through which to notify the executor of new transaction data chunks
+    executor_notifier: mpsc::Sender<TransactionDataChunk>,
+
+    // The interface to read and write to storage
     storage: Arc<RwLock<DbReaderWriter>>,
+
+    // The runtime operating the storage synchronizer
+    _storage_synchronizer_runtime: Option<Runtime>,
 }
 
-impl<ChunkExecutor: ChunkExecutorTrait> StorageSynchronizer<ChunkExecutor> {
-    pub fn new(chunk_executor: Arc<ChunkExecutor>, storage: Arc<RwLock<DbReaderWriter>>) -> Self {
-        Self {
+impl StorageSynchronizer {
+    pub fn new<ChunkExecutor: ChunkExecutorTrait + 'static>(
+        create_runtime: bool,
+        chunk_executor: Arc<ChunkExecutor>,
+        commit_notification_sender: mpsc::UnboundedSender<CommitNotification>,
+        storage: Arc<RwLock<DbReaderWriter>>,
+    ) -> Self {
+        // Create a channel to notify the executor when transaction data chunks are ready
+        let (executor_notifier, executor_listener) = mpsc::channel(MAX_PENDING_CHUNKS);
+
+        // Create a channel to notify the committer when executed chunks are ready
+        let (committer_notifier, committer_listener) = mpsc::channel(MAX_PENDING_CHUNKS);
+
+        // Create a new runtime (if required)
+        let storage_synchronizer_runtime = if create_runtime {
+            Some(
+                Builder::new_multi_thread()
+                    .thread_name("storage-synchronizer")
+                    .enable_all()
+                    .build()
+                    .expect("Failed to create state sync v2 storage synchronizer runtime!"),
+            )
+        } else {
+            None
+        };
+
+        // Spawn the executor that executes/applies transaction data chunks
+        spawn_executor(
+            chunk_executor.clone(),
+            executor_listener,
+            committer_notifier,
+            storage_synchronizer_runtime.as_ref(),
+        );
+
+        // Spawn the committer that commits executed (but pending) chunks
+        spawn_committer(
             chunk_executor,
+            committer_listener,
+            commit_notification_sender,
+            storage_synchronizer_runtime.as_ref(),
+        );
+
+        Self {
+            executor_notifier,
             storage,
+            _storage_synchronizer_runtime: storage_synchronizer_runtime,
         }
     }
 
+    /// Fetches a summary of storage by reading directly from the database
     fn fetch_storage_summary(&mut self) -> Result<StorageStateSummary, Error> {
         // Fetch the startup info from storage
         let startup_info = self
@@ -120,49 +173,50 @@ impl<ChunkExecutor: ChunkExecutorTrait> StorageSynchronizer<ChunkExecutor> {
         };
         Ok(storage_state_summary)
     }
+
+    /// Notifies the executor of new transaction data chunks
+    fn notify_executor(
+        &mut self,
+        transaction_data_chunk: TransactionDataChunk,
+    ) -> Result<(), Error> {
+        self.executor_notifier
+            .try_send(transaction_data_chunk)
+            .map_err(|error| {
+                Error::UnexpectedError(format!(
+                    "Failed to send transaction data chunk to executor: {:?}",
+                    error
+                ))
+            })
+    }
 }
 
-impl<ChunkExecutor: ChunkExecutorTrait> StorageSynchronizerInterface
-    for StorageSynchronizer<ChunkExecutor>
-{
-    fn apply_and_commit_transaction_outputs(
+impl StorageSynchronizerInterface for StorageSynchronizer {
+    fn apply_transaction_outputs(
         &mut self,
         output_list_with_proof: TransactionOutputListWithProof,
         target_ledger_info: LedgerInfoWithSignatures,
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
-    ) -> Result<Vec<ContractEvent>, Error> {
-        let (committed_events, _) = self
-            .chunk_executor
-            .apply_and_commit_chunk(
-                output_list_with_proof,
-                &target_ledger_info,
-                end_of_epoch_ledger_info.as_ref(),
-            )
-            .map_err(|error| {
-                Error::UnexpectedError(format!("Apply and commit chunk failed: {}", error))
-            })?;
-
-        Ok(committed_events)
+    ) -> Result<(), Error> {
+        let transaction_data_chunk = TransactionDataChunk::TransactionOutputs(
+            output_list_with_proof,
+            target_ledger_info,
+            end_of_epoch_ledger_info,
+        );
+        self.notify_executor(transaction_data_chunk)
     }
 
-    fn execute_and_commit_transactions(
+    fn execute_transactions(
         &mut self,
         transaction_list_with_proof: TransactionListWithProof,
         target_ledger_info: LedgerInfoWithSignatures,
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
-    ) -> Result<Vec<ContractEvent>, Error> {
-        let (committed_events, _) = self
-            .chunk_executor
-            .execute_and_commit_chunk(
-                transaction_list_with_proof,
-                &target_ledger_info,
-                end_of_epoch_ledger_info.as_ref(),
-            )
-            .map_err(|error| {
-                Error::UnexpectedError(format!("Execute and commit chunk failed: {}", error))
-            })?;
-
-        Ok(committed_events)
+    ) -> Result<(), Error> {
+        let transaction_data_chunk = TransactionDataChunk::Transactions(
+            transaction_list_with_proof,
+            target_ledger_info,
+            end_of_epoch_ledger_info,
+        );
+        self.notify_executor(transaction_data_chunk)
     }
 
     fn get_storage_summary(&mut self) -> Result<StorageStateSummary, Error> {
@@ -174,5 +228,122 @@ impl<ChunkExecutor: ChunkExecutorTrait> StorageSynchronizerInterface
         _account_states_with_proof: AccountStatesChunkWithProof,
     ) -> Result<(), Error> {
         unimplemented!("Saving account states to storage is not currently supported!")
+    }
+}
+
+/// A chunk of data (i.e., transactions or transaction outputs) to be executed
+/// and committed.
+enum TransactionDataChunk {
+    Transactions(
+        TransactionListWithProof,
+        LedgerInfoWithSignatures,
+        Option<LedgerInfoWithSignatures>,
+    ),
+    TransactionOutputs(
+        TransactionOutputListWithProof,
+        LedgerInfoWithSignatures,
+        Option<LedgerInfoWithSignatures>,
+    ),
+}
+
+/// Spawns a dedicated executor that executes/applies transaction data chunks
+fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
+    chunk_executor: Arc<ChunkExecutor>,
+    mut executor_listener: mpsc::Receiver<TransactionDataChunk>,
+    mut committer_notifier: mpsc::Sender<()>,
+    runtime: Option<&Runtime>,
+) {
+    // Create an executor
+    let executor = async move {
+        loop {
+            ::futures::select! {
+                transaction_data_chunk = executor_listener.select_next_some() => {
+                    // Execute/apply the transaction data chunk
+                    let result = match transaction_data_chunk {
+                        TransactionDataChunk::Transactions(transactions_with_proof, target_ledger_info, end_of_epoch_ledger_info) => {
+                            chunk_executor
+                               .execute_chunk(
+                                    transactions_with_proof,
+                                    &target_ledger_info,
+                                    end_of_epoch_ledger_info.as_ref(),
+                                ).map_err(|error| {
+                                     error!(
+                                        "Failed to execute the transaction data chunk! Error: {:?}", error
+                                    );
+                                    error
+                                })
+                        },
+                        TransactionDataChunk::TransactionOutputs(outputs_with_proof, target_ledger_info, end_of_epoch_ledger_info) => {
+                            chunk_executor
+                                .apply_chunk(
+                                    outputs_with_proof,
+                                    &target_ledger_info,
+                                    end_of_epoch_ledger_info.as_ref(),
+                                ).map_err(|error| {
+                                    error!(
+                                        "Failed to apply the transaction data chunk! Error: {:?}", error
+                                    );
+                                    error
+                                })
+                        }
+                    };
+
+                    // Notify the committer of new executed chunks
+                    if result.is_ok() {
+                        if let Err(error) = committer_notifier.try_send(()) {
+                            error!(
+                                "Failed to notify the committer! Error: {:?}", error
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    // Spawn the executor
+    spawn(runtime, executor);
+}
+
+/// Spawns a dedicated committer that commits executed (but pending) chunks
+fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
+    chunk_executor: Arc<ChunkExecutor>,
+    mut committer_listener: mpsc::Receiver<()>,
+    mut commit_notification_sender: mpsc::UnboundedSender<CommitNotification>,
+    runtime: Option<&Runtime>,
+) {
+    // Create an executor
+    let committer = async move {
+        loop {
+            ::futures::select! {
+                _ = committer_listener.select_next_some() => {
+                    // Commit the executed chunk
+                    match chunk_executor.commit_chunk() {
+                        Ok((events, transactions)) => {
+                            let commit_notification = CommitNotification::new(events, transactions);
+                            if let Err(error) = commit_notification_sender.send(commit_notification).await {
+                                error!("Failed to send commit notification! Error: {:?}", error);
+                            }
+                        }
+                        Err(error) => {
+                            error!("Failed to commit executed chunk! Error: {:?}", error);
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    // Spawn the committer
+    spawn(runtime, committer);
+}
+
+/// Spawns a future on a specified runtime. If no runtime is specified, uses
+/// the current runtime.
+fn spawn(runtime: Option<&Runtime>, future: impl Future<Output = ()> + Send + 'static) {
+    if let Some(runtime) = runtime {
+        runtime.spawn(future);
+    } else {
+        tokio::spawn(future);
     }
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -122,7 +122,7 @@ fn create_driver_for_tests(
         mempool_notifications::new_mempool_notifier_listener_pair();
 
     // Create the chunk executor
-    let chunk_executor = Box::new(ChunkExecutor::<DiemVM>::new(db_rw.clone()).unwrap());
+    let chunk_executor = Arc::new(ChunkExecutor::<DiemVM>::new(db_rw.clone()).unwrap());
 
     // Create a streaming service client
     let (streaming_service_client, _) = new_streaming_service_client_listener_pair();

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -144,7 +144,7 @@ fn create_driver_for_tests(
         false,
         &node_config,
         waypoint,
-        db_rw,
+        db_rw.reader,
         chunk_executor,
         mempool_notifier,
         consensus_listener,

--- a/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/utils.rs
@@ -1,22 +1,15 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    error::Error, notification_handlers::MempoolNotificationHandler,
-    storage_synchronizer::StorageStateSummary,
-};
+use crate::error::Error;
 use data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
     data_stream::DataStreamListener,
     streaming_client::{DataStreamingClient, NotificationFeedback, StreamingServiceClient},
 };
-use diem_infallible::Mutex;
 use diem_logger::prelude::*;
-use diem_types::{contract_event::ContractEvent, transaction::Transaction};
-use event_notifications::{EventNotificationSender, EventSubscriptionService};
 use futures::StreamExt;
-use mempool_notifications::MempoolNotificationSender;
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 use tokio::time::timeout;
 
 // TODO(joshlind): make this configurable
@@ -82,42 +75,4 @@ pub async fn handle_end_of_stream_or_invalid_payload(
         DataPayload::EndOfStream => Ok(()),
         _ => Err(Error::InvalidPayload("Unexpected payload type!".into())),
     }
-}
-
-/// Notifies mempool of the committed transactions and notifies the event
-/// subscription service of committed events.
-pub async fn notify_committed_events_and_transactions<M: MempoolNotificationSender>(
-    latest_storage_summary: &StorageStateSummary,
-    mut mempool_notification_handler: MempoolNotificationHandler<M>,
-    committed_transactions: Vec<Transaction>,
-    event_subscription_service: Arc<Mutex<EventSubscriptionService>>,
-    committed_events: Vec<ContractEvent>,
-) -> Result<(), Error> {
-    let latest_synced_version = latest_storage_summary.latest_synced_version;
-
-    // Notify mempool of the committed transactions
-    debug!(
-        "Notifying mempool of transactions at version: {:?}",
-        latest_synced_version
-    );
-    let blockchain_timestamp_usecs = latest_storage_summary
-        .latest_ledger_info
-        .ledger_info()
-        .timestamp_usecs();
-    mempool_notification_handler
-        .notify_mempool_of_committed_transactions(
-            committed_transactions.clone(),
-            blockchain_timestamp_usecs,
-        )
-        .await?;
-
-    // Notify the event subscription service of the events
-    debug!(
-        "Notifying the event subscription service of events at version: {:?}",
-        latest_synced_version
-    );
-    event_subscription_service
-        .lock()
-        .notify_events(latest_synced_version, committed_events)
-        .map_err(|error| error.into())
 }


### PR DESCRIPTION
## Motivation

This PR updates the state sync driver to used decoupled execute/apply and commit. To achieve this, it offers the following commits:
1. First, we replace `Box<dyn ChunkExecutorTrait>` with `Arc<ChunkExecutorTrait>`. This is primarily for consistency in the state sync v2 code. Nothing else changes here.
2. Next, we update the `ChunkExecutor` implementation and trait to return both the events and transactions committed by the chunk. This is required so that state sync can notify mempool of the newly committed transactons. 
3. Next, we update the state sync driver and storage synchronizer to use decoupled execute/apply and commit. This is done simply by spawning two dedicated threads (an executor and committer) and creating channels between them to forward messages.
4. Finally, we provide the state sync driver with a DbReader so that it can read directly from storage (instead of relying on the storage synchronizer). This is a small optimization to reduce lock contention on the storage synchronizer.

Note: this version of the code is currently unoptimized. I'll follow up with some optimizations later on (with performance numbers) and also support the various failure cases.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The existing smoke tests cover this functionality.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906