### PR TITLE
DiemValidatorInterface: DebuggerStateView::version usage clean up

### DIFF
--- a/diem-move/writeset-transaction-generator/src/release_flow/create.rs
+++ b/diem-move/writeset-transaction-generator/src/release_flow/create.rs
@@ -100,7 +100,7 @@ pub(crate) fn create_release_from_artifact(
     let modules_payload = create_release_writeset(&remote_modules, release_modules)?;
 
     Ok(if let Some(updated_diem_version) = artifact.diem_version {
-        let state_view = DebuggerStateView::new(&remote, artifact.version);
+        let state_view = DebuggerStateView::new(&remote, Some(artifact.version));
         let (updated_version_writeset, events) = build_changeset(&state_view, |session| {
             session.set_diem_version(updated_diem_version);
         })

--- a/diem-move/writeset-transaction-generator/src/release_flow/verify.rs
+++ b/diem-move/writeset-transaction-generator/src/release_flow/verify.rs
@@ -86,7 +86,7 @@ pub(crate) fn verify_payload_change<'a>(
 
     let output = {
         let txn_replay = DiemDebugger::new(validator);
-        txn_replay.execute_writeset_at_version(block_height, payload, false)?
+        txn_replay.execute_writeset_at_version(block_height + 1, payload, false)?
     };
 
     if output.status() != &TransactionStatus::Keep(KeptVMStatus::Executed) {


### PR DESCRIPTION

## Motivation
It's weird and confusing that DebuggerStateView queries at self.version - 1.

Made self.version an Option<Version>.
On the callsites (mainly the transaction replay tool):
* annotate_x_at_version annotates the *result* state of the version
* execute_x_at_version and run_x_at_version runs things based on the previous version state.
* create_release_from_artifact runs on top of artifact.version state


### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan

existing coverage