### PR TITLE
Update dockerhub_prune.sh to disable release deletion and update comments

### DIFF
--- a/scripts/dockerhub_prune.sh
+++ b/scripts/dockerhub_prune.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ######################################################################################################################
-# Takes a slug org/repo ( diem/client ) and deletes all tags with release-* over 90 days and all other              #
-# over 2 days (assumed to be test images).                                                                           #
+# Takes a slug org/repo ( diem/client ) and deletes all tags with release-* over 180 days and all other              #
+# over 7 days (assumed to be test images).                                                                           #
 ######################################################################################################################
 
 user=
@@ -111,6 +111,8 @@ function prune_repo {
 
     TO_DELETE=
     PAGE=0
+    # Variable to enable release version deletion
+    Release_Deletion=false
     while [[ $(echo "$RELEASES" | wc -l) -gt 1 ]]; do
       PAGE=$(( PAGE + 1))
       while IFS= read -r line; do
@@ -119,7 +121,7 @@ function prune_repo {
           DAYS_SINCE_0=$(( TIME / 86400));
           AGE_DAYS=$(( NOW_DAYS - DAYS_SINCE_0 ));
 
-          if [[ $TAG == "release-"* ]] && [[ $AGE_DAYS -gt 180 ]]; then
+          if [[ $TAG == "release-"* ]] && [[ $AGE_DAYS -gt 180 ]] && "$Release_Deletion"; then
               echo "$REPO:$TAG is a release. It's age is $AGE_DAYS -- will delete"
               TO_DELETE="${TO_DELETE}"'
               '"${TAG}"


### PR DESCRIPTION
Create a variable called Release_Deletion to enable or disable release image deletion and changed comments to reflect release images will be deleted that are over 180 days old and all other images that are over 7 days old. Was not able test this script e2e nor do a complete dry run.

<!--
Thank you for sending a PR. We appreciate you spending time to help improve the Diem project.

The project is undergoing daily changes. Pull Requests will be reviewed and responded to as time permits.
-->

## Motivation

(Write your motivation for proposed changes here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/diem/diem/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Share your test plan here. If you changed code, please provide us with clear instructions for verifying that your changes work.)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/diem/diem/tree/main/developers.diem.com, and link to your PR here.)

## If targeting a release branch, please fill the below out as well

 * Justification and breaking nature (who does it affect? validators, full nodes, tooling, operators, AOS, etc.)
 * Comprehensive test results that demonstrate the fix working and not breaking existing workflows.
 * Why we must have it for V1 launch.
 * What workarounds and alternative we have if we do not push the PR.
