### PR TITLE
Rename set.move to set_script.move

### DIFF
--- a/diem-move/df-cli/src/lib.rs
+++ b/diem-move/df-cli/src/lib.rs
@@ -1,0 +1,2 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0

--- a/diem-move/df-cli/tests/testsuite/compare_smoke/args.exp
+++ b/diem-move/df-cli/tests/testsuite/compare_smoke/args.exp
@@ -1,3 +1,3 @@
 Command `sandbox publish`:
-Command `sandbox run scripts/set.move --dry-run`:
+Command `sandbox run scripts/set_script.move --dry-run`:
 Execution aborted with code 999 in module 00000000000000000000000000000002::Set.

--- a/diem-move/df-cli/tests/testsuite/compare_smoke/args.txt
+++ b/diem-move/df-cli/tests/testsuite/compare_smoke/args.txt
@@ -1,2 +1,2 @@
 sandbox publish
-sandbox run scripts/set.move --dry-run
+sandbox run scripts/set_script.move --dry-run

--- a/diem-move/df-cli/tests/testsuite/compare_smoke/scripts/set_script.move
+++ b/diem-move/df-cli/tests/testsuite/compare_smoke/scripts/set_script.move
@@ -1,6 +1,6 @@
 script {
 use 0x2::Set;
-fun set() {
+fun set_script() {
     // add 10 elements in arbitrary order, check sortedness at the end
     let s = Set::empty<u64>();
     Set::insert(&mut s, 4);


### PR DESCRIPTION
On Mac files are case insensitive. The Set.move in sources/ and set.move in scripts eventually clash on source map on Mac.
Rename set.move so that they work on Mac. Run tests and see them pass.