### PR TITLE
[move-book] Fix a markdown rendering typo in the chapter "Abort and Assert"

### DIFF
--- a/language/documentation/book/src/abort-and-assert.md
+++ b/language/documentation/book/src/abort-and-assert.md
@@ -100,7 +100,7 @@ fun check_vec(v: &vector<u64>, bound: u64) {
 Note that because the operation is replaced with this `if-else`, the argument for the `code` is not
 always evaluated. For example:
 
-````move
+```move
 assert!(true, 1 / 0)
 ```
 
@@ -205,4 +205,3 @@ let b =
     else abort 42;
 //       ^^^^^^^^ `abort 42` has type `bool`
 ```
-````


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

Now the chapter ["Abort and Assert"](https://diem.github.io/move/abort-and-assert.html) is terribly rendered due to a markdown typo, so this PR is proposed to solve the problem.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.
