### PR TITLE
[State Sync] Start supporting account state downloading for bootstrapping.

### DIFF
--- a/diem-node/src/lib.rs
+++ b/diem-node/src/lib.rs
@@ -289,7 +289,7 @@ fn create_state_sync_runtimes<M: MempoolNotificationSender + 'static>(
         state_sync_network_handles,
         mempool_notifier,
         consensus_listener,
-        db_rw.reader,
+        db_rw,
         chunk_executor,
         node_config,
         waypoint,

--- a/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/data-streaming-service/src/tests/utils.rs
@@ -138,6 +138,7 @@ impl DiemDataClient for MockDiemDataClient {
             last_key: HashValue::random(),
             account_blobs,
             proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::zero(),
         };
         Ok(create_data_client_response(account_states))
     }

--- a/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
+++ b/state-sync/state-sync-v2/state-sync-driver/Cargo.toml
@@ -19,6 +19,7 @@ tokio-stream = "0.1.4"
 consensus-notifications = { path = "../../inter-component/consensus-notifications" }
 data-streaming-service = { path = "../data-streaming-service" }
 diem-config = { path = "../../../config" }
+diem-crypto = { path = "../../../crates/diem-crypto" }
 diem-data-client = { path = "../../diem-data-client" }
 diem-infallible = { path = "../../../crates/diem-infallible" }
 diem-logger = { path = "../../../crates/diem-logger" }

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -320,7 +320,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         if self.active_data_stream.is_some() {
             // We have an active data stream. Process any notifications!
             self.process_active_stream_notifications().await?;
-        } else if !self.storage_synchronizer.pending_transaction_data() {
+        } else if !self.storage_synchronizer.pending_storage_data() {
             // Fetch a new data stream to start streaming data
             self.initialize_active_data_stream(global_data_summary)
                 .await?;

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -14,10 +14,13 @@ use diem_config::config::BootstrappingMode;
 use diem_data_client::GlobalDataSummary;
 use diem_logger::*;
 use diem_types::{
+    account_state_blob::AccountStatesChunkWithProof,
     epoch_change::Verifier,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
+    transaction::{
+        TransactionInfo, TransactionListWithProof, TransactionOutputListWithProof, Version,
+    },
     waypoint::Waypoint,
 };
 use futures::channel::oneshot;
@@ -210,8 +213,54 @@ impl VerifiedEpochStates {
     }
 }
 
+// TODO(joshlind): persist the index (e.g., in case we crash mid-download)?
+/// A simple container to manage state related to account state snapshot syncing
+struct AccountStateSyncer {
+    // Whether or not a state snapshot receiver has been initialized
+    initialized_state_snapshot_receiver: bool,
+
+    // Whether or not all states have been synced
+    is_sync_complete: bool,
+
+    // The ledger info we're currently syncing
+    ledger_info_to_sync: Option<LedgerInfoWithSignatures>,
+
+    // The next account index to commit (all accounts before this have been
+    // committed).
+    next_account_index_to_commit: u64,
+
+    // The next account index to process (all accounts before this have been
+    // processed -- i.e., sent to the storage synchronizer).
+    next_account_index_to_process: u64,
+
+    // The transaction info for the version we're trying to sync to
+    transaction_info_for_version: Option<TransactionInfo>,
+}
+
+impl AccountStateSyncer {
+    pub fn new() -> Self {
+        Self {
+            initialized_state_snapshot_receiver: false,
+            is_sync_complete: false,
+            ledger_info_to_sync: None,
+            next_account_index_to_commit: 0,
+            next_account_index_to_process: 0,
+            transaction_info_for_version: None,
+        }
+    }
+
+    /// Resets all speculative state related to account state syncing (i.e., all
+    /// speculative data that as not been successfully committed to storage)
+    pub fn reset_speculative_state(&mut self) {
+        self.next_account_index_to_process = self.next_account_index_to_commit
+    }
+}
+
 /// A simple component that manages the bootstrapping of the node
 pub struct Bootstrapper<StorageSyncer> {
+    // The component used to sync account states (if downloading accounts)
+    account_state_syncer: AccountStateSyncer,
+
     // The currently active data stream (provided by the data streaming service)
     active_data_stream: Option<DataStreamListener>,
 
@@ -253,6 +302,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         let verified_epoch_states = VerifiedEpochStates::new(latest_epoch_state);
 
         Self {
+            account_state_syncer: AccountStateSyncer::new(),
             active_data_stream: None,
             bootstrap_notifier_channel: None,
             bootstrapped: false,
@@ -330,17 +380,22 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         self.notify_listeners_if_bootstrapped()
     }
 
+    /// Returns true iff the bootstrapper should continue to fetch epoch ending
+    /// ledger infos (in order to make progress).
+    fn should_fetch_epoch_ending_ledger_infos(&self) -> bool {
+        !self
+            .verified_epoch_states
+            .fetched_epoch_ending_ledger_infos()
+            || !self.verified_epoch_states.verified_waypoint()
+    }
+
     /// Initializes an active data stream so that we can begin to process notifications
     async fn initialize_active_data_stream(
         &mut self,
         global_data_summary: &GlobalDataSummary,
     ) -> Result<(), Error> {
         // Always fetch the new epoch ending ledger infos first
-        if !self
-            .verified_epoch_states
-            .fetched_epoch_ending_ledger_infos()
-            || !self.verified_epoch_states.verified_waypoint()
-        {
+        if self.should_fetch_epoch_ending_ledger_infos() {
             return self
                 .fetch_epoch_ending_ledger_infos(global_data_summary)
                 .await;
@@ -352,7 +407,9 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         let highest_known_ledger_version = highest_known_ledger_info.ledger_info().version();
 
         // Check if we've already fetched the required data for bootstrapping
-        if highest_synced_version == highest_known_ledger_version {
+        if highest_synced_version == highest_known_ledger_version
+            || self.account_state_syncer.is_sync_complete
+        {
             return self.bootstrapping_complete();
         }
 
@@ -363,46 +420,16 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
             );
         }
 
-        // Fetch all data until the epoch ending ledger info for the current epoch
-        let next_version = highest_synced_version.checked_add(1).ok_or_else(|| {
-            Error::IntegerOverflow("The next output version has overflown!".into())
-        })?;
-        let end_version = self
-            .verified_epoch_states
-            .next_epoch_ending_version(highest_synced_version)
-            .expect("No higher epoch ending version known!");
-        let data_stream = match self.driver_configuration.config.bootstrapping_mode {
-            BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
-                self.streaming_service_client
-                    .get_all_transaction_outputs(
-                        next_version,
-                        end_version,
-                        highest_known_ledger_version,
-                    )
-                    .await?
-            }
-            BootstrappingMode::ExecuteTransactionsFromGenesis => {
-                self.streaming_service_client
-                    .get_all_transactions(
-                        next_version,
-                        end_version,
-                        highest_known_ledger_version,
-                        false,
-                    )
-                    .await?
-            }
-            bootstrapping_mode => {
-                unimplemented!("Bootstrapping mode not supported: {:?}", bootstrapping_mode)
-            }
-        };
-        self.speculative_stream_state = Some(SpeculativeStreamState::new(
-            utils::fetch_latest_epoch_state(self.storage.clone())?,
-            Some(highest_known_ledger_info),
-            highest_synced_version,
-        ));
-        self.active_data_stream = Some(data_stream);
-
-        Ok(())
+        // Bootstrap according to the mode
+        if self.driver_configuration.config.bootstrapping_mode
+            == BootstrappingMode::DownloadLatestAccountStates
+        {
+            self.fetch_all_account_states(highest_known_ledger_info)
+                .await
+        } else {
+            self.fetch_missing_transaction_data(highest_synced_version, highest_known_ledger_info)
+                .await
+        }
     }
 
     /// Processes any notifications already pending on the active stream
@@ -412,6 +439,13 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
             let data_notification =
                 utils::get_data_notification(self.active_data_stream.as_mut()).await?;
             match data_notification.data_payload {
+                DataPayload::AccountStatesWithProof(account_states_with_proof) => {
+                    self.process_account_states_payload(
+                        data_notification.notification_id,
+                        account_states_with_proof,
+                    )
+                    .await?;
+                }
                 DataPayload::EpochEndingLedgerInfos(epoch_ending_ledger_infos) => {
                     self.process_epoch_ending_payload(
                         data_notification.notification_id,
@@ -447,6 +481,97 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
                 }
             }
         }
+    }
+
+    /// Fetches all account states (as required to bootstrap the node)
+    async fn fetch_all_account_states(
+        &mut self,
+        highest_known_ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<(), Error> {
+        let highest_known_ledger_version = highest_known_ledger_info.ledger_info().version();
+
+        // Verify we're trying to sync to an unchanging ledger info
+        if let Some(ledger_info_to_sync) = &self.account_state_syncer.ledger_info_to_sync {
+            if ledger_info_to_sync != &highest_known_ledger_info {
+                panic!(
+                    "Mismatch in ledger info to sync! Highest: {:?}, target: {:?}",
+                    highest_known_ledger_info, ledger_info_to_sync
+                );
+            }
+        } else {
+            self.account_state_syncer.ledger_info_to_sync = Some(highest_known_ledger_info);
+        }
+
+        // Fetch the transaction info first, before the account states
+        let data_stream = if self
+            .account_state_syncer
+            .transaction_info_for_version
+            .is_none()
+        {
+            self.streaming_service_client
+                .get_all_transaction_outputs(
+                    highest_known_ledger_version,
+                    highest_known_ledger_version,
+                    highest_known_ledger_version,
+                )
+                .await?
+        } else {
+            let start_account_index = Some(self.account_state_syncer.next_account_index_to_commit);
+            self.streaming_service_client
+                .get_all_accounts(highest_known_ledger_version, start_account_index)
+                .await?
+        };
+        self.active_data_stream = Some(data_stream);
+
+        Ok(())
+    }
+
+    /// Fetches all missing transaction data in order to bootstrap the node
+    async fn fetch_missing_transaction_data(
+        &mut self,
+        highest_synced_version: Version,
+        highest_known_ledger_info: LedgerInfoWithSignatures,
+    ) -> Result<(), Error> {
+        let highest_known_ledger_version = highest_known_ledger_info.ledger_info().version();
+        let next_version = highest_synced_version.checked_add(1).ok_or_else(|| {
+            Error::IntegerOverflow("The next output version has overflown!".into())
+        })?;
+        let end_version = self
+            .verified_epoch_states
+            .next_epoch_ending_version(highest_synced_version)
+            .expect("No higher epoch ending version known!");
+        let data_stream = match self.driver_configuration.config.bootstrapping_mode {
+            BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
+                self.streaming_service_client
+                    .get_all_transaction_outputs(
+                        next_version,
+                        end_version,
+                        highest_known_ledger_version,
+                    )
+                    .await?
+            }
+            BootstrappingMode::ExecuteTransactionsFromGenesis => {
+                self.streaming_service_client
+                    .get_all_transactions(
+                        next_version,
+                        end_version,
+                        highest_known_ledger_version,
+                        false,
+                    )
+                    .await?
+            }
+            bootstrapping_mode => {
+                unreachable!("Bootstrapping mode not supported: {:?}", bootstrapping_mode)
+            }
+        };
+        self.speculative_stream_state = Some(SpeculativeStreamState::new(
+            utils::fetch_latest_epoch_state(self.storage.clone())?,
+            Some(highest_known_ledger_info),
+            highest_synced_version,
+        ));
+        self.active_data_stream = Some(data_stream);
+
+        Ok(())
     }
 
     /// Fetches all epoch ending ledger infos (from the current epoch to the
