### PR TITLE
Using ubuntu-20.04-xl as ubuntu-latest-xl will be deprecated starting…

### DIFF
--- a/.github/workflows/dep-update-review.yml
+++ b/.github/workflows/dep-update-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   generate-report:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     name: Comment update review report on PR
     env:
       MAX_ALLOWED_CHARS: 65536

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -27,7 +27,7 @@ jobs:
           webhook: ${{ secrets.WEBHOOK_DEPENDENCY_CHANGES }}
 
   transaction-replay:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-20.04-xl
     container:
       image: ghcr.io/diem/diem_build_environment:main
       volumes:


### PR DESCRIPTION
On January 24, 2022, GitHub Actions Ubuntu XL runners will be removing the `ubuntu-latest-xl` image label which is based on the Ubuntu 18 image. Using ubuntu-20.04-xl as the new recommended tag for the image