### PR TITLE
[x] don't cancel test run on first failing test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,7 +3,10 @@
 retries = 2
 # Show skipped tests in the CI output.
 status-level = "skip"
+# Show output for all tests as soon as they fail and at the end of the test run.
 failure-output = "immediate-final"
+# Do not cancel test run on the first failure.
+fail-fast = false
 
 [profile.ci.junit]
 path = "junit.xml"


### PR DESCRIPTION
Followup to #10075 -- I changed the default for nextest to cancel the
test run on the first failing test. In CI we should keep going on,
though.