### PR TITLE
add Transaction::StateCheckpoint

### DIFF
--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -25,7 +25,7 @@ use move_core_types::{
 };
 use move_resource_viewer::MoveValueAnnotator;
 
-use crate::transaction::ModuleBundlePayload;
+use crate::transaction::{ModuleBundlePayload, StateCheckpointTransaction};
 use anyhow::{ensure, format_err, Result};
 use serde_json::Value;
 use std::{
@@ -87,6 +87,12 @@ impl<'a, R: MoveResolver + ?Sized> MoveConverter<'a, R> {
                 (info, payload, events).into()
             }
             BlockMetadata(txn) => (&txn, info).into(),
+            StateCheckpoint => {
+                Transaction::StateCheckpointTransaction(StateCheckpointTransaction {
+                    info,
+                    timestamp: timestamp.into(),
+                })
+            }
         })
     }
 

--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -104,6 +104,7 @@ pub enum Transaction {
     UserTransaction(Box<UserTransaction>),
     GenesisTransaction(GenesisTransaction),
     BlockMetadataTransaction(BlockMetadataTransaction),
+    StateCheckpointTransaction(StateCheckpointTransaction),
 }
 
 impl Transaction {
@@ -113,6 +114,7 @@ impl Transaction {
             Transaction::BlockMetadataTransaction(txn) => txn.timestamp.0,
             Transaction::PendingTransaction(_) => 0,
             Transaction::GenesisTransaction(_) => 0,
+            Transaction::StateCheckpointTransaction(txn) => txn.timestamp.0,
         }
     }
 
@@ -122,6 +124,7 @@ impl Transaction {
             Transaction::BlockMetadataTransaction(txn) => txn.info.success,
             Transaction::PendingTransaction(_txn) => false,
             Transaction::GenesisTransaction(txn) => txn.info.success,
+            Transaction::StateCheckpointTransaction(txn) => txn.info.success,
         }
     }
 
@@ -135,6 +138,7 @@ impl Transaction {
             Transaction::BlockMetadataTransaction(txn) => txn.info.vm_status.clone(),
             Transaction::PendingTransaction(_txn) => "pending".to_owned(),
             Transaction::GenesisTransaction(txn) => txn.info.vm_status.clone(),
+            Transaction::StateCheckpointTransaction(txn) => txn.info.vm_status.clone(),
         }
     }
 
@@ -146,6 +150,7 @@ impl Transaction {
                 bail!("pending transaction does not have TransactionInfo")
             }
             Transaction::GenesisTransaction(txn) => &txn.info,
+            Transaction::StateCheckpointTransaction(txn) => &txn.info,
         })
     }
 }
@@ -255,6 +260,13 @@ pub struct UserTransaction {
     #[serde(flatten)]
     pub request: UserTransactionRequest,
     pub events: Vec<Event>,
+    pub timestamp: U64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct StateCheckpointTransaction {
+    #[serde(flatten)]
+    pub info: TransactionInfo,
     pub timestamp: U64,
 }
 

--- a/diem-move/diem-vm/src/adapter_common.rs
+++ b/diem-move/diem-vm/src/adapter_common.rs
@@ -264,6 +264,7 @@ pub enum PreprocessedTransaction {
     BlockMetadata(BlockMetadata),
     WriteSet(Box<SignatureCheckedTransaction>),
     InvalidSignature,
+    StateCheckpoint,
 }
 
 /// Check the signature (if any) of a transaction. If the signature is OK, the result
@@ -288,6 +289,7 @@ pub(crate) fn preprocess_transaction<A: VMAdapter>(txn: Transaction) -> Preproce
                 _ => PreprocessedTransaction::UserTransaction(Box::new(checked_txn)),
             }
         }
+        Transaction::StateCheckpoint => PreprocessedTransaction::StateCheckpoint,
     }
 }
 

--- a/diem-move/diem-vm/src/diem_vm.rs
+++ b/diem-move/diem-vm/src/diem_vm.rs
@@ -912,6 +912,15 @@ impl VMAdapter for DiemVM {
                     discard_error_vm_status(VMStatus::Error(StatusCode::INVALID_SIGNATURE));
                 (vm_status, output, None)
             }