@@ -552,12 +677,149 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         }
     }
 
+    /// Verifies the start and end indices in the given account states chunk
+    async fn verify_account_states_indices(
+        &mut self,
+        notification_id: NotificationId,
+        account_states_chunk_with_proof: &AccountStatesChunkWithProof,
+    ) -> Result<(), Error> {
+        // Verify the payload start index is valid
+        let expected_start_index = self.account_state_syncer.next_account_index_to_process;
+        if expected_start_index != account_states_chunk_with_proof.first_index {
+            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
+            return Err(Error::VerificationError(format!(
+                "The start index of the account states was invalid! Expected: {:?}, received: {:?}",
+                expected_start_index, account_states_chunk_with_proof.first_index
+            )));
+        }
+
+        // Verify the number of account blobs is valid
+        let expected_num_accounts = account_states_chunk_with_proof
+            .last_index
+            .checked_sub(account_states_chunk_with_proof.first_index)
+            .and_then(|version| version.checked_add(1)) // expected_num_accounts = last_index - first_index + 1
+            .ok_or_else(|| {
+                Error::IntegerOverflow("The expected number of accounts has overflown!".into())
+            })?;
+        let num_accounts = account_states_chunk_with_proof.account_blobs.len() as u64;
+        if expected_num_accounts != num_accounts {
+            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
+            return Err(Error::VerificationError(format!(
+                "The expected number of accounts was invalid! Expected: {:?}, received: {:?}",
+                expected_num_accounts, num_accounts,
+            )));
+        }
+
+        // Verify the payload end index is valid
+        let expected_end_index = account_states_chunk_with_proof
+            .first_index
+            .checked_add(num_accounts)
+            .and_then(|version| version.checked_sub(1)) // expected_end_index = first_index + num_accounts - 1
+            .ok_or_else(|| {
+                Error::IntegerOverflow("The expected end of index has overflown!".into())
+            })?;
+        if expected_end_index != account_states_chunk_with_proof.last_index {
+            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
+            return Err(Error::VerificationError(format!(
+                "The expected end index was invalid! Expected: {:?}, received: {:?}",
+                expected_num_accounts, account_states_chunk_with_proof.last_index,
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Process a single account states with proof payload
+    async fn process_account_states_payload(
+        &mut self,
+        notification_id: NotificationId,
+        account_states_chunk_with_proof: AccountStatesChunkWithProof,
+    ) -> Result<(), Error> {
+        // Verify that we're expecting account payloads
+        let bootstrapping_mode = self.driver_configuration.config.bootstrapping_mode;
+        if self.should_fetch_epoch_ending_ledger_infos()
+            || !matches!(
+                bootstrapping_mode,
+                BootstrappingMode::DownloadLatestAccountStates
+            )
+        {
+            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
+            return Err(Error::InvalidPayload(
+                "Received an unexpected account states payload!".into(),
+            ));
+        }
+
+        // TODO(joshlind): Verify the expected root hash!
+        // Initialize the account state synchronizer (if not already done)
+        if !self
+            .account_state_syncer
+            .initialized_state_snapshot_receiver
+        {
+            let version = self
+                .account_state_syncer
+                .ledger_info_to_sync
+                .as_ref()
+                .expect("Account state syncer version not initialized!")
+                .ledger_info()
+                .version();
+            let expected_root_hash = account_states_chunk_with_proof.root_hash;
+            self.storage_synchronizer.initialize_account_synchronizer(
+                expected_root_hash,
+                version,
+                None, // TODO(joshlind): support spawning on a given runtime!
+            )?;
+            self.account_state_syncer
+                .initialized_state_snapshot_receiver = true;
+        }
+
+        // Verify the account payload start and end indices
+        self.verify_account_states_indices(notification_id, &account_states_chunk_with_proof)
+            .await?;
+
+        // TODO(joshlind): Verify the sparse merkle tree proof is valid!
+
+        // Process the account states chunk and proof
+        let last_account_index = account_states_chunk_with_proof.last_index;
+        if let Err(error) = self
+            .storage_synchronizer
+            .save_account_states(notification_id, account_states_chunk_with_proof)
+        {
+            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
+            return Err(Error::InvalidPayload(format!(
+                "The account states chunk with proof was invalid! Error: {:?}",
+                error,
+            )));
+        }
+
+        // Update the next account index to process
+        self.account_state_syncer.next_account_index_to_process =
+            last_account_index.checked_add(1).ok_or_else(|| {
+                Error::IntegerOverflow("The next account index to process has overflown!".into())
+            })?;
+
+        Ok(())
+    }
+
     /// Process a single epoch ending payload
     async fn process_epoch_ending_payload(
         &mut self,
         notification_id: NotificationId,
         epoch_ending_ledger_infos: Vec<LedgerInfoWithSignatures>,
     ) -> Result<(), Error> {
+        // Verify that we're expecting epoch ending ledger info payloads
+        if !self.should_fetch_epoch_ending_ledger_infos() {
+            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
+            return Err(Error::InvalidPayload(
+                "Received an unexpected epoch ending payload!".into(),
+            ));
+        }
+
         // Verify the payload isn't empty
         if epoch_ending_ledger_infos.is_empty() {
             self.terminate_active_stream(notification_id, NotificationFeedback::EmptyPayloadData)
@@ -597,9 +859,48 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         transaction_outputs_with_proof: Option<TransactionOutputListWithProof>,
         payload_start_version: Option<Version>,
     ) -> Result<(), Error> {
+        // Verify that we're expecting transaction or output payloads
+        let bootstrapping_mode = self.driver_configuration.config.bootstrapping_mode;
+        if self.should_fetch_epoch_ending_ledger_infos()
+            || (matches!(
+                bootstrapping_mode,
+                BootstrappingMode::DownloadLatestAccountStates
+            ) && self
+                .account_state_syncer
+                .transaction_info_for_version
+                .is_some())
+        {
+            self.terminate_active_stream(notification_id, NotificationFeedback::InvalidPayloadData)
+                .await?;
+            return Err(Error::InvalidPayload(
+                "Received an unexpected transaction or output payload!".into(),
+            ));
+        }
+
+        // If we're account state syncing, we expect a single transaction info
+        if matches!(
+            bootstrapping_mode,
+            BootstrappingMode::DownloadLatestAccountStates
+        ) {
+            return self
+                .verify_transaction_info_to_sync(
+                    notification_id,
+                    transaction_outputs_with_proof,
+                    payload_start_version,
+                )
+                .await;
+        }
+
         // Verify the payload starting version
+        let expected_start_version = self
+            .get_speculative_stream_state()
+            .expected_next_version()?;
         let payload_start_version = self
-            .verify_payload_start_version(notification_id, payload_start_version)
+            .verify_payload_start_version(
+                notification_id,
+                payload_start_version,
+                expected_start_version,
+            )
             .await?;
 
         // Get the expected proof ledger info for the payload
@@ -616,8 +917,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
             .await?;
 
         // Execute/apply and commit the transactions/outputs
-        let num_transactions_or_outputs = match self.driver_configuration.config.bootstrapping_mode
-        {
+        let num_transactions_or_outputs = match bootstrapping_mode {
             BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
                 if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
                     let num_transaction_outputs = transaction_outputs_with_proof
@@ -663,7 +963,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
                 }
             }
             bootstrapping_mode => {
-                unimplemented!("Bootstrapping mode not supported: {:?}", bootstrapping_mode)
+                unreachable!("Bootstrapping mode not supported: {:?}", bootstrapping_mode)
             }
         };
         let synced_version = payload_start_version
@@ -676,18 +976,78 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
         Ok(())
     }
 
+    /// Verifies the payload contains the transaction info we require to
+    /// download all account states.
+    async fn verify_transaction_info_to_sync(
+        &mut self,
+        notification_id: NotificationId,
+        transaction_outputs_with_proof: Option<TransactionOutputListWithProof>,
+        payload_start_version: Option<Version>,
+    ) -> Result<(), Error> {
+        // Verify the payload starting version
+        let ledger_info_to_sync = self
+            .account_state_syncer
+            .ledger_info_to_sync
+            .clone()
+            .expect("Ledger info to sync is missing!");
+        let expected_start_version = ledger_info_to_sync.ledger_info().version();
+        let _ = self
+            .verify_payload_start_version(
+                notification_id,
+                payload_start_version,
+                expected_start_version,
+            )
+            .await?;
+
+        // Verify the payload proof (the ledger info has already been verified)
+        // and save the transaction info.
+        if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
+            match &transaction_outputs_with_proof.proof.transaction_infos[..] {
+                [transaction_info] => {
+                    // TODO(joshlind): don't save the transaction info until after verification!
+                    self.account_state_syncer.transaction_info_for_version =
+                        Some(transaction_info.clone());
+                    self.storage_synchronizer.apply_transaction_outputs(
+                        notification_id,
+                        transaction_outputs_with_proof,
+                        ledger_info_to_sync,
+                        None,
+                    )?;
+                }
+                _ => {
+                    self.terminate_active_stream(
+                        notification_id,
+                        NotificationFeedback::InvalidPayloadData,
+                    )
+                    .await?;
+                    return Err(Error::InvalidPayload(
+                        "Payload does not contain a single transaction info!".into(),
+                    ));
+                }
+            }
+        } else {
+            self.terminate_active_stream(
+                notification_id,
+                NotificationFeedback::PayloadTypeIsIncorrect,
+            )
+            .await?;
+            return Err(Error::InvalidPayload(
+                "Did not receive transaction outputs with proof!".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Verifies the first payload version matches the version we wish to sync
     async fn verify_payload_start_version(
         &mut self,
         notification_id: NotificationId,
         payload_start_version: Option<Version>,
+        expected_start_version: Version,
     ) -> Result<Version, Error> {
-        // Compare the payload start version with the expected version
-        let expected_version = self
-            .get_speculative_stream_state()
-            .expected_next_version()?;
         if let Some(payload_start_version) = payload_start_version {
-            if payload_start_version != expected_version {
+            if payload_start_version != expected_start_version {
                 self.terminate_active_stream(
                     notification_id,
                     NotificationFeedback::InvalidPayloadData,
@@ -695,7 +1055,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
                 .await?;
                 Err(Error::VerificationError(format!(
                     "The payload start version does not match the expected version! Start: {:?}, expected: {:?}",
-                    payload_start_version, expected_version
+                    payload_start_version, expected_start_version
                 )))
             } else {
                 Ok(payload_start_version)
@@ -823,10 +1183,25 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
     /// committed to storage.
     pub fn handle_committed_accounts(
         &mut self,
-        _committed_accounts: CommittedAccounts,
+        committed_accounts: CommittedAccounts,
     ) -> Result<(), Error> {
-        // TODO(joshlind): implement me!
-        unimplemented!();
+        // Update the last committed account index
+        self.account_state_syncer.next_account_index_to_commit = committed_accounts
+            .last_committed_account_index
+            .checked_add(1)
+            .ok_or_else(|| {
+                Error::IntegerOverflow("The next account index to commit has overflown!".into())
+            })?;
+
+        // Check if we've downloaded all account states
+        if committed_accounts.all_accounts_synced {
+            info!("Successfully synced all account states at version: {:?}. Last committed account index: {:?}",
+                  self.account_state_syncer.ledger_info_to_sync,
+                  committed_accounts.last_committed_account_index);
+            self.account_state_syncer.is_sync_complete = true;
+        }
+
+        Ok(())
     }
 
     /// Returns the speculative stream state. Assumes that the state exists.
@@ -838,6 +1213,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
 
     /// Resets the currently active data stream and speculative state
     fn reset_active_stream(&mut self) {
+        self.account_state_syncer.reset_speculative_state();
         self.speculative_stream_state = None;
         self.active_data_stream = None;
     }

--- a/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/bootstrapper.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    driver::DriverConfiguration, error::Error, storage_synchronizer::StorageSynchronizerInterface,
-    utils, utils::SpeculativeStreamState,
+    driver::DriverConfiguration, error::Error, notification_handlers::CommittedAccounts,
+    storage_synchronizer::StorageSynchronizerInterface, utils, utils::SpeculativeStreamState,
 };
 use data_streaming_service::{
     data_notification::{DataNotification, DataPayload, NotificationId},
@@ -817,6 +817,16 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> Bootstrapper<StorageSy
             notification_feedback,
         )
         .await
+    }
+
+    /// Handles a notification from the driver that new accounts have been
+    /// committed to storage.
+    pub fn handle_committed_accounts(
+        &mut self,
+        _committed_accounts: CommittedAccounts,
+    ) -> Result<(), Error> {
+        // TODO(joshlind): implement me!
+        unimplemented!();
     }
 
     /// Returns the speculative stream state. Assumes that the state exists.

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -67,7 +67,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
             self.process_active_stream_notifications(consensus_sync_request)
                 .await
         } else if self.storage_synchronizer.pending_storage_data() {
-            // Wait for any pending transaction data to be processed
+            // Wait for any pending data to be processed
             Ok(())
         } else {
             // Fetch a new data stream to start streaming data

--- a/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/continuous_syncer.rs
@@ -66,7 +66,7 @@ impl<StorageSyncer: StorageSynchronizerInterface + Clone> ContinuousSyncer<Stora
             // We have an active data stream. Process any notifications!
             self.process_active_stream_notifications(consensus_sync_request)
                 .await
-        } else if self.storage_synchronizer.pending_transaction_data() {
+        } else if self.storage_synchronizer.pending_storage_data() {
             // Wait for any pending transaction data to be processed
             Ok(())
         } else {

--- a/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/driver_factory.rs
@@ -20,7 +20,7 @@ use executor_types::ChunkExecutorTrait;
 use futures::channel::mpsc;
 use mempool_notifications::MempoolNotificationSender;
 use std::sync::Arc;
-use storage_interface::DbReader;
+use storage_interface::DbReaderWriter;
 use tokio::runtime::{Builder, Runtime};
 
 /// Creates a new state sync driver and client
@@ -38,7 +38,7 @@ impl DriverFactory {
         create_runtime: bool,
         node_config: &NodeConfig,
         waypoint: Waypoint,
-        storage: Arc<dyn DbReader>,
+        storage: DbReaderWriter,
         chunk_executor: Arc<ChunkExecutor>,
         mempool_notification_sender: MempoolNotifier,
         consensus_listener: ConsensusNotificationListener,
@@ -76,6 +76,7 @@ impl DriverFactory {
             chunk_executor,
             commit_notification_sender,
             error_notification_sender,
+            storage.writer,
             driver_runtime.as_ref(),
         );
 
@@ -98,7 +99,7 @@ impl DriverFactory {
             storage_synchronizer,
             diem_data_client,
             streaming_service_client,
-            storage,
+            storage.reader,
         );
 
         // Spawn the driver

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -21,6 +21,7 @@ use std::{
         Arc,
     },
 };
+use storage_interface::DbWriter;
 use tokio::runtime::Runtime;
 
 // TODO(joshlind): add structured logging support!
@@ -72,6 +73,9 @@ pub struct StorageSynchronizer {
 
     // The number of transaction data chunks pending execute/apply, or commit
     pending_transaction_chunks: Arc<AtomicU64>,
+
+    // The writer to storage (required for account state syncing)
+    storage: Arc<dyn DbWriter>,
 }
 
 impl StorageSynchronizer {
@@ -79,6 +83,7 @@ impl StorageSynchronizer {
         chunk_executor: Arc<ChunkExecutor>,
         commit_notification_sender: mpsc::UnboundedSender<CommitNotification>,
         error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
+        storage: Arc<dyn DbWriter>,
         runtime: Option<&Runtime>,
     ) -> Self {
         // Create a channel to notify the executor when transaction data chunks are ready
@@ -113,6 +118,7 @@ impl StorageSynchronizer {
         Self {
             executor_notifier,
             pending_transaction_chunks,
+            storage,
         }
     }
 

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -278,7 +278,7 @@ fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
                     // Commit the executed chunk
                     match chunk_executor.commit_chunk() {
                         Ok((events, transactions)) => {
-                            let commit_notification = CommitNotification::new(events, transactions);
+                            let commit_notification = CommitNotification::new_committed_transactions(events, transactions);
                             if let Err(error) = commit_notification_sender.send(commit_notification).await {
                                 let error = format!("Failed to send commit notification! Error: {:?}", error);
                                 send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;

--- a/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/storage_synchronizer.rs
@@ -6,11 +6,12 @@ use crate::{
     notification_handlers::{CommitNotification, ErrorNotification},
 };
 use data_streaming_service::data_notification::NotificationId;
+use diem_crypto::HashValue;
 use diem_logger::prelude::*;
 use diem_types::{
     account_state_blob::AccountStatesChunkWithProof,
     ledger_info::LedgerInfoWithSignatures,
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof},
+    transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
 };
 use executor_types::ChunkExecutorTrait;
 use futures::{channel::mpsc, SinkExt, StreamExt};
@@ -54,13 +55,29 @@ pub trait StorageSynchronizerInterface {
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
     ) -> Result<(), Error>;
 
-    /// Returns true iff there is transaction data that is still waiting
-    /// to be executed/applied or committed.
-    fn pending_transaction_data(&self) -> bool;
+    /// Initializes an account synchronizer with the specified version and
+    /// expected root hash and spawns the synchronizer on the given `runtime`.
+    /// If `runtime` is None, uses the current runtime.
+    ///
+    /// Note: this assumes `expected_root_hash` has already been verified.
+    fn initialize_account_synchronizer(
+        &mut self,
+        expected_root_hash: HashValue,
+        version: Version,
+        runtime: Option<&Runtime>,
+    ) -> Result<(), Error>;
 
-    /// Saves the given account states to storage
+    /// Returns true iff there is storage data that is still waiting
+    /// to be executed/applied or committed.
+    fn pending_storage_data(&self) -> bool;
+
+    /// Saves the given account states to storage.
+    ///
+    /// Note: this requires that `initialize_account_synchronizer` has been
+    /// called.
     fn save_account_states(
         &mut self,
+        notification_id: NotificationId,
         account_states_with_proof: AccountStatesChunkWithProof,
     ) -> Result<(), Error>;
 }
@@ -68,11 +85,20 @@ pub trait StorageSynchronizerInterface {
 /// The implementation of the `StorageSynchronizerInterface` used by state sync
 #[derive(Clone)]
 pub struct StorageSynchronizer {
-    // A channel through which to notify the executor of new transaction data chunks
-    executor_notifier: mpsc::Sender<TransactionDataChunk>,
+    // A channel through which to notify the driver of committed data
+    commit_notification_sender: mpsc::UnboundedSender<CommitNotification>,
 
-    // The number of transaction data chunks pending execute/apply, or commit
-    pending_transaction_chunks: Arc<AtomicU64>,
+    // A channel through which to notify the driver of storage errors
+    error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
+
+    // A channel through which to notify the executor of new data chunks
+    executor_notifier: mpsc::Sender<StorageDataChunk>,
+
+    // The number of storage data chunks pending execute/apply, or commit
+    pending_data_chunks: Arc<AtomicU64>,
+
+    // The channel through which to notify the state snapshot receiver of new data chunks
+    state_snapshot_notifier: Option<mpsc::Sender<StorageDataChunk>>,
 
     // The writer to storage (required for account state syncing)
     storage: Arc<dyn DbWriter>,
@@ -86,16 +112,16 @@ impl StorageSynchronizer {
         storage: Arc<dyn DbWriter>,
         runtime: Option<&Runtime>,
     ) -> Self {
-        // Create a channel to notify the executor when transaction data chunks are ready
+        // Create a channel to notify the executor when data chunks are ready
         let (executor_notifier, executor_listener) = mpsc::channel(MAX_PENDING_CHUNKS);
 
         // Create a channel to notify the committer when executed chunks are ready
         let (committer_notifier, committer_listener) = mpsc::channel(MAX_PENDING_CHUNKS);
 
-        // Create a shared pending transaction chunk counter
+        // Create a shared pending data chunk counter
         let pending_transaction_chunks = Arc::new(AtomicU64::new(0));
 
-        // Spawn the executor that executes/applies transaction data chunks
+        // Spawn the executor that executes/applies storage data chunks
         spawn_executor(
             chunk_executor.clone(),
             error_notification_sender.clone(),
@@ -109,31 +135,31 @@ impl StorageSynchronizer {
         spawn_committer(
             chunk_executor,
             committer_listener,
-            commit_notification_sender,
-            error_notification_sender,
+            commit_notification_sender.clone(),
+            error_notification_sender.clone(),
             pending_transaction_chunks.clone(),
             runtime,
         );
 
         Self {
+            commit_notification_sender,
+            error_notification_sender,
             executor_notifier,
-            pending_transaction_chunks,
+            pending_data_chunks: pending_transaction_chunks,
+            state_snapshot_notifier: None,
             storage,
         }
     }
 
-    /// Notifies the executor of new transaction data chunks
-    fn notify_executor(
-        &mut self,
-        transaction_data_chunk: TransactionDataChunk,
-    ) -> Result<(), Error> {
-        if let Err(error) = self.executor_notifier.try_send(transaction_data_chunk) {
+    /// Notifies the executor of new data chunks
+    fn notify_executor(&mut self, storage_data_chunk: StorageDataChunk) -> Result<(), Error> {
+        if let Err(error) = self.executor_notifier.try_send(storage_data_chunk) {
             Err(Error::UnexpectedError(format!(
-                "Failed to send transaction data chunk to executor: {:?}",
+                "Failed to send storage data chunk to executor: {:?}",
                 error
             )))
         } else {
-            increment_atomic(self.pending_transaction_chunks.clone());
+            increment_atomic(self.pending_data_chunks.clone());
             Ok(())
         }
     }
@@ -147,13 +173,13 @@ impl StorageSynchronizerInterface for StorageSynchronizer {
         target_ledger_info: LedgerInfoWithSignatures,
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
     ) -> Result<(), Error> {
-        let transaction_data_chunk = TransactionDataChunk::TransactionOutputs(
+        let storage_data_chunk = StorageDataChunk::TransactionOutputs(
             notification_id,
             output_list_with_proof,
             target_ledger_info,
             end_of_epoch_ledger_info,
         );
-        self.notify_executor(transaction_data_chunk)
+        self.notify_executor(storage_data_chunk)
     }
 
     fn execute_transactions(
@@ -163,30 +189,73 @@ impl StorageSynchronizerInterface for StorageSynchronizer {
         target_ledger_info: LedgerInfoWithSignatures,
         end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
     ) -> Result<(), Error> {
-        let transaction_data_chunk = TransactionDataChunk::Transactions(
+        let storage_data_chunk = StorageDataChunk::Transactions(
             notification_id,
             transaction_list_with_proof,
             target_ledger_info,
             end_of_epoch_ledger_info,
         );
-        self.notify_executor(transaction_data_chunk)
+        self.notify_executor(storage_data_chunk)
     }
 
-    fn pending_transaction_data(&self) -> bool {
-        self.pending_transaction_chunks.load(Ordering::Relaxed) > 0
+    fn initialize_account_synchronizer(
+        &mut self,
+        expected_root_hash: HashValue,
+        version: Version,
+        runtime: Option<&Runtime>,
+    ) -> Result<(), Error> {
+        // Create a channel to notify the state snapshot receiver when data chunks are ready
+        let (state_snapshot_notifier, state_snapshot_listener) = mpsc::channel(MAX_PENDING_CHUNKS);
+
+        // Spawn the state snapshot receiver that commits account states
+        spawn_state_snapshot_receiver(
+            state_snapshot_listener,
+            self.commit_notification_sender.clone(),
+            expected_root_hash,
+            self.error_notification_sender.clone(),
+            self.pending_data_chunks.clone(),
+            self.storage.clone(),
+            version,
+            runtime,
+        );
+        self.state_snapshot_notifier = Some(state_snapshot_notifier);
+
+        Ok(())
+    }
+
+    fn pending_storage_data(&self) -> bool {
+        self.pending_data_chunks.load(Ordering::Relaxed) > 0
     }
 
     fn save_account_states(
         &mut self,
-        _account_states_with_proof: AccountStatesChunkWithProof,
+        notification_id: NotificationId,
+        account_states_with_proof: AccountStatesChunkWithProof,
     ) -> Result<(), Error> {
-        unimplemented!("Saving account states to storage is not currently supported!")
+        let state_snapshot_notifier = &mut self
+            .state_snapshot_notifier
+            .as_mut()
+            .expect("The state snapshot receiver has not been initialized!");
+        let storage_data_chunk =
+            StorageDataChunk::Accounts(notification_id, account_states_with_proof);
+        if let Err(error) = state_snapshot_notifier.try_send(storage_data_chunk) {
+            Err(Error::UnexpectedError(format!(
+                "Failed to send storage data chunk to state snapshot listener: {:?}",
+                error
+            )))
+        } else {
+            increment_atomic(self.pending_data_chunks.clone());
+            Ok(())
+        }
     }
 }
 
-/// A chunk of data (i.e., transactions or transaction outputs) to be executed
-/// and committed.
-enum TransactionDataChunk {
+/// A chunk of data to be executed and/or committed to storage (i.e., accounts,
+/// transactions or outputs).
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+enum StorageDataChunk {
+    Accounts(NotificationId, AccountStatesChunkWithProof),
     Transactions(
         NotificationId,
         TransactionListWithProof,
@@ -201,11 +270,11 @@ enum TransactionDataChunk {
     ),
 }
 
-/// Spawns a dedicated executor that executes/applies transaction data chunks
+/// Spawns a dedicated executor that executes/applies storage data chunks
 fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
     chunk_executor: Arc<ChunkExecutor>,
     error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
-    mut executor_listener: mpsc::Receiver<TransactionDataChunk>,
+    mut executor_listener: mpsc::Receiver<StorageDataChunk>,
     mut committer_notifier: mpsc::Sender<NotificationId>,
     pending_transaction_chunks: Arc<AtomicU64>,
     runtime: Option<&Runtime>,
@@ -214,10 +283,10 @@ fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
     let executor = async move {
         loop {
             ::futures::select! {
-                transaction_data_chunk = executor_listener.select_next_some() => {
-                    // Execute/apply the transaction data chunk
-                    let (notification_id, result) = match transaction_data_chunk {
-                        TransactionDataChunk::Transactions(notification_id, transactions_with_proof, target_ledger_info, end_of_epoch_ledger_info) => {
+                storage_data_chunk = executor_listener.select_next_some() => {
+                    // Execute/apply the storage data chunk
+                    let (notification_id, result) = match storage_data_chunk {
+                        StorageDataChunk::Transactions(notification_id, transactions_with_proof, target_ledger_info, end_of_epoch_ledger_info) => {
                             let result = chunk_executor
                                .execute_chunk(
                                     transactions_with_proof,
@@ -226,7 +295,7 @@ fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
                                 );
                             (notification_id, result)
                         },
-                        TransactionDataChunk::TransactionOutputs(notification_id, outputs_with_proof, target_ledger_info, end_of_epoch_ledger_info) => {
+                        StorageDataChunk::TransactionOutputs(notification_id, outputs_with_proof, target_ledger_info, end_of_epoch_ledger_info) => {
                             let result = chunk_executor
                                 .apply_chunk(
                                     outputs_with_proof,
@@ -234,6 +303,9 @@ fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
                                     end_of_epoch_ledger_info.as_ref(),
                                 );
                              (notification_id, result)
+                        }
+                        storage_data_chunk => {
+                            panic!("Invalid storage data chunk sent to executor: {:?}", storage_data_chunk);
                         }
                     };
 
@@ -247,7 +319,7 @@ fn spawn_executor<ChunkExecutor: ChunkExecutorTrait + 'static>(
                             }
                         },
                         Err(error) => {
-                            let error = format!("Failed to execute/apply the transaction data chunk! Error: {:?}", error);
+                            let error = format!("Failed to execute/apply the storage data chunk! Error: {:?}", error);
                             send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
                             decrement_atomic(pending_transaction_chunks.clone());
                         }
@@ -270,7 +342,7 @@ fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
     pending_transaction_chunks: Arc<AtomicU64>,
     runtime: Option<&Runtime>,
 ) {
-    // Create an executor
+    // Create a committer
     let committer = async move {
         loop {
             ::futures::select! {
@@ -278,9 +350,10 @@ fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
                     // Commit the executed chunk
                     match chunk_executor.commit_chunk() {
                         Ok((events, transactions)) => {
+                            // Send a commit notification to the commit listener
                             let commit_notification = CommitNotification::new_committed_transactions(events, transactions);
                             if let Err(error) = commit_notification_sender.send(commit_notification).await {
-                                let error = format!("Failed to send commit notification! Error: {:?}", error);
+                                let error = format!("Failed to send transaction commit notification! Error: {:?}", error);
                                 send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
                             }
                         }
@@ -297,6 +370,73 @@ fn spawn_committer<ChunkExecutor: ChunkExecutorTrait + 'static>(
 
     // Spawn the committer
     spawn(runtime, committer);
+}
+
+/// Spawns a dedicated receiver that commits accounts from a state snapshot
+fn spawn_state_snapshot_receiver(
+    mut state_snapshot_listener: mpsc::Receiver<StorageDataChunk>,
+    mut commit_notification_sender: mpsc::UnboundedSender<CommitNotification>,
+    expected_root_hash: HashValue,
+    error_notification_sender: mpsc::UnboundedSender<ErrorNotification>,
+    pending_transaction_chunks: Arc<AtomicU64>,
+    storage: Arc<dyn DbWriter>,
+    version: Version,
+    runtime: Option<&Runtime>,
+) {
+    // Create a state snapshot receiver
+    let receiver = async move {
+        let mut state_snapshot_receiver = storage
+            .get_state_snapshot_receiver(version, expected_root_hash)
+            .expect("Failed to initialize the state snapshot receiver!");
+        loop {
+            ::futures::select! {
+                storage_data_chunk = state_snapshot_listener.select_next_some() => {
+                    // Commit the account states chunk
+                    match storage_data_chunk {
+                        StorageDataChunk::Accounts(notification_id, account_states_with_proof) => {
+                            let all_accounts_synced = account_states_with_proof.proof.right_siblings().is_empty();
+                            let last_committed_account_index = account_states_with_proof.last_index;
+
+                            // Attempt to the commit the chunk
+                            let commit_result = state_snapshot_receiver.add_chunk(
+                                account_states_with_proof.account_blobs,
+                                account_states_with_proof.proof.clone(),
+                            );
+                            match commit_result {
+                                Ok(()) => {
+                                    // Send a commit notification to the commit listener
+                                    let commit_notification = CommitNotification::new_committed_accounts(all_accounts_synced, last_committed_account_index);
+                                    if let Err(error) = commit_notification_sender.send(commit_notification).await {
+                                        let error = format!("Failed to send account commit notification! Error: {:?}", error);
+                                        send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
+                                    } else if all_accounts_synced {
+                                        // Update the receiver and return
+                                        if let Err(error) = state_snapshot_receiver.finish_box() {
+                                            let error = format!("Failed to finish the account states synchronization! Error: {:?}", error);
+                                            send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
+                                        }
+                                        decrement_atomic(pending_transaction_chunks.clone());
+                                        return;
+                                    }
+                                },
+                                Err(error) => {
+                                    let error = format!("Failed to commit account states chunk! Error: {:?}", error);
+                                    send_storage_synchronizer_error(error_notification_sender.clone(), notification_id, error).await;
+                                }
+                            }
+                            decrement_atomic(pending_transaction_chunks.clone());
+                        },
+                        storage_data_chunk => {
+                            panic!("Invalid storage data chunk sent to state snapshot receiver: {:?}", storage_data_chunk);
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    // Spawn the receiver
+    spawn(runtime, receiver);
 }
 
 /// Spawns a future on a specified runtime. If no runtime is specified, uses

--- a/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
+++ b/state-sync/state-sync-v2/state-sync-driver/src/tests/utils.rs
@@ -144,7 +144,7 @@ fn create_driver_for_tests(
         false,
         &node_config,
         waypoint,
-        db_rw.reader,
+        db_rw,
         chunk_executor,
         mempool_notifier,
         consensus_listener,

--- a/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
+++ b/state-sync/state-sync-v2/state-sync-multiplexer/src/lib.rs
@@ -19,7 +19,7 @@ use state_sync_v1::{
     network::{StateSyncEvents, StateSyncSender},
 };
 use std::sync::Arc;
-use storage_interface::DbReader;
+use storage_interface::DbReaderWriter;
 use tokio::runtime::Runtime;
 
 /// A struct for holding the various runtimes required by state sync v2.
@@ -68,7 +68,7 @@ impl StateSyncMultiplexer {
         network: Vec<(NetworkId, StateSyncSender, StateSyncEvents)>,
         mempool_notifier: MempoolNotifier,
         consensus_listener: ConsensusNotificationListener,
-        storage: Arc<dyn DbReader>,
+        storage: DbReaderWriter,
         chunk_executor: Arc<ChunkExecutor>,
         node_config: &NodeConfig,
         waypoint: Waypoint,
@@ -77,7 +77,7 @@ impl StateSyncMultiplexer {
         streaming_service_client: StreamingServiceClient,
     ) -> Self {
         // Notify subscribers of the initial on-chain config values
-        match (&*storage).fetch_synced_version() {
+        match (&*storage.reader).fetch_synced_version() {
             Ok(synced_version) => {
                 if let Err(error) =
                     event_subscription_service.notify_initial_configs(synced_version)
@@ -119,7 +119,7 @@ impl StateSyncMultiplexer {
                 network,
                 mempool_notifier,
                 consensus_listener,
-                storage,
+                storage.reader,
                 chunk_executor,
                 node_config,
                 waypoint,
@@ -233,7 +233,7 @@ mod tests {
             vec![],
             mempool_notifier,
             consensus_listener,
-            db_rw.reader.clone(),
+            db_rw.clone(),
             Arc::new(ChunkExecutor::<DiemVM>::new(db_rw).unwrap()),
             &node_config,
             Waypoint::new_any(&LedgerInfo::new(BlockInfo::empty(), HashValue::random())),

--- a/state-sync/storage-service/server/src/tests.rs
+++ b/state-sync/storage-service/server/src/tests.rs
@@ -105,6 +105,7 @@ async fn test_get_account_states_chunk_with_proof() {
             last_key: HashValue::zero(),
             account_blobs,
             proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::zero(),
         });
     assert_eq!(response, expected_response);
 }
@@ -541,6 +542,7 @@ impl DbReader for MockDbReader {
             last_key: HashValue::zero(),
             account_blobs,
             proof: SparseMerkleRangeProof::new(vec![]),
+            root_hash: HashValue::zero(),
         };
         Ok(account_states_chunk_with_proof)
     }

--- a/storage/diemdb/src/state_store/mod.rs
+++ b/storage/diemdb/src/state_store/mod.rs
@@ -181,6 +181,7 @@ impl StateStore {
         let first_key = account_blobs.first().expect("checked to exist").0;
         let last_key = account_blobs.last().expect("checked to exist").0;
         let proof = self.get_account_state_range_proof(last_key, version)?;
+        let root_hash = self.get_root_hash(version)?;
 
         Ok(AccountStatesChunkWithProof {
             first_index: first_index as u64,
@@ -189,6 +190,7 @@ impl StateStore {
             last_key,
             account_blobs,
             proof,
+            root_hash,
         })
     }
 

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -127,13 +127,13 @@ pub trait TreeReader<V> {
     fn get_rightmost_leaf(&self) -> Result<Option<(NodeKey, LeafNode<V>)>>;
 }
 
-pub trait TreeWriter<V> {
+pub trait TreeWriter<V>: Send + Sync {
     /// Writes a node batch into storage.
     fn write_node_batch(&self, node_batch: &NodeBatch<V>) -> Result<()>;
 }
 
 /// `Value` defines the types of data that can be stored in a Jellyfish Merkle tree.
-pub trait Value: Clone + CryptoHash + Serialize + DeserializeOwned {}
+pub trait Value: Clone + CryptoHash + Serialize + DeserializeOwned + Send + Sync {}
 
 /// `TestValue` defines the types of data that can be stored in a Jellyfish Merkle tree and used in
 /// tests.

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -132,7 +132,7 @@ impl TreeState {
     }
 }
 
-pub trait StateSnapshotReceiver<V> {
+pub trait StateSnapshotReceiver<V>: Send {
     fn add_chunk(
         &mut self,
         chunk: Vec<(HashValue, V)>,

--- a/testsuite/smoke-test/src/state_sync_v2.rs
+++ b/testsuite/smoke-test/src/state_sync_v2.rs
@@ -8,6 +8,7 @@ use crate::{
 use diem_config::config::{BootstrappingMode, ContinuousSyncingMode, NodeConfig};
 use diem_rest_client::Client as RestClient;
 use diem_sdk::{transaction_builder::TransactionFactory, types::LocalAccount};
+use diem_types::PeerId;
 use forge::{LocalSwarm, NodeExt, Swarm, SwarmExt};
 use std::{
     fs,
@@ -17,9 +18,44 @@ use std::{
 const MAX_CATCH_UP_SECS: u64 = 60; // The max time we'll wait for nodes to catch up
 
 #[tokio::test]
+async fn test_full_node_bootstrap_accounts() {
+    // Create a validator swarm of 1 validator node
+    let mut swarm = new_local_swarm(1).await;
+
+    // Create a fullnode config that uses account state syncing
+    let mut vfn_config = NodeConfig::default_for_validator_full_node();
+    vfn_config.state_sync.state_sync_driver.enable_state_sync_v2 = true;
+    vfn_config.state_sync.state_sync_driver.bootstrapping_mode =
+        BootstrappingMode::DownloadLatestAccountStates;
+
+    // Create (and stop) the fullnode
+    let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
+    swarm.fullnode_mut(vfn_peer_id).unwrap().stop();
+
+    // Enable account count support for the validator (with at most 2 accounts
+    // per storage request).
+    let validator = swarm.validators_mut().next().unwrap();
+    let mut config = validator.config().clone();
+    config.storage.account_count_migration = true;
+    config
+        .state_sync
+        .storage_service
+        .max_account_states_chunk_sizes = 2;
+    config.save(validator.config_path()).unwrap();
+    validator.restart().await.unwrap();
+    validator
+        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
+        .await
+        .unwrap();
+
+    // Test the ability of the fullnode to sync
+    test_full_node_sync(vfn_peer_id, swarm, true).await;
+}
+
+#[tokio::test]
 async fn test_full_node_bootstrap_outputs() {
     // Create a validator swarm of 1 validator node
-    let swarm = new_local_swarm(1).await;
+    let mut swarm = new_local_swarm(1).await;
 
     // Create a fullnode config that uses transaction outputs to sync
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -31,14 +67,17 @@ async fn test_full_node_bootstrap_outputs() {
         .state_sync_driver
         .continuous_syncing_mode = ContinuousSyncingMode::ApplyTransactionOutputs;
 
+    // Create the fullnode
+    let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
+
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_config, swarm, true).await;
+    test_full_node_sync(vfn_peer_id, swarm, true).await;
 }
 
 #[tokio::test]
 async fn test_full_node_bootstrap_transactions() {
     // Create a validator swarm of 1 validator node
-    let swarm = new_local_swarm(1).await;
+    let mut swarm = new_local_swarm(1).await;
 
     // Create a fullnode config that uses transactions to sync
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -50,14 +89,17 @@ async fn test_full_node_bootstrap_transactions() {
         .state_sync_driver
         .continuous_syncing_mode = ContinuousSyncingMode::ExecuteTransactions;
 
+    // Create the fullnode
+    let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
+
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_config, swarm, true).await;
+    test_full_node_sync(vfn_peer_id, swarm, true).await;
 }
 
 #[tokio::test]
 async fn test_full_node_continuous_sync_outputs() {
     // Create a validator swarm of 1 validator node
-    let swarm = new_local_swarm(1).await;
+    let mut swarm = new_local_swarm(1).await;
 
     // Create a fullnode config that uses transaction outputs to sync
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -67,14 +109,17 @@ async fn test_full_node_continuous_sync_outputs() {
         .state_sync_driver
         .continuous_syncing_mode = ContinuousSyncingMode::ApplyTransactionOutputs;
 
+    // Create the fullnode
+    let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
+
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_config, swarm, false).await;
+    test_full_node_sync(vfn_peer_id, swarm, false).await;
 }
 
 #[tokio::test]
 async fn test_full_node_continuous_sync_transactions() {
     // Create a validator swarm of 1 validator node
-    let swarm = new_local_swarm(1).await;
+    let mut swarm = new_local_swarm(1).await;
 
     // Create a fullnode config that uses transactions to sync
     let mut vfn_config = NodeConfig::default_for_validator_full_node();
@@ -84,18 +129,15 @@ async fn test_full_node_continuous_sync_transactions() {
         .state_sync_driver
         .continuous_syncing_mode = ContinuousSyncingMode::ExecuteTransactions;
 
+    // Create the fullnode
+    let vfn_peer_id = create_full_node(vfn_config, &mut swarm).await;
+
     // Test the ability of the fullnode to sync
-    test_full_node_sync(vfn_config, swarm, false).await;
+    test_full_node_sync(vfn_peer_id, swarm, false).await;
 }
 
-/// A helper method that tests that a full node can sync from a validator after
-/// a failure and continue to stay up-to-date.
-async fn test_full_node_sync(
-    full_node_config: NodeConfig,
-    mut swarm: LocalSwarm,
-    epoch_changes: bool,
-) {
-    // Start the validator and fullnode (make sure they boot up)
+/// Creates a new full node using the given config and swarm
+async fn create_full_node(full_node_config: NodeConfig, swarm: &mut LocalSwarm) -> PeerId {
     // Create the fullnode
     let validator_peer_id = swarm.validators().next().unwrap().peer_id();
     let vfn_peer_id = swarm
@@ -106,24 +148,23 @@ async fn test_full_node_sync(
         )
         .await
         .unwrap();
-
-    swarm
-        .validator_mut(validator_peer_id)
-        .unwrap()
-        .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
-        .await
-        .unwrap();
     for fullnode in swarm.full_nodes_mut() {
         fullnode
             .wait_until_healthy(Instant::now() + Duration::from_secs(MAX_CATCH_UP_SECS))
             .await
             .unwrap();
     }
+    vfn_peer_id
+}
 
+/// A helper method that tests that a full node can sync from a validator after
+/// a failure and continue to stay up-to-date.
+async fn test_full_node_sync(vfn_peer_id: PeerId, mut swarm: LocalSwarm, epoch_changes: bool) {
     // Stop the fullnode
     swarm.fullnode_mut(vfn_peer_id).unwrap().stop();
 
     // Execute a number of transactions on the validator
+    let validator_peer_id = swarm.validators().next().unwrap().peer_id();
     let validator_client = swarm.validator(validator_peer_id).unwrap().rest_client();
     let transaction_factory = swarm.chain_info().transaction_factory();
 
@@ -334,7 +375,7 @@ async fn execute_transactions(
     receiver: &LocalAccount,
     execute_epoch_changes: bool,
 ) {
-    let num_transfers = 4;
+    let num_transfers = 10;
     if execute_epoch_changes {
         transfer_and_reconfig(
             client,

--- a/types/src/account_state_blob.rs
+++ b/types/src/account_state_blob.rs
@@ -230,17 +230,13 @@ impl AccountStateWithProof {
 /// in the struct itself and not behind pointers/handles to file locations.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AccountStatesChunkWithProof {
-    pub first_index: u64,
-    // The first account index in chunk
-    pub last_index: u64,
-    // The last account index in chunk
-    pub first_key: HashValue,
-    // The first account key in chunk
-    pub last_key: HashValue,
-    // The last account key in chunk
-    pub account_blobs: Vec<(HashValue, AccountStateBlob)>,
-    // The account blobs in the chunk
+    pub first_index: u64,     // The first account index in chunk
+    pub last_index: u64,      // The last account index in chunk
+    pub first_key: HashValue, // The first account key in chunk
+    pub last_key: HashValue,  // The last account key in chunk
+    pub account_blobs: Vec<(HashValue, AccountStateBlob)>, // The account blobs in the chunk
     pub proof: SparseMerkleRangeProof, // The proof to ensure the chunk is in the account states
+    pub root_hash: HashValue, // The root hash of the sparse merkle tree for this chunk
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Note: the implementation is not complete. However, given that the PR has grown so large, this seems like a reasonable checkpoint.

## Motivation

This PR starts adding support for account state downloading when a node is bootstrapping in state sync. At a high-level, the way this works is:
1. The state sync bootstrapper epoch skips to the head of the blockchain and grabs the latest epoch ending ledger info (at version `V`).
2. The storage synchronizer spawns a dedicated state snapshot receiver for account states at version `V`.
3. The bootstapper fetches the transaction info for version `V` from the network (so it can verify the expected account states root hash) and then fetches all account states at version `V` and writes them to storage.
4. Once all account states have been written, the bootstrapper is complete and the continuous syncer begins syncing transactions/outputs from version `V + 1`.

To achieve this, the PR offers the following commits:
1. Add a simple smoke test for account state bootstrapping. This test currently fails.
2. Add the expected root hash to each `AccountStatesChunkWithProof` (useful for verifying proofs later).
3. Update the state snapshot receiver to be thread spawnable.
4. Pass a DB writer to the state synchronizer (required for constructing the state snapshot receiver).
5. Add a new `CommittedAccounts` variant for `CommitNotifications`. This allows the driver/bootstrapper to be notified about successfully committed accounts during synchronization.
6. Update the storage synchronizer to provide new API calls for spawning a state snapshot receiver and writing account states to the DB.
7. Update the state sync bootstrapper to support the new mode, including: (i) fetching the transaction info for version `V`; and (ii) fetching all account states at version `V`.

Note:
- After commit 7, the smoke test added in commit 1 now passes. However, this is due to the fact that once the bootstrapper has completed syncing all account states at `V`, the continuous syncer starts fetching all missing transactions/outputs from version `0` (not `V`!). This is because we still need to update the executor/continuous syncer to accept missing transaction data. This is the next step.
- Other implementation pieces still missing: proof verification, complex unit tests, etc.

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

Yes.

## Test Plan

The smoke test verifies some of the new functionality. Moreover, I have manually inspected the execution traces to ensure that account state data is being fetched from the network and written to storage through the pipeline.

## Related PRs

None, but this PR relates to: https://github.com/diem/diem/issues/8906