### PR TITLE
[State Sync] Further optimizations for transaction and output syncing.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -90,7 +90,7 @@ impl Default for StateSyncDriverConfig {
             bootstrapping_mode: BootstrappingMode::DownloadLatestAccountStates,
             enable_state_sync_v2: false,
             continuous_syncing_mode: ContinuousSyncingMode::ApplyTransactionOutputs,
-            progress_check_interval_ms: 500,
+            progress_check_interval_ms: 100,
         }
     }
 }
@@ -108,11 +108,11 @@ pub struct StorageServiceConfig {
 impl Default for StorageServiceConfig {
     fn default() -> Self {
         Self {
-            max_account_states_chunk_sizes: 1000,
+            max_account_states_chunk_sizes: 3000,
             max_concurrent_requests: 50,
             max_epoch_chunk_size: 100,
-            max_transaction_chunk_size: 1000,
-            max_transaction_output_chunk_size: 1000,
+            max_transaction_chunk_size: 3000,
+            max_transaction_output_chunk_size: 3000,
         }
     }
 }
@@ -146,10 +146,10 @@ pub struct DataStreamingServiceConfig {
 impl Default for DataStreamingServiceConfig {
     fn default() -> Self {
         Self {
-            global_summary_refresh_interval_ms: 1000,
-            max_concurrent_requests: 3,
+            global_summary_refresh_interval_ms: 300,
+            max_concurrent_requests: 5,
             max_data_stream_channel_sizes: 1000,
-            max_request_retry: 10,
+            max_request_retry: 5,
             max_notification_id_mappings: 2000,
             progress_check_interval_ms: 100,
         }
@@ -167,7 +167,7 @@ impl Default for DiemDataClientConfig {
     fn default() -> Self {
         Self {
             response_timeout_ms: 3_000,
-            summary_poll_interval_ms: 1_000,
+            summary_poll_interval_ms: 300,
         }
     }
 }

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -325,7 +325,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         if self.active_data_stream.is_some() {
             // We have an active data stream. Process any notifications!
             self.process_active_stream_notifications().await?;
-        } else {
+        } else if !self.storage_synchronizer.pending_transaction_data() {
             // Fetch a new data stream to start streaming data
             self.initialize_active_data_stream(global_data_summary)
                 .await?;

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -35,15 +35,15 @@ pub struct ContinuousSyncer<StorageSyncer> {
     storage: Arc<dyn DbReader>,
 
     // The storage synchronizer used to update local storage
-    storage_synchronizer: Arc<Mutex<StorageSyncer>>,
+    storage_synchronizer: StorageSyncer,
 }
 
-impl<StorageSyncer: StorageSynchronizerInterface> ContinuousSyncer<StorageSyncer> {
+impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<StorageSyncer> {
     pub fn new(
         driver_configuration: DriverConfiguration,
         streaming_service_client: StreamingServiceClient,
         storage: Arc<dyn DbReader>,
-        storage_synchronizer: Arc<Mutex<StorageSyncer>>,
+        storage_synchronizer: StorageSyncer,
     ) -> Self {
         Self {
             active_data_stream: None,
@@ -197,7 +197,7 @@ impl<StorageSyncer: StorageSynchronizerInterface> ContinuousSyncer<StorageSyncer
         match self.driver_configuration.config.continuous_syncing_mode {
             ContinuousSyncingMode::ApplyTransactionOutputs => {
                 if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
-                    self.storage_synchronizer.lock().apply_transaction_outputs(
+                    self.storage_synchronizer.apply_transaction_outputs(
                         transaction_outputs_with_proof,
                         ledger_info_with_signatures,
                         None,
@@ -215,7 +215,7 @@ impl<StorageSyncer: StorageSynchronizerInterface> ContinuousSyncer<StorageSyncer
             }
             ContinuousSyncingMode::ExecuteTransactions => {
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
-                    self.storage_synchronizer.lock().execute_transactions(
+                    self.storage_synchronizer.execute_transactions(
                         transaction_list_with_proof,
                         ledger_info_with_signatures,
                         None,

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -63,6 +63,9 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
             // We have an active data stream. Process any notifications!
             self.process_active_stream_notifications(consensus_sync_request)
                 .await
+        } else if self.storage_synchronizer.pending_transaction_data() {
+            // Wait for any pending transaction data to be processed
+            Ok(())
         } else {
             // Fetch a new data stream to start streaming data
             self.initialize_active_data_stream(consensus_sync_request)

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver.rs
@@ -96,7 +96,7 @@ pub struct StateSyncDriver<DataClient, MempoolNotifier, StorageSyncer> {
 impl<
         DataClient: DiemDataClient + Send + Clone + 'static,
         MempoolNotifier: MempoolNotificationSender,
-        StorageSyncer: StorageSynchronizerInterface,
+        StorageSyncer: StorageSynchronizerInterface + Clone,
     > StateSyncDriver<DataClient, MempoolNotifier, StorageSyncer>
 {
     pub fn new(
@@ -112,7 +112,6 @@ impl<
         storage: Arc<dyn DbReader>,
     ) -> Self {
         let event_subscription_service = Arc::new(Mutex::new(event_subscription_service));
-        let storage_synchronizer = Arc::new(Mutex::new(storage_synchronizer));
         let bootstrapper = Bootstrapper::new(
             driver_configuration.clone(),
             streaming_service_client.clone(),

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -69,8 +69,11 @@ impl DriverFactory {
         };
 
         // Create the storage synchronizer
-        let storage_synchronizer =
-            StorageSynchronizer::new(create_runtime, chunk_executor, commit_notification_sender);
+        let storage_synchronizer = StorageSynchronizer::new(
+            chunk_executor,
+            commit_notification_sender,
+            driver_runtime.as_ref(),
+        );
 
         // Create the driver configuration
         let driver_configuration = DriverConfiguration::new(
@@ -101,8 +104,8 @@ impl DriverFactory {
         }
 
         Self {
-            _driver_runtime: driver_runtime,
             client_notification_sender,
+            _driver_runtime: driver_runtime,
         }
     }
 

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -141,9 +141,9 @@ async fn test_get_storage_server_summary() {
     let expected_server_summary = StorageServerSummary {
         protocol_metadata: ProtocolMetadata {
             max_epoch_chunk_size: 100,
-            max_transaction_chunk_size: 1000,
-            max_transaction_output_chunk_size: 1000,
-            max_account_states_chunk_size: 1000,
+            max_transaction_chunk_size: 3000,
+            max_transaction_output_chunk_size: 3000,
+            max_account_states_chunk_size: 3000,
         },
         data_summary: DataSummary {
             synced_ledger_info: Some(create_test_ledger_info_with_sigs(


### PR DESCRIPTION
## Motivation

This PR offers some small optimizations to increase the syncing throughput of the state sync driver. As measured in forge, we now see:
- Transaction execution syncing: ~3.6k tx/s (max observed)
- Transaction output syncing: ~8.8k tx/s (max observed) 🚀 

The PR offers the following commits:
1. Make the storage synchronizer clone-able and remove the shared lock. We can do this because the synchronizer is now just a struct containing channel senders.
2. Add support for checking if there is data pending in the execute/apply or commit pipelines. If so, the driver will wait for those pipelines to flush before attempting to make further progress (reducing CPU contention).
3. Make the interval checks more aggressive and support larger chunk sizes.
4. Reduce contention around storage when syncing. This is done by introducing a `SpeculativeStreamState` allowing the driver to speculatively verify data coming along the streams without having to block on storage. 

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The smoke tests cover this functionality.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906