### PR TITLE
docs: fix a broken link to move-module in glossary

### DIFF
--- a/developers.diem.com/docs/reference/glossary.md
+++ b/developers.diem.com/docs/reference/glossary.md
@@ -398,7 +398,7 @@ Under the DPN Rules, a VASP is defined as a natural or legal person that as a bu
 
 - Each transaction submitted by a user includes a **transaction script**.
 - It represents the operation a client submits to a validator.
-- The operation could be a request to move coins from user A to user B, or it could involve interactions with published [Move modules](#move-modules)/smart contracts.
+- The operation could be a request to move coins from user A to user B, or it could involve interactions with published [Move modules](#move-module)/smart contracts.
 - The transaction script is an arbitrary program that interacts with resources published in the global storage of the Diem Blockchain by calling the procedures of a module. It encodes the logic for a transaction.
 - A single transaction script can send funds to multiple recipients and invoke procedures from several different modules.
 - A transaction script **is not** stored in the global state and cannot be invoked by other transaction scripts. It is a single-use program.


### PR DESCRIPTION
<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

This fixes a broken link to the Move Module section. The broken link was referenced in the "Transaction Script" section.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
