### PR TITLE
[move-model] Represent Move attributes in the move-model.

### DIFF
--- a/language/move-model/src/ast.rs
+++ b/language/move-model/src/ast.rs
@@ -61,6 +61,21 @@ pub struct SpecFunDecl {
 }
 
 // =================================================================================================
+/// # Attributes
+
+#[derive(Debug, Clone)]
+pub enum AttributeValue {
+    Value(NodeId, Value),
+    Name(NodeId, Option<ModuleName>, Symbol),
+}
+
+#[derive(Debug, Clone)]
+pub enum Attribute {
+    Apply(NodeId, Symbol, Vec<Attribute>),
+    Assign(NodeId, Symbol, AttributeValue),
+}
+
+// =================================================================================================
 /// # Conditions
 
 #[derive(Debug, PartialEq, Clone)]

--- a/language/move-model/src/builder/model_builder.rs
+++ b/language/move-model/src/builder/model_builder.rs
@@ -16,7 +16,7 @@ use move_compiler::{expansion::ast as EA, parser::ast as PA, shared::NumericalAd
 use move_symbol_pool::Symbol as MoveStringSymbol;
 
 use crate::{
-    ast::{ModuleName, Operation, QualifiedSymbol, Spec, Value},
+    ast::{Attribute, ModuleName, Operation, QualifiedSymbol, Spec, Value},
     builder::spec_builtins,
     model::{
         FunId, FunctionVisibility, GlobalEnv, Loc, ModuleId, QualifiedId, SpecFunId, SpecVarId,
@@ -107,6 +107,7 @@ pub(crate) struct StructEntry {
     pub is_resource: bool,
     pub type_params: Vec<(Symbol, Type)>,
     pub fields: Option<BTreeMap<Symbol, (usize, Type)>>,
+    pub attributes: Vec<Attribute>,
 }
 
 /// A declaration of a function.
@@ -120,6 +121,7 @@ pub(crate) struct FunEntry {
     pub params: Vec<(Symbol, Type)>,
     pub result_type: Type,
     pub is_pure: bool,
+    pub attributes: Vec<Attribute>,
 }
 
 #[derive(Debug, Clone)]
@@ -237,6 +239,7 @@ impl<'env> ModelBuilder<'env> {
     pub fn define_struct(
         &mut self,
         loc: Loc,
+        attributes: Vec<Attribute>,
         name: QualifiedSymbol,
         module_id: ModuleId,
         struct_id: StructId,
@@ -246,6 +249,7 @@ impl<'env> ModelBuilder<'env> {
     ) {
         let entry = StructEntry {
             loc,
+            attributes,
             module_id,
             struct_id,
             is_resource,
@@ -262,6 +266,7 @@ impl<'env> ModelBuilder<'env> {
     pub fn define_fun(
         &mut self,
         loc: Loc,
+        attributes: Vec<Attribute>,
         name: QualifiedSymbol,
         module_id: ModuleId,
         fun_id: FunId,
@@ -272,6 +277,7 @@ impl<'env> ModelBuilder<'env> {
     ) {
         let entry = FunEntry {
             loc,
+            attributes,
             module_id,
             fun_id,
             visibility,

--- a/language/move-model/src/lib.rs
+++ b/language/move-model/src/lib.rs
@@ -309,8 +309,14 @@ pub fn run_bytecode_model_builder<'a>(
             let name = m.identifier_at(m.struct_handle_at(def.struct_handle).name);
             let symbol = env.symbol_pool().make(name.as_str());
             let struct_id = StructId::new(symbol);
-            let data =
-                env.create_move_struct_data(m, def_idx, symbol, Loc::default(), Spec::default());
+            let data = env.create_move_struct_data(
+                m,
+                def_idx,
+                symbol,
+                Loc::default(),
+                Vec::default(),
+                Spec::default(),
+            );
             module_data.struct_data.insert(struct_id, data);
             module_data.struct_idx_to_id.insert(def_idx, struct_id);
         }


### PR DESCRIPTION
Attributes weren't yet represented in the move-model. This PR adds a representation and extends the model builder to translate them from the expansion AST.

## Motivation

Attributes in the model are needed for playing with EVM code generation, and possibly also Jazz.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

NA

## Related PRs

NA
