### PR TITLE
[State Sync] Reduce the frequency of the error logs when missing peers.

### DIFF
--- a/state-sync/diem-data-client/src/diemnet/mod.rs
+++ b/state-sync/diem-data-client/src/diemnet/mod.rs
@@ -45,7 +45,9 @@ mod state;
 #[cfg(test)]
 mod tests;
 
+// Useful constants for the Diem Data Client
 const GLOBAL_DATA_LOG_FREQ_SECS: u64 = 5;
+const POLLER_ERROR_LOG_FREQ_SECS: u64 = 1;
 
 /// A [`DiemDataClient`] that fulfills requests from remote peers' Storage Service
 /// over DiemNet.
@@ -461,11 +463,14 @@ impl DataSummaryPoller {
             {
                 Ok(peer) => peer,
                 Err(error) => {
-                    error!(
-                        (LogSchema::new(LogEntry::StorageSummaryRequest)
-                            .event(LogEvent::NoPeersToPoll)
-                            .message("Unable to select next peer")
-                            .error(&error))
+                    sample!(
+                        SampleRate::Duration(Duration::from_secs(POLLER_ERROR_LOG_FREQ_SECS)),
+                        error!(
+                            (LogSchema::new(LogEntry::StorageSummaryRequest)
+                                .event(LogEvent::NoPeersToPoll)
+                                .message("Unable to select next peer")
+                                .error(&error))
+                        );
                     );
                     continue;
                 }


### PR DESCRIPTION
## Motivation

This PR reduces the frequency of error logs when a node is missing peers (e.g., if the node is a single validator deployment and no peers are expected 😄 ). We do this simply by sampling the error logs (similar to https://github.com/diem/diem/pull/10091).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

Viewing the logs after a run.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906