### PR TITLE
[executor-benchmark] ajustments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,6 +3094,7 @@ name = "executor-benchmark"
 version = "0.1.0"
 dependencies = [
  "bcs",
+ "chrono",
  "criterion",
  "diem-config",
  "diem-crypto",

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 [dependencies]
 bcs = "0.1.2"
 criterion = "0.3.4"
+chrono = "0.4.19"
 indicatif = "0.15.0"
 itertools = { version = "0.10.0", default-features = false }
 jemallocator = { version = "0.3.2", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -75,7 +75,7 @@ pub fn run_benchmark(
     let executor_2 = executor_1.clone();
 
     let (block_sender, block_receiver) = mpsc::sync_channel(50 /* bound */);
-    let (commit_sender, commit_receiver) = mpsc::sync_channel(50 /* bound */);
+    let (commit_sender, commit_receiver) = mpsc::sync_channel(3 /* bound */);
 
     let mut generator =
         TransactionGenerator::new_with_metafile(genesis_key, block_sender, source_dir);

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -34,7 +34,7 @@ use std::{
 use storage_interface::DbReader;
 
 const META_FILENAME: &str = "metadata.toml";
-const MAX_ACCOUNTS_INVOLVED_IN_P2P: usize = 100_000;
+const MAX_ACCOUNTS_INVOLVED_IN_P2P: usize = 1_000_000;
 
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", content = "args")]

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -20,8 +20,9 @@ pub mod schema;
 use crate::{
     metrics::{
         DIEM_SCHEMADB_BATCH_COMMIT_BYTES, DIEM_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS,
-        DIEM_SCHEMADB_DELETES, DIEM_SCHEMADB_GET_BYTES, DIEM_SCHEMADB_GET_LATENCY_SECONDS,
-        DIEM_SCHEMADB_ITER_BYTES, DIEM_SCHEMADB_ITER_LATENCY_SECONDS, DIEM_SCHEMADB_PUT_BYTES,
+        DIEM_SCHEMADB_BATCH_PUT_LATENCY_SECONDS, DIEM_SCHEMADB_DELETES, DIEM_SCHEMADB_GET_BYTES,
+        DIEM_SCHEMADB_GET_LATENCY_SECONDS, DIEM_SCHEMADB_ITER_BYTES,
+        DIEM_SCHEMADB_ITER_LATENCY_SECONDS, DIEM_SCHEMADB_PUT_BYTES,
     },
     schema::{KeyCodec, Schema, SeekKeyCodec, ValueCodec},
 };
@@ -68,6 +69,9 @@ impl SchemaBatch {
 
     /// Adds an insert/update operation to the batch.
     pub fn put<S: Schema>(&mut self, key: &S::Key, value: &S::Value) -> Result<()> {
+        let _timer = DIEM_SCHEMADB_BATCH_PUT_LATENCY_SECONDS
+            .with_label_values(&["unknown"])
+            .start_timer();
         let key = <S::Key as KeyCodec<S>>::encode_key(key)?;
         let value = <S::Value as ValueCodec<S>>::encode_value(value)?;
         self.rows

--- a/storage/schemadb/src/metrics.rs
+++ b/storage/schemadb/src/metrics.rs
@@ -96,3 +96,15 @@ pub static DIEM_SCHEMADB_DELETES: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static DIEM_SCHEMADB_BATCH_PUT_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        // metric name
+        "diem_schemadb_batch_put_latency_seconds",
+        // metric description
+        "Diem schemadb schema batch put latency in seconds",
+        // metric labels (dimensions)
+        &["db_name"]
+    )
+    .unwrap()
+});

--- a/storage/scratchpad/src/sparse_merkle/metrics.rs
+++ b/storage/scratchpad/src/sparse_merkle/metrics.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use diem_metrics::{register_int_gauge, IntGauge};
+use diem_metrics::{register_histogram_vec, register_int_gauge, HistogramVec, IntGauge};
 use once_cell::sync::Lazy;
 
 pub static OLDEST_GENERATION: Lazy<IntGauge> = Lazy::new(|| {
@@ -18,6 +18,15 @@ pub static LATEST_GENERATION: Lazy<IntGauge> = Lazy::new(|| {
     register_int_gauge!(
         "diem_scratchpad_smt_latest_generation",
         "Generation value on newly spawned SMT."
+    )
+    .unwrap()
+});
+
+pub static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "diem_scratchpad_smt_timer_seconds",
+        "Various timers for performance analysis.",
+        &["name"]
     )
     .unwrap()
 });

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -81,7 +81,7 @@ mod sparse_merkle_test;
 pub mod test_utils;
 
 use crate::sparse_merkle::{
-    metrics::{LATEST_GENERATION, OLDEST_GENERATION},
+    metrics::{LATEST_GENERATION, OLDEST_GENERATION, TIMER},
     node::{NodeInner, SubTree},
     updater::SubTreeUpdater,
     utils::partition,
@@ -477,6 +477,9 @@ where
         // must be sorted
         touched_accounts: Vec<HashValue>,
     ) -> HashMap<NibblePath, HashValue> {
+        let _timer = TIMER
+            .with_label_values(&["generate_node_hashes"])
+            .start_timer();
         let mut node_hashes = HashMap::new();
         let mut nibble_path = NibblePath::new(vec![]);
         self.collect_new_hashes(


### PR DESCRIPTION
## Motivation

1. create-db pipelines execution and commission
2. up to 1M accounts involved in p2p test
3. shorten commit queue length, 50->3, to save some memory and make it more realistic (less SMT nodes cached in mem); for db-create, also shorten the execution queue 50->3, there's no point buffering too much and it makes the progress bar I'll introduce later too not accurate.

also,

add a few progress bars for db-create, so we have a idea how far we've gone when generating a large db.

add a few timers for analysis

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan

local runs

```
cargo run -p executor-benchmark -- --block-size 1000 create-db --data-dir ~/work/data/tmp/10k --num-accounts 10000 --prune-window 20000
```

```
 time cargo run -p executor-benchmark -- --block-size 1000 run-executor --data-dir ~/work/data/tmp/10k --checkpoint-dir /tmp/t
```