### PR TITLE
[forge] accept and ignore "-Z unstable-options" and "--show-output"

### DIFF
--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -48,6 +48,15 @@ pub struct Options {
     ///   (json is unsupported, exists for compatibility with the default test harness)
     #[structopt(long, possible_values = &Format::variants(), default_value, case_insensitive = true)]
     format: Format,
+    #[structopt(short = "Z")]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    /// -Z unstable-options Enable nightly-only flags:
+    ///                     unstable-options = Allow use of experimental features
+    z_unstable_options: Option<String>,
+    #[structopt(long)]
+    /// NO-OP: unsupported option, exists for compatibility with the default test harness
+    /// Show captured stdout of successful tests
+    show_output: bool,
 }
 
 impl Options {


### PR DESCRIPTION

## Motivation

My IDE insists to add these options while start debugging tests, so I'm adding these much like the existing NO-OP options, like test_threads, to the forge runner option.


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan

My IDE now works.
