### PR TITLE
[executor] ParsedTransactionOutput and refactors

### DIFF
--- a/execution/executor-types/src/executed_chunk.rs
+++ b/execution/executor-types/src/executed_chunk.rs
@@ -10,7 +10,6 @@ use diem_types::{
     contract_event::ContractEvent,
     epoch_state::EpochState,
     ledger_info::LedgerInfoWithSignatures,
-    on_chain_config,
     proof::accumulator::InMemoryAccumulator,
     transaction::{Transaction, TransactionInfo, TransactionStatus, TransactionToCommit},
 };
@@ -169,7 +168,6 @@ impl ExecutedChunk {
         &self,
         parent_accumulator: &Arc<InMemoryAccumulator<TransactionAccumulatorHasher>>,
     ) -> StateComputeResult {
-        let new_epoch_event_key = on_chain_config::new_epoch_event_key();
         let txn_accu = self.result_view.txn_accumulator();
 
         let mut transaction_info_hashes = Vec::new();
@@ -177,13 +175,7 @@ impl ExecutedChunk {
 
         for (_, txn_data) in &self.to_commit {
             transaction_info_hashes.push(txn_data.txn_info_hash());
-            reconfig_events.extend(
-                txn_data
-                    .events()
-                    .iter()
-                    .filter(|e| *e.key() == new_epoch_event_key)
-                    .cloned(),
-            )
+            reconfig_events.extend(txn_data.reconfig_events.iter().cloned())
         }
 
         StateComputeResult::new(

--- a/execution/executor-types/src/lib.rs
+++ b/execution/executor-types/src/lib.rs
@@ -423,11 +423,11 @@ pub struct TransactionData {
     /// The list of events emitted during this transaction.
     events: Vec<ContractEvent>,
 
+    /// List of reconfiguration events emitted during this transaction.
+    reconfig_events: Vec<ContractEvent>,
+
     /// The execution status set by the VM.
     status: TransactionStatus,
-
-    /// Root hash of the state tree.
-    state_root_hash: HashValue,
 
     /// The in-memory Merkle Accumulator that has all events emitted by this transaction.
     event_tree: Arc<InMemoryAccumulator<EventAccumulatorHasher>>,
@@ -448,8 +448,8 @@ impl TransactionData {
         jf_node_hashes: HashMap<NibblePath, HashValue>,
         write_set: WriteSet,
         events: Vec<ContractEvent>,
+        reconfig_events: Vec<ContractEvent>,
         status: TransactionStatus,
-        state_root_hash: HashValue,
         event_tree: Arc<InMemoryAccumulator<EventAccumulatorHasher>>,
         gas_used: u64,
         txn_info: TransactionInfo,
@@ -460,8 +460,8 @@ impl TransactionData {
             jf_node_hashes,
             write_set,
             events,
+            reconfig_events,
             status,
-            state_root_hash,
             event_tree,
             gas_used,
             txn_info,
@@ -487,10 +487,6 @@ impl TransactionData {
 
     pub fn status(&self) -> &TransactionStatus {
         &self.status
-    }
-
-    pub fn state_root_hash(&self) -> HashValue {
-        self.state_root_hash
     }
 
     pub fn event_root_hash(&self) -> HashValue {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -967,6 +967,16 @@ impl TransactionOutput {
     pub fn status(&self) -> &TransactionStatus {
         &self.status
     }
+
+    pub fn unpack(self) -> (WriteSet, Vec<ContractEvent>, u64, TransactionStatus) {
+        let Self {
+            write_set,
+            events,
+            gas_used,
+            status,
+        } = self;
+        (write_set, events, gas_used, status)
+    }
 }
 
 /// `TransactionInfo` is the object we store in the transaction accumulator. It consists of the


### PR DESCRIPTION


## Motivation
1. avoid repeatedly parse txn_output.events for the reconfig events
2. txn_output.unpack() to avoid clones.
3. txn_output.state_root_hash removed since it's not used.

this is in prepare for the per_block SMT update PR

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?
Y

## Test Plan
existing coverage