### PR TITLE
[move-prover] Disable the daily test for Prover

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -127,8 +127,10 @@ jobs:
         run: |
           cd /opt/git/diem/
           set -o pipefail
-          MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover --release 2>&1 | tee -a $MESSAGE_PAYLOAD_FILE
-          MVP_TEST_FEATURE=cvc5 cargo test -p move-prover --release 2>&1 | tee -a $MESSAGE_PAYLOAD_FILE
+        #  Disabling for now as `move-prover` has migrated to a separate repository, thus being unavailable
+        #  in the Diem repo. TODO: fix this.
+        #  MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover --release 2>&1 | tee -a $MESSAGE_PAYLOAD_FILE
+        #  MVP_TEST_FEATURE=cvc5 cargo test -p move-prover --release 2>&1 | tee -a $MESSAGE_PAYLOAD_FILE
       - uses: ./.github/actions/slack-file
         with:
           webhook: ${{ secrets.WEBHOOK_MOVE_PROVER }}


### PR DESCRIPTION
Move and Move Prover have moved to their own repository. `move-prover` is not available in the Diem repository any longer. 

This PR temporarily disables the daily test for Prover in order to suppress the recent [test failures](https://github.com/diem/diem/runs/4854448001?check_suite_focus=true#step:6:28).

TODO:
- Fix this daily test. The Prover inconsistency (daily) test is specially important not only for Prover but also for the Diem Framework. So, this daily test should be fixed rather than removed from the Diem repo.

## Motivation

To disable the daily test for Prover which is no longer available in the Diem repo

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes