### PR TITLE
[State Sync] Support failure handling for the storage synchronizer.

### DIFF
--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -624,6 +624,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
                         .transactions_and_outputs
                         .len();
                     self.storage_synchronizer.apply_transaction_outputs(
+                        notification_id,
                         transaction_outputs_with_proof,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,
@@ -644,6 +645,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                     let num_transactions = transaction_list_with_proof.transactions.len();
                     self.storage_synchronizer.execute_transactions(
+                        notification_id,
                         transaction_list_with_proof,
                         proof_ledger_info,
                         end_of_epoch_ledger_info,
@@ -788,7 +790,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
 
     /// Handles the end of stream notification or an invalid payload by
     /// terminating the stream appropriately.
-    pub async fn handle_end_of_stream_or_invalid_payload(
+    async fn handle_end_of_stream_or_invalid_payload(
         &mut self,
         data_notification: DataNotification,
     ) -> Result<(), Error> {
@@ -802,7 +804,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
     }
 
     /// Terminates the currently active stream with the provided feedback
-    async fn terminate_active_stream(
+    pub async fn terminate_active_stream(
         &mut self,
         notification_id: NotificationId,
         notification_feedback: NotificationFeedback,

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -214,6 +214,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
                             .transactions_and_outputs
                             .len();
                         self.storage_synchronizer.apply_transaction_outputs(
+                            notification_id,
                             transaction_outputs_with_proof,
                             ledger_info_with_signatures,
                             None,
@@ -234,6 +235,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
                     if let Some(transaction_list_with_proof) = transaction_list_with_proof {
                         let num_transactions = transaction_list_with_proof.transactions.len();
                         self.storage_synchronizer.execute_transactions(
+                            notification_id,
                             transaction_list_with_proof,
                             ledger_info_with_signatures,
                             None,
@@ -338,7 +340,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
 
     /// Handles the end of stream notification or an invalid payload by
     /// terminating the stream appropriately.
-    pub async fn handle_end_of_stream_or_invalid_payload(
+    async fn handle_end_of_stream_or_invalid_payload(
         &mut self,
         data_notification: DataNotification,
     ) -> Result<(), Error> {
@@ -352,7 +354,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
     }
 
     /// Terminates the currently active stream with the provided feedback
-    async fn terminate_active_stream(
+    pub async fn terminate_active_stream(
         &mut self,
         notification_id: NotificationId,
         notification_feedback: NotificationFeedback,

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -5,7 +5,8 @@ use crate::{
     driver::{DriverConfiguration, StateSyncDriver},
     driver_client::{ClientNotificationListener, DriverClient, DriverNotification},
     notification_handlers::{
-        CommitNotificationListener, ConsensusNotificationHandler, MempoolNotificationHandler,
+        CommitNotificationListener, ConsensusNotificationHandler, ErrorNotificationListener,
+        MempoolNotificationHandler,
     },
     storage_synchronizer::StorageSynchronizer,
 };
@@ -52,6 +53,8 @@ impl DriverFactory {
         let (commit_notification_sender, commit_notification_listener) =
             CommitNotificationListener::new();
         let consensus_notification_handler = ConsensusNotificationHandler::new(consensus_listener);
+        let (error_notification_sender, error_notification_listener) =
+            ErrorNotificationListener::new();
         let mempool_notification_handler =
             MempoolNotificationHandler::new(mempool_notification_sender);
 
@@ -72,6 +75,7 @@ impl DriverFactory {
         let storage_synchronizer = StorageSynchronizer::new(
             chunk_executor,
             commit_notification_sender,
+            error_notification_sender,
             driver_runtime.as_ref(),
         );
 
@@ -88,6 +92,7 @@ impl DriverFactory {
             commit_notification_listener,
             consensus_notification_handler,
             driver_configuration,
+            error_notification_listener,
             event_subscription_service,
             mempool_notification_handler,
             storage_synchronizer,


### PR DESCRIPTION
## Motivation

This PR updates the state sync driver to handle storage synchronizer failures (e.g., if the node receives bad data from a peer). In this case, the driver will: (i) terminate the currently active data stream; (ii) penalize the peer who sent the data notification containing the invalid data; (iii) wait for the storage synchronizer pipeline to drain; and (iv) start fetching a new data stream to make progress.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The smoke tests only cover very basic functionality. As such, this new behavior will need to be verified when we add a more complex test framework (coming soon!).

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906