### PR TITLE
[Forge] Use append mode for node logs

### DIFF
--- a/testsuite/forge/src/backend/local/node.rs
+++ b/testsuite/forge/src/backend/local/node.rs
@@ -85,6 +85,7 @@ impl LocalNode {
         let log_file = OpenOptions::new()
             .create(true)
             .write(true)
+            .append(true)
             .open(self.log_path())?;
 
         // Start node process


### PR DESCRIPTION
## Motivation

This (tiny) PR updates Forge to allow nodes to write to logs using [append mode](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.append). This is useful for when a node is restarted during a run (e.g., a smoke test), allowing it to append to the previous log (as opposed to writing over the old content -- something that had me super confused until I realized what was happening 😃).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Verified this using a local smoke test run.

## Related PRs

None.
