### PR TITLE
[State Sync] Reduce logging burden of storage service and data client

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -154,7 +154,7 @@ impl VerifiedEpochStates {
         epoch_ending_ledger_info: LedgerInfoWithSignatures,
     ) {
         debug!(
-            "Adding a new epoch to the epoch ending ledger infos: {:?}",
+            "Adding a new epoch to the epoch ending ledger infos: {}",
             &epoch_ending_ledger_info
         );
 

--- a/state-sync/storage-service/server/src/logging.rs
+++ b/state-sync/storage-service/server/src/logging.rs
@@ -4,14 +4,14 @@
 use crate::Error;
 use diem_logger::Schema;
 use serde::Serialize;
-use storage_service_types::{StorageServiceError, StorageServiceRequest, StorageServiceResponse};
+use storage_service_types::StorageServiceRequest;
 
 #[derive(Schema)]
 pub struct LogSchema<'a> {
     name: LogEntry,
     error: Option<&'a Error>,
     message: Option<&'a str>,
-    response: Option<&'a Result<StorageServiceResponse, StorageServiceError>>,
+    response: Option<&'a str>,
     request: Option<&'a StorageServiceRequest>,
 }
 

--- a/state-sync/storage-service/types/src/lib.rs
+++ b/state-sync/storage-service/types/src/lib.rs
@@ -17,7 +17,10 @@ use proptest::{
     strategy::{BoxedStrategy, Strategy},
 };
 use serde::{de, Deserialize, Serialize};
-use std::convert::TryFrom;
+use std::{
+    convert::TryFrom,
+    fmt::{Display, Formatter},
+};
 use thiserror::Error;
 
 /// A type alias for different epochs.
@@ -103,6 +106,24 @@ impl StorageServiceResponse {
             Self::TransactionOutputsWithProof(_) => "transaction_outputs_with_proof",
             Self::TransactionsWithProof(_) => "transactions_with_proof",
         }
+    }
+}
+
+impl Display for StorageServiceResponse {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        // To prevent log spamming, we only display storage response data for summaries
+        let data = match self {
+            StorageServiceResponse::StorageServerSummary(storage_summary) => {
+                format!("{:?}", storage_summary)
+            }
+            _ => "...".into(),
+        };
+        write!(
+            f,
+            "Storage service response: {}, data: {}",
+            self.get_label(),
+            data
+        )
     }
 }
 


### PR DESCRIPTION
## Motivation

This PR reduces some of the logging frequency/burden of the storage service and data client. This is to help reduce log spam. It offers the following commits:
1. We: (i) reduce the frequency of storage service responses when sending out storage summaries to peers (to every 5 seconds); and (ii) avoid printing out storage service response data (as these can quite large).
2. Next, we reduce the frequency of the global data summary log so that it's only displayed every 5 seconds. We may want to make this configurable in the future, but it should be fine for now.
3. We use display formatting to print epoch ending ledger infos whenever the bootstrapper identifies new ledger infos in the network.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Viewing the logs after a run.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906