### PR TITLE
[Operator Tool] Add `VerifyValidatorState` command to compare local and on-chain state

### DIFF
--- a/config/management/operational/src/lib.rs
+++ b/config/management/operational/src/lib.rs
@@ -14,6 +14,7 @@ mod print;
 mod validate_transaction;
 mod validator_config;
 mod validator_set;
+mod validator_state;
 
 mod network_checker;
 #[cfg(any(test, feature = "testing"))]

--- a/config/management/operational/src/test_helper.rs
+++ b/config/management/operational/src/test_helper.rs
@@ -7,6 +7,7 @@ use crate::{
     keys::{load_key, EncodingType, KeyType},
     validator_config::DecryptedValidatorConfig,
     validator_set::DecryptedValidatorInfo,
+    validator_state::VerifyValidatorStateResult,
     TransactionContext,
 };
 use diem_config::{config, config::Peer, network_id::NetworkId};
@@ -707,6 +708,26 @@ impl OperationalTool {
             CommandName::RemoveValidator,
             |cmd| cmd.remove_validator(),
         )
+    }
+
+    pub fn verify_validator_state(
+        &self,
+        backend: &config::SecureBackend,
+    ) -> Result<VerifyValidatorStateResult, Error> {
+        let args = format!(
+            "
+                {command}
+                --json-server {host}
+                --chain-id {chain_id}
+                --validator-backend {backend_args}
+            ",
+            command = command(TOOL_NAME, CommandName::VerifyValidatorState),
+            host = self.host,
+            chain_id = self.chain_id.id(),
+            backend_args = backend_args(backend)?,
+        );
+        let command = Command::from_iter(args.split_whitespace());
+        command.verify_validator_state()
     }
 }
 

--- a/config/management/operational/src/validator_state.rs
+++ b/config/management/operational/src/validator_state.rs
@@ -1,0 +1,68 @@
+// Copyright (c) The Diem Core Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{json_rpc::JsonRpcClientWrapper, validator_config::DecryptedValidatorConfig};
+use diem_global_constants::{CONSENSUS_KEY, OWNER_ACCOUNT};
+use diem_management::error::Error;
+use serde::Serialize;
+use structopt::StructOpt;
+
+#[derive(Debug, Default, Serialize)]
+pub struct VerifyValidatorStateResult {
+    /// Check if a validator is in the latest validator set on-chain.
+    pub in_validator_set: Option<bool>,
+    /// Check if the consensus key held in secure storage matches
+    /// that registered on-chain for the validator.
+    pub consensus_key_match: Option<bool>,
+}
+
+impl VerifyValidatorStateResult {
+    pub fn is_state_consistent(&self) -> bool {
+        self.in_validator_set == Some(true) && self.consensus_key_match == Some(true)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct VerifyValidatorState {
+    #[structopt(long, required_unless = "config")]
+    json_server: Option<String>,
+    #[structopt(flatten)]
+    validator_config: diem_management::validator_config::ValidatorConfig,
+}
+
+impl VerifyValidatorState {
+    pub fn execute(self) -> Result<VerifyValidatorStateResult, Error> {
+        // Load the config, storage backend and create a json rpc client.
+        let config = self
+            .validator_config
+            .config()?
+            .override_json_server(&self.json_server);
+        let storage = config.validator_backend();
+        let client = JsonRpcClientWrapper::new(config.json_server);
+        let owner_account = storage.account_address(OWNER_ACCOUNT)?;
+
+        // Verify if the validator is in the set
+        let in_validator_set = client
+            .validator_set(None)?
+            .iter()
+            .any(|vi| vi.account_address() == &owner_account);
+
+        // TODO(khiemngo): consider return early if the validator is not in the set
+
+        // Fetch the current on-chain config for this operator's owner
+        let validator_config = client.validator_config(owner_account).and_then(|vc| {
+            DecryptedValidatorConfig::from_validator_config_resource(&vc, owner_account)
+        })?;
+
+        let storage_key = storage.ed25519_public_from_private(CONSENSUS_KEY)?;
+        let consensus_key_match = storage_key == validator_config.consensus_public_key;
+
+        // TODO(khiemngo): add checks for validator/fullnode network addresses
+        // TODO(khiemngo): add check for key uniqueness
+
+        Ok(VerifyValidatorStateResult {
+            in_validator_set: Some(in_validator_set),
+            consensus_key_match: Some(consensus_key_match),
+        })
+    }
+}

--- a/testsuite/smoke-test/src/operational_tooling.rs
+++ b/testsuite/smoke-test/src/operational_tooling.rs
@@ -1046,6 +1046,25 @@ async fn test_validator_set() {
     );
 }
 
+#[tokio::test]
+async fn test_verify_validator_state() {
+    let (_env, op_tool, backend, mut storage) = launch_swarm_with_op_tool_and_backend(4).await;
+
+    let result = op_tool.verify_validator_state(&backend).unwrap();
+    assert_eq!(result.in_validator_set, Some(true));
+    assert_eq!(result.consensus_key_match, Some(true));
+
+    // Rotate consensus key locally, but we do not update it on-chain
+    // Verify the local validator state again.
+    // The local consensus key is no longer mached with that registered on-chain
+    let _ = storage.rotate_key(CONSENSUS_KEY).unwrap();
+    let result = op_tool.verify_validator_state(&backend).unwrap();
+    assert_eq!(result.in_validator_set, Some(true));
+    assert_eq!(result.consensus_key_match, Some(false));
+
+    // TODO(khiemngo): consider adding test where the validator is no longer in set
+}
+
 /// Creates a new account address and key for testing.
 fn create_new_test_account() -> (Ed25519PrivateKey, AccountAddress) {
     let mut rng = OsRng;


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This PR adds a new command, `VerifyValidatorState`, to the operator tool. This new command allows validator operators to compare their local validator state against the validator state held on-chain and ensure that both states are consistent (Issue #9177).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

- Initially, start 4 validator nodes, and verify that the validator's local state is consistent with its state on-chain.
- Rotate the consensus key locally, and verify that the validator's local state is no longer consistent with its state on-chain.
![Screen Shot 2021-12-22 at 5 45 20 PM](https://user-images.githubusercontent.com/10539152/147176084-b3b9d4fd-071a-4cb7-9f1d-a91eee28a43a.png)


## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