+            PreprocessedTransaction::StateCheckpoint => {
+                let output = TransactionOutput::new(
+                    WriteSet::default(),
+                    Vec::new(),
+                    0,
+                    TransactionStatus::Keep(KeptVMStatus::Executed),
+                );
+                (VMStatus::Executed, output, Some("state_checkpoint".into()))
+            }
         })
     }
 }

--- a/diem-move/diem-vm/src/read_write_set_analysis.rs
+++ b/diem-move/diem-vm/src/read_write_set_analysis.rs
@@ -199,6 +199,7 @@ impl<'a, R: MoveResolver> ReadWriteSetAnalysis<'a, R> {
             PreprocessedTransaction::WriteSet(_) | PreprocessedTransaction::WaypointWriteSet(_) => {
                 bail!("Unsupported writeset transaction")
             }
+            PreprocessedTransaction::StateCheckpoint => Ok((vec![], vec![])),
         }
     }
 

--- a/diem-move/e2e-tests-replay/src/lib.rs
+++ b/diem-move/e2e-tests-replay/src/lib.rs
@@ -1049,6 +1049,7 @@ fn replay_trace<P: AsRef<Path>>(
                         replayer.data_store.add_write_set(res.write_set());
                     }
                 }
+                Transaction::StateCheckpoint => {}
             }
         }
     }

--- a/execution/executor/src/components/apply_chunk_output.rs
+++ b/execution/executor/src/components/apply_chunk_output.rs
@@ -343,6 +343,7 @@ pub fn process_write_set(
                         }
                         TransactionPayload::WriteSet(_) => (),
                     },
+                    Transaction::StateCheckpoint => {}
                 }
 
                 let mut account_state = Default::default();

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -1342,6 +1342,7 @@ fn test_get_transactions() {
                     }
                     _ => panic!("Returned value doesn't match!"),
                 },
+                Transaction::StateCheckpoint => {}
             }
         }
     }

--- a/json-rpc/types/src/views.rs
+++ b/json-rpc/types/src/views.rs
@@ -1091,6 +1091,8 @@ pub enum TransactionDataView {
         script_bytes: BytesView,
         script: ScriptView,
     },
+    #[serde(rename = "statecheckpoint")]
+    StateCheckpoint {},
     #[serde(rename = "unknown")]
     #[serde(other)]
     UnknownTransaction,
@@ -1176,6 +1178,7 @@ impl From<Transaction> for TransactionDataView {
                     script,
                 }
             }
+            Transaction::StateCheckpoint => TransactionDataView::StateCheckpoint {},
         }
     }
 }

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -348,6 +348,8 @@ Transaction:
       BlockMetadata:
         NEWTYPE:
           TYPENAME: BlockMetadata
+    3:
+      StateCheckpoint: UNIT
 TransactionArgument:
   ENUM:
     0:

--- a/testsuite/generate-format/tests/staged/diem.yaml
+++ b/testsuite/generate-format/tests/staged/diem.yaml
@@ -238,6 +238,8 @@ Transaction:
       BlockMetadata:
         NEWTYPE:
           TYPENAME: BlockMetadata
+    3:
+      StateCheckpoint: UNIT
 TransactionArgument:
   ENUM:
     0:

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1504,6 +1504,10 @@ pub enum Transaction {
 
     /// Transaction to update the block metadata resource at the beginning of a block.
     BlockMetadata(BlockMetadata),
+
+    /// Transaction to let the executor update the global state tree and record the root hash
+    /// in the TransactionInfo
+    StateCheckpoint,
 }
 
 impl Transaction {
@@ -1523,6 +1527,8 @@ impl Transaction {
             Transaction::GenesisTransaction(_write_set) => String::from("genesis"),
             // TODO: display proper information for client
             Transaction::BlockMetadata(_block_metadata) => String::from("block_metadata"),
+            // TODO: display proper information for client
+            Transaction::StateCheckpoint => String::from("state_checkpoint"),
         }
     }
 }


### PR DESCRIPTION

## Motivation

Add Transaction::StateCheckpoint, which will be later issued at the end of each block from consensus (much like what we do today for the epilogue transaction)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Y

## Test Plan

Existing coverage
