### PR TITLE
[Operational Tool] Fix build error.

### DIFF
--- a/config/management/operational/Cargo.toml
+++ b/config/management/operational/Cargo.toml
@@ -26,7 +26,7 @@ tokio-util = { version = "0.6.4", features = ["compat"] }
 toml = { version = "0.5.8", default-features = false }
 
 bcs = "0.1.2"
-diem-client = { path = "../../../crates/diem-client", features = ["blocking"], default-features = false }
+diem-client = { path = "../../../crates/diem-client", features = ["blocking"] }
 diem-config = { path = "../.."}
 diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-global-constants = { path = "../../global-constants" }


### PR DESCRIPTION
## Motivation

This tiny PR fixes the operational tool. It looks like a recent change to the `diem-client` crate prevented the `diem-operational-tool` from building, e.g.:

```
% cargo build -p diem-operational-tool
   Compiling diem-client v0.0.3 (/Users/joshlind/Facebook/Libra/Code/fork/diem/crates/diem-client)
error[E0433]: failed to resolve: use of undeclared crate or module `reqwest`
  --> crates/diem-client/src/state.rs:25:35
   |
25 |     pub fn from_headers(headers: &reqwest::header::HeaderMap) -> anyhow::Result<Self> {
   |                                   ^^^^^^^ use of undeclared crate or module `reqwest`

For more information about this error, try `rustc --explain E0433`.
```

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

`cargo build -p diem-operational-tool` now works.

## Related PRs

None.