### PR TITLE
[move-prover] Enable the inconsistency test for Prover

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -127,10 +127,7 @@ jobs:
         run: |
           cd /opt/git/diem/
           set -o pipefail
-        #  Disabling for now as `move-prover` has migrated to a separate repository, thus being unavailable
-        #  in the Diem repo. TODO: fix this.
-        #  MVP_TEST_INCONSISTENCY=1 cargo test -p move-prover --release 2>&1 | tee -a $MESSAGE_PAYLOAD_FILE
-        #  MVP_TEST_FEATURE=cvc5 cargo test -p move-prover --release 2>&1 | tee -a $MESSAGE_PAYLOAD_FILE
+          cargo test -p diem-framework --release -- --include-ignored 2>&1 | tee -a $MESSAGE_PAYLOAD_FILE
       - uses: ./.github/actions/slack-file
         with:
           webhook: ${{ secrets.WEBHOOK_MOVE_PROVER }}

--- a/diem-move/diem-framework/tests/move_verification_test.rs
+++ b/diem-move/diem-framework/tests/move_verification_test.rs
@@ -10,3 +10,18 @@ fn prove_all() {
     ProverTest::create("experimental").run();
     ProverTest::create("DPN").run()
 }
+
+#[test]
+#[ignore]
+fn prove_checking_inconsistency() {
+    ProverTest::create("DPN")
+        .with_options(&["--check-inconsistency"])
+        .run()
+}
+
+#[test]
+#[ignore]
+fn prove_using_cvc5() {
+    // TODO: This test is disabled because it hangs (> 10 mins in a local test).
+    //ProverTest::create("DPN").with_options(&["--use-cvc5"]).run()
+}


### PR DESCRIPTION
This PR re-enables the daily test of the inconsistency check for Prover. It was disabled due the `move-prover`'s migration into the separate `move` repo.

TODO
- Proving DPN with cvc5 (version 0.0.3) hangs. This needs an investigation.
- Upon the daily test failure, the report goes to the Slack (move-prover) channel. We may need to change this process since we're not using the Slack channel.

## Motivation

To enable the daily test for Prover

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

yes

## Test Plan

cargo test
