### PR TITLE
Make absint public

### DIFF
--- a/language/move-bytecode-verifier/src/absint.rs
+++ b/language/move-bytecode-verifier/src/absint.rs
@@ -10,18 +10,18 @@ use std::collections::BTreeMap;
 
 /// Trait for finite-height abstract domains. Infinite height domains would require a more complex
 /// trait with widening and a partial order.
-pub(crate) trait AbstractDomain: Clone + Sized {
+pub trait AbstractDomain: Clone + Sized {
     fn join(&mut self, other: &Self) -> JoinResult;
 }
 
 #[derive(Debug)]
-pub(crate) enum JoinResult {
+pub enum JoinResult {
     Changed,
     Unchanged,
 }
 
 #[derive(Clone)]
-pub(crate) enum BlockPostcondition<AnalysisError> {
+pub enum BlockPostcondition<AnalysisError> {
     /// Block not yet analyzed
     Unprocessed,
     /// Analyzing block was successful
@@ -33,21 +33,21 @@ pub(crate) enum BlockPostcondition<AnalysisError> {
 
 #[allow(dead_code)]
 #[derive(Clone)]
-pub(crate) struct BlockInvariant<State, AnalysisError> {
+pub struct BlockInvariant<State, AnalysisError> {
     /// Precondition of the block
-    pub(crate) pre: State,
+    pub pre: State,
     /// Postcondition of the block
-    pub(crate) post: BlockPostcondition<AnalysisError>,
+    pub post: BlockPostcondition<AnalysisError>,
 }
 
 /// A map from block id's to the pre/post of each block after a fixed point is reached.
 #[allow(dead_code)]
-pub(crate) type InvariantMap<State, AnalysisError> =
+pub type InvariantMap<State, AnalysisError> =
     BTreeMap<BlockId, BlockInvariant<State, AnalysisError>>;
 
 /// Take a pre-state + instruction and mutate it to produce a post-state
 /// Auxiliary data can be stored in self.
-pub(crate) trait TransferFunctions {
+pub trait TransferFunctions {
     type State: AbstractDomain;
     type AnalysisError: Clone;
 
@@ -70,7 +70,7 @@ pub(crate) trait TransferFunctions {
     ) -> Result<(), Self::AnalysisError>;
 }
 
-pub(crate) trait AbstractInterpreter: TransferFunctions {
+pub trait AbstractInterpreter: TransferFunctions {
     /// Analyze procedure local@function_view starting from pre-state local@initial_state.
     fn analyze_function(
         &mut self,

--- a/language/move-bytecode-verifier/src/lib.rs
+++ b/language/move-bytecode-verifier/src/lib.rs
@@ -7,6 +7,7 @@
 
 // Bounds checks are implemented in the `vm` crate.
 pub mod ability_field_requirements;
+pub mod absint;
 pub mod check_duplication;
 pub mod code_unit_verifier;
 pub mod constants;
@@ -28,7 +29,6 @@ pub use signature::SignatureChecker;
 pub use struct_defs::RecursiveStructDefChecker;
 pub use verifier::{verify_module, verify_script};
 
-mod absint;
 mod acquires_list_verifier;
 mod locals_safety;
 mod reference_safety;


### PR DESCRIPTION
Make absint module and its definitions public.
This will allow us to define abstract interpretation-based verifier passes outside of the Diem repo.